### PR TITLE
[Do not merge] Trace API playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target site/target core/.js/target core/.jvm/target .jvm/target .native/target java/.jvm/target project/target
+        run: mkdir -p target .js/target site/target core/.js/target core/.jvm/target .jvm/target .native/target examples/.jvm/target java/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target site/target core/.js/target core/.jvm/target .jvm/target .native/target java/.jvm/target project/target
+        run: tar cf targets.tar target .js/target site/target core/.js/target core/.jvm/target .jvm/target .native/target examples/.jvm/target java/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val examples = crossProject(JVMPlatform)
   .settings(
     name := "otel4s-examples",
     libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % "3.2.11",
       "io.opentelemetry" % "opentelemetry-exporter-jaeger" % "1.15.0"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,11 @@ lazy val java = crossProject(JVMPlatform)
     libraryDependencies ++= Seq(
       "io.opentelemetry" % "opentelemetry-api" % "1.15.0",
       "io.opentelemetry" % "opentelemetry-exporter-logging" % "1.15.0" % Test,
-      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "1.13.0-alpha" % Test
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "1.13.0-alpha" % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.15.0" % Test,
+      "org.scalameta" %% "munit" % "0.7.29" % Test,
+      "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % "3.3.13" % Test
     )
   )
   .dependsOn(core % "compile->compile,test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / crossScalaVersions := Seq(Scala213, "3.1.3")
 ThisBuild / scalaVersion := Scala213 // the default Scala
 
 lazy val root = tlCrossRootProject
-  .aggregate(core, java)
+  .aggregate(core, java, examples)
   .settings(name := "otel4s")
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)
@@ -60,5 +60,16 @@ lazy val java = crossProject(JVMPlatform)
     )
   )
   .dependsOn(core % "compile->compile,test->test")
+
+lazy val examples = crossProject(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("examples"))
+  .settings(
+    name := "otel4s-examples",
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-exporter-jaeger" % "1.15.0"
+    )
+  )
+  .dependsOn(core, java)
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -15,19 +15,18 @@
  */
 
 package org.typelevel.otel4s
+package trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+private[otel4s] trait SpanMacro[F[_]] {
+  self: Span[F] =>
 
-trait Otel4s[F[_]] {
+  def recordException(
+      exception: Throwable,
+      attributes: Attribute[_]*
+  ): F[Unit] =
+    macro TracesMacro.recordException
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
+  def setAttributes(attributes: Attribute[_]*): F[Unit] =
+    macro TracesMacro.setAttributes
 
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
 }

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -64,4 +64,5 @@ private[otel4s] trait TracerMacro[F[_]] {
       attributes: Attribute[_]*
   ): Resource[F, Span.Auto[F]] =
     macro TracesMacro.rootSpan
+
 }

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -28,10 +28,10 @@ private[otel4s] trait TracerMacro[F[_]] {
     * The lifecycle of the span is managed automatically. That means the span is
     * ended upon the finalization of a resource.
     *
-    * To attach span to a certain parent, use [[childOf]].
+    * To attach span to a specific parent, use [[childOf]].
     *
     * @example
-    *   attaching span to a certain parent
+    *   attaching span to a specific parent
     *   {{{
     * val tracer: Tracer[F] = ???
     * val span: Span[F] = ???
@@ -39,7 +39,7 @@ private[otel4s] trait TracerMacro[F[_]] {
     *   }}}
     *
     * @see
-    *   [[spanBuilder]] to make fully manual span (explicit end)
+    *   [[spanBuilder]] to make a fully manual span (explicit end)
     *
     * @param name
     *   the name of the span

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.effect.Resource
+
+private[otel4s] trait TracerMacro[F[_]] {
+  self: Tracer[F] =>
+
+  /** Creates a new child span. The span is automatically attached to a parent
+    * span (based on the context).
+    *
+    * The lifecycle of the span is managed automatically. That means the span is
+    * ended upon the finalization of a resource.
+    *
+    * To attach span to a certain parent, use [[childOf]].
+    *
+    * @example
+    *   attaching span to a certain parent
+    *   {{{
+    * val tracer: Tracer[F] = ???
+    * val span: Span[F] = ???
+    * val customParent: Resource[F, Span.Auto[F]] = tracer.childOf(span).span("custom-parent")
+    *   }}}
+    *
+    * @see
+    *   [[spanBuilder]] to make fully manual span (explicit end)
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  def span(name: String, attributes: Attribute[_]*): Resource[F, Span.Auto[F]] =
+    macro TracesMacro.span
+
+  /** Creates a new root span. Even if a parent span is available in the
+    * context, the span is created without a parent.
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  def rootSpan(
+      name: String,
+      attributes: Attribute[_]*
+  ): Resource[F, Span.Auto[F]] =
+    macro TracesMacro.rootSpan
+}

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -23,7 +23,7 @@ private[otel4s] trait TracerMacro[F[_]] {
   self: Tracer[F] =>
 
   /** Creates a new child span. The span is automatically attached to a parent
-    * span (based on the context).
+    * span (based on the scope).
     *
     * The lifecycle of the span is managed automatically. That means the span is
     * ended upon the finalization of a resource.
@@ -65,4 +65,25 @@ private[otel4s] trait TracerMacro[F[_]] {
   ): Resource[F, Span.Auto[F]] =
     macro TracesMacro.rootSpan
 
+  /** Creates a new child span. The span is automatically attached to a parent
+    * span (based on the scope).
+    *
+    * The structure of the inner spans:
+    * {{{
+    * > name
+    *   > acquire
+    *   > use
+    *   > release
+    * }}}
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  def resourceSpan[A](name: String, attributes: Attribute[_]*)(
+      resource: Resource[F, A]
+  ): Resource[F, Span.Res[F, A]] =
+    macro TracesMacro.resourceSpan[F, A]
 }

--- a/core/src/main/scala-2/org/typelevel/otel4s/trace/TracesMacro.scala
+++ b/core/src/main/scala-2/org/typelevel/otel4s/trace/TracesMacro.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import scala.reflect.macros.blackbox
+
+private[otel4s] object TracesMacro {
+
+  def span(c: blackbox.Context)(
+      name: c.Expr[String],
+      attributes: c.Expr[Attribute[_]]*
+  ): c.universe.Tree = {
+    import c.universe._
+    val meta = q"${c.prefix}.meta"
+
+    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).withAttributes(..$attributes).createAuto else $meta.resourceNoopSpan"
+  }
+
+  def rootSpan(c: blackbox.Context)(
+      name: c.Expr[String],
+      attributes: c.Expr[Attribute[_]]*
+  ): c.universe.Tree = {
+    import c.universe._
+    val meta = q"${c.prefix}.meta"
+
+    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.withAttributes(..$attributes).createAuto else $meta.resourceNoopSpan"
+  }
+
+  def recordException(c: blackbox.Context)(
+      exception: c.Expr[Throwable],
+      attributes: c.Expr[Attribute[_]]*
+  ): c.universe.Tree = {
+    import c.universe._
+    val backend = q"${c.prefix}.backend"
+    val meta = q"$backend.meta"
+
+    q"if ($meta.isEnabled) $backend.recordException($exception, ..$attributes) else $meta.unit"
+  }
+
+  def setAttributes(c: blackbox.Context)(
+      attributes: c.Expr[Attribute[_]]*
+  ): c.universe.Tree = {
+    import c.universe._
+    val backend = q"${c.prefix}.backend"
+    val meta = q"$backend.meta"
+
+    q"if ($meta.isEnabled) $backend.setAttributes(..$attributes) else $meta.unit"
+  }
+
+}

--- a/core/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -15,19 +15,20 @@
  */
 
 package org.typelevel.otel4s
+package trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+import scala.quoted.*
 
-trait Otel4s[F[_]] {
+private[otel4s] trait SpanMacro[F[_]] {
+  self: Span[F] =>
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
+  inline def recordException(
+      inline exception: Throwable,
+      inline attributes: Attribute[_]*
+  ): F[Unit] =
+    ${ TracesMacro.recordException('self, 'exception, 'attributes) }
 
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
+  inline def setAttributes(inline attributes: Attribute[_]*): F[Unit] =
+    ${ TracesMacro.setAttributes('self, 'attributes) }
+
 }

--- a/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -30,10 +30,10 @@ private[otel4s] trait TracerMacro[F[_]] {
     * The lifecycle of the span is managed automatically. That means the span is
     * ended upon the finalization of a resource.
     *
-    * To attach span to a certain parent, use [[childOf]].
+    * To attach span to a specific parent, use [[childOf]].
     *
     * @example
-    *   attaching span to a certain parent
+    *   attaching span to a specific parent
     *   {{{
     * val tracer: Tracer[F] = ???
     * val span: Span[F] = ???
@@ -41,7 +41,7 @@ private[otel4s] trait TracerMacro[F[_]] {
     *   }}}
     *
     * @see
-    *   [[spanBuilder]] to make fully manual span (explicit end)
+    *   [[spanBuilder]] to make a fully manual span (explicit end)
     *
     * @param name
     *   the name of the span

--- a/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -25,7 +25,7 @@ private[otel4s] trait TracerMacro[F[_]] {
   self: Tracer[F] =>
 
   /** Creates a new child span. The span is automatically attached to a parent
-    * span (based on the context).
+    * span (based on the scope).
     *
     * The lifecycle of the span is managed automatically. That means the span is
     * ended upon the finalization of a resource.
@@ -69,5 +69,27 @@ private[otel4s] trait TracerMacro[F[_]] {
       inline attributes: Attribute[_]*
   ): Resource[F, Span[F]] =
     ${ TracesMacro.rootSpan('self, 'name, 'attributes) }
+
+  /** Creates a new child span. The span is automatically attached to a parent
+    * span (based on the scope).
+    *
+    * The structure of the inner spans:
+    * {{{
+    * > name
+    *   > acquire
+    *   > use
+    *   > release
+    * }}}
+    *
+    * @param name
+    *   the name of the span
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  inline def resourceSpan[A](
+      inline name: String,
+      inline attributes: Attribute[_]*
+  )(inline resource: Resource[F, A]): Resource[F, Span.Res[F, A]] =
+    ${ TracesMacro.resourceSpan('self, 'name, 'attributes, 'resource) }
 
 }

--- a/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/src/main/scala-3/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.effect.Resource
+
+import scala.quoted.*
+
+private[otel4s] trait TracerMacro[F[_]] {
+  self: Tracer[F] =>
+
+  /** Creates a new child span. The span is automatically attached to a parent
+    * span (based on the context).
+    *
+    * The lifecycle of the span is managed automatically. That means the span is
+    * ended upon the finalization of a resource.
+    *
+    * To attach span to a certain parent, use [[childOf]].
+    *
+    * @example
+    *   attaching span to a certain parent
+    *   {{{
+    * val tracer: Tracer[F] = ???
+    * val span: Span[F] = ???
+    * val customParent: Resource[F, Span.Auto[F]] = tracer.childOf(span).span("custom-parent")
+    *   }}}
+    *
+    * @see
+    *   [[spanBuilder]] to make fully manual span (explicit end)
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  inline def span(
+      inline name: String,
+      inline attributes: Attribute[_]*
+  ): Resource[F, Span[F]] =
+    ${ TracesMacro.span('self, 'name, 'attributes) }
+
+  /** Creates a new root span. Even if a parent span is available in the
+    * context, the span is created without a parent.
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  inline def rootSpan(
+      inline name: String,
+      inline attributes: Attribute[_]*
+  ): Resource[F, Span[F]] =
+    ${ TracesMacro.rootSpan('self, 'name, 'attributes) }
+
+}

--- a/core/src/main/scala-3/org/typelevel/otel4s/trace/TracesMacro.scala
+++ b/core/src/main/scala-3/org/typelevel/otel4s/trace/TracesMacro.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import scala.concurrent.duration.TimeUnit
+import scala.quoted.*
+
+private[otel4s] object TracesMacro {
+
+  def span[F[_]](
+      tracer: Expr[Tracer[F]],
+      name: Expr[String],
+      attributes: Expr[Seq[Attribute[_]]]
+  )(using Quotes, Type[F]) =
+    '{
+      if ($tracer.meta.isEnabled)
+        $tracer.spanBuilder($name).withAttributes($attributes*).createAuto
+      else $tracer.meta.resourceNoopSpan
+    }
+
+  def rootSpan[F[_]](
+      tracer: Expr[Tracer[F]],
+      name: Expr[String],
+      attributes: Expr[Seq[Attribute[_]]]
+  )(using Quotes, Type[F]) =
+    '{
+      if ($tracer.meta.isEnabled)
+        $tracer.spanBuilder($name).root.withAttributes($attributes*).createAuto
+      else $tracer.meta.resourceNoopSpan
+    }
+
+  def recordException[F[_]](
+      span: Expr[Span[F]],
+      exception: Expr[Throwable],
+      attributes: Expr[Seq[Attribute[_]]]
+  )(using Quotes, Type[F]) =
+    '{
+      if ($span.backend.meta.isEnabled)
+        $span.backend.recordException($exception, $attributes*)
+      else $span.backend.meta.unit
+    }
+
+  def setAttributes[F[_]](
+      span: Expr[Span[F]],
+      attributes: Expr[Seq[Attribute[_]]]
+  )(using Quotes, Type[F]) =
+    '{
+      if ($span.backend.meta.isEnabled)
+        $span.backend.setAttributes($attributes*)
+      else $span.backend.meta.unit
+    }
+
+}

--- a/core/src/main/scala/org/typelevel/otel4s/Otel4s.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/Otel4s.scala
@@ -17,7 +17,7 @@
 package org.typelevel.otel4s
 
 import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+import org.typelevel.otel4s.trace.TracerProvider
 
 trait Otel4s[F[_]] {
 
@@ -29,5 +29,5 @@ trait Otel4s[F[_]] {
   /** The entry point of the tracing API. It provides access to
     * [[org.typelevel.otel4s.trace.Tracer Tracer]].
     */
-  def traceProvider: TraceProvider[F]
+  def tracerProvider: TracerProvider[F]
 }

--- a/core/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.meta
+
+import cats.Applicative
+import cats.effect.Resource
+
+trait InstrumentMeta[F[_]] {
+
+  /** Indicates whether instrumentation is enabled or not.
+    */
+  def isEnabled: Boolean
+
+  /** A no-op effect.
+    */
+  def unit: F[Unit]
+
+  /** A resource with a no-op allocation and a no-op release.
+    */
+  def resourceUnit: Resource[F, Unit]
+}
+
+object InstrumentMeta {
+
+  def enabled[F[_]: Applicative]: InstrumentMeta[F] =
+    make(enabled = true)
+
+  def disabled[F[_]: Applicative]: InstrumentMeta[F] =
+    make(enabled = false)
+
+  private def make[F[_]: Applicative](enabled: Boolean): InstrumentMeta[F] =
+    new InstrumentMeta[F] {
+      val isEnabled: Boolean = enabled
+      val unit: F[Unit] = Applicative[F].unit
+      val resourceUnit: Resource[F, Unit] = Resource.unit
+    }
+
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.Applicative
+import org.typelevel.otel4s.meta.InstrumentMeta
+
+import scala.concurrent.duration.FiniteDuration
+
+/** The API to trace an operation.
+  *
+  * There are two types of span: [[Span.Manual]] and [[Span.Auto]].
+  *
+  * ==[[Span.Manual]]==
+  * The manual span requires an ''explicit'' end. Manual span can be used when
+  * it's necessary to end a span outside of the resource scope (i.e. async
+  * callback). Make sure the span is ended properly
+  *
+  * Leaked span:
+  * {{{
+  * val tracer: Tracer[F] = ???
+  * val leaked: F[Unit] =
+  *   tracer.spanBuilder("manual-span").createManual.use { span =>
+  *     this.setStatus(Status.Ok, "all good")
+  *   }
+  * }}}
+  *
+  * Properly ended span:
+  * {{{
+  * val tracer: Tracer[F] = ???
+  * val ok: F[Unit] =
+  *   tracer.spanBuilder("manual-span").createManual.use { span =>
+  *     this.setStatus(Status.Ok, "all good") >> span.end
+  *   }
+  * }}}
+  *
+  * ==[[Span.Auto]]==
+  * Unlike [[Span.Manual]] the auto span has a fully managed lifecycle. That
+  * means the span is started upon resource allocation and ended upon
+  * finalization. Abnormal terminations (error, cancelation) are recorded as
+  * well.
+  *
+  * Automatically ended span:
+  * {{{
+  * val tracer: Tracer[F] = ???
+  * val ok: F[Unit] =
+  *   tracer.spanBuilder("manual-span").createAuto.use { span =>
+  *     this.setStatus(Status.Ok, "all good")
+  *   }
+  * }}}
+  */
+trait Span[F[_]] extends SpanMacro[F] {
+  def backend: Span.Backend[F]
+
+  final def setStatus(status: Status): F[Unit] =
+    backend.setStatus(status)
+
+  final def setStatus(status: Status, description: String): F[Unit] =
+    backend.setStatus(status, description)
+
+}
+
+object Span {
+
+  trait Backend[F[_]] {
+    def meta: InstrumentMeta[F]
+
+    def recordException(
+        exception: Throwable,
+        attributes: Attribute[_]*
+    ): F[Unit]
+
+    def setAttributes(attributes: Attribute[_]*): F[Unit]
+    def setStatus(status: Status): F[Unit]
+    def setStatus(status: Status, description: String): F[Unit]
+
+    private[otel4s] def child(name: String): SpanBuilder[F]
+    private[otel4s] def end: F[Unit]
+    private[otel4s] def end(timestamp: FiniteDuration): F[Unit]
+  }
+
+  trait Auto[F[_]] extends Span[F]
+
+  trait Manual[F[_]] extends Span[F] {
+
+    final def end: F[Unit] =
+      backend.end
+
+    final def end(timestamp: FiniteDuration): F[Unit] =
+      backend.end(timestamp)
+
+  }
+
+  def noopAuto[F[_]: Applicative]: Auto[F] =
+    new Auto[F] {
+      val backend: Backend[F] = noopBackend
+    }
+
+  def noopManual[F[_]: Applicative]: Manual[F] =
+    new Manual[F] {
+      val backend: Backend[F] = noopBackend
+    }
+
+  def noopBackend[F[_]: Applicative]: Backend[F] =
+    new Backend[F] {
+      private val unit = Applicative[F].unit
+      private val noopBuilder = SpanBuilder.noop(this)
+
+      val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+
+      def recordException(
+          exception: Throwable,
+          attributes: Attribute[_]*
+      ): F[Unit] = unit
+
+      def setStatus(status: Status): F[Unit] = unit
+      def setStatus(status: Status, description: String): F[Unit] = unit
+      def setAttributes(attributes: Attribute[_]*): F[Unit] = unit
+
+      private[otel4s] def child(name: String): SpanBuilder[F] = noopBuilder
+      private[otel4s] def end: F[Unit] = unit
+      private[otel4s] def end(timestamp: FiniteDuration): F[Unit] = unit
+    }
+
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -74,13 +74,19 @@ trait Span[F[_]] extends SpanMacro[F] {
     backend.setStatus(status, description)
 
   /** Returns trace identifier of the current span.
+    *
+    * @return
+    *   `Some` for a valid span and `None` for noop
     */
-  final def traceId: String =
+  final def traceId: Option[String] =
     backend.traceId
 
   /** Returns span identifier of the current span.
+    *
+    * @return
+    *   `Some` for a valid span and `None` for noop
     */
-  final def spanId: String =
+  final def spanId: Option[String] =
     backend.spanId
 
 }
@@ -99,8 +105,8 @@ object Span {
     def setStatus(status: Status): F[Unit]
     def setStatus(status: Status, description: String): F[Unit]
 
-    def traceId: String
-    def spanId: String
+    def traceId: Option[String]
+    def spanId: Option[String]
 
     private[otel4s] def child(name: String): SpanBuilder[F]
     private[otel4s] def end: F[Unit]
@@ -131,8 +137,8 @@ object Span {
 
       val meta: InstrumentMeta[F] = InstrumentMeta.disabled
 
-      val traceId: String = "00000000000000000000000000000000"
-      val spanId: String = "0000000000000000"
+      val traceId: Option[String] = None
+      val spanId: Option[String] = None
 
       def recordException(
           exception: Throwable,

--- a/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -42,12 +42,8 @@ object SpanBuilder {
 
   def noop[F[_]](back: Span.Backend[F]): SpanBuilder[F] =
     new SpanBuilder[F] {
-      private val manual: Span.Manual[F] = new Span.Manual[F] {
-        def backend: Span.Backend[F] = back
-      }
-      private val auto: Span.Auto[F] = new Span.Auto[F] {
-        def backend: Span.Backend[F] = back
-      }
+      private val manual: Span.Manual[F] = Span.Manual.fromBackend(back)
+      private val auto: Span.Auto[F] = Span.Auto.fromBackend(back)
 
       def withSpanKind(spanKind: SpanKind): SpanBuilder[F] = this
       def withAttribute[A](attribute: Attribute[A]): SpanBuilder[F] = this
@@ -66,6 +62,6 @@ object SpanBuilder {
         Resource.pure(auto)
 
       def createRes[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]] =
-        Span.Res.fromResource(resource, back)
+        resource.map(a => Span.Res.fromBackend(a, back))
     }
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.effect.Resource
+
+import scala.concurrent.duration.FiniteDuration
+
+trait SpanBuilder[F[_]] {
+
+  def withSpanKind(spanKind: SpanKind): SpanBuilder[F]
+  def withAttribute[A](attribute: Attribute[A]): SpanBuilder[F]
+  def withAttributes(attributes: Attribute[_]*): SpanBuilder[F]
+  def withLink(
+      spanContext: SpanContext,
+      attributes: Attribute[_]*
+  ): SpanBuilder[F]
+  def root: SpanBuilder[F]
+  def withStartTimestamp(timestamp: FiniteDuration): SpanBuilder[F]
+
+  def createManual: Resource[F, Span.Manual[F]]
+  def createAuto: Resource[F, Span.Auto[F]]
+
+}
+
+object SpanBuilder {
+
+  def noop[F[_]](back: Span.Backend[F]): SpanBuilder[F] =
+    new SpanBuilder[F] {
+      private val manual: Span.Manual[F] = new Span.Manual[F] {
+        def backend: Span.Backend[F] = back
+      }
+      private val auto: Span.Auto[F] = new Span.Auto[F] {
+        def backend: Span.Backend[F] = back
+      }
+
+      def withSpanKind(spanKind: SpanKind): SpanBuilder[F] = this
+      def withAttribute[A](attribute: Attribute[A]): SpanBuilder[F] = this
+      def withAttributes(attributes: Attribute[_]*): SpanBuilder[F] = this
+      def withLink(
+          spanContext: SpanContext,
+          attributes: Attribute[_]*
+      ): SpanBuilder[F] = this
+      def root: SpanBuilder[F] = this
+      def withStartTimestamp(timestamp: FiniteDuration): SpanBuilder[F] = this
+
+      val createManual: Resource[F, Span.Manual[F]] =
+        Resource.pure(manual)
+
+      val createAuto: Resource[F, Span.Auto[F]] =
+        Resource.pure(auto)
+    }
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -35,7 +35,7 @@ trait SpanBuilder[F[_]] {
 
   def createManual: Resource[F, Span.Manual[F]]
   def createAuto: Resource[F, Span.Auto[F]]
-
+  def createRes[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]]
 }
 
 object SpanBuilder {
@@ -64,5 +64,8 @@ object SpanBuilder {
 
       val createAuto: Resource[F, Span.Auto[F]] =
         Resource.pure(auto)
+
+      def createRes[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]] =
+        Span.Res.fromResource(resource, back)
     }
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/SpanContext.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/SpanContext.scala
@@ -15,19 +15,17 @@
  */
 
 package org.typelevel.otel4s
+package trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+trait SpanContext {
+  def traceId: String
+  def spanId: String
+}
 
-trait Otel4s[F[_]] {
+object SpanContext {
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
+  trait Provider[F[_]] {
+    def current: F[SpanContext]
+  }
 
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/SpanKind.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/SpanKind.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+/** Type of [[Span]]. Can be used to specify additional relationships between
+  * spans in addition to a parent/child relationship.
+  */
+sealed trait SpanKind extends Product with Serializable
+
+object SpanKind {
+
+  /** Default value. Indicates that the span is used internally. */
+  case object Internal extends SpanKind
+
+  /** Indicates that the span covers server-side handling of an RPC or other
+    * remote request.
+    */
+  case object Server extends SpanKind
+
+  /** Indicates that the span covers the client-side wrapper around an RPC or
+    * other remote request.
+    */
+  case object Client extends SpanKind
+
+  /** Indicates that the span describes producer sending a message to a broker.
+    * Unlike client and server, there is no direct critical path latency
+    * relationship between producer and consumer spans.
+    */
+  case object Producer extends SpanKind
+
+  /** Indicates that the span describes consumer receiving a message from a
+    * broker. Unlike client and server, there is no direct critical path latency
+    * relationship between producer and consumer spans.
+    */
+  case object Consumer extends SpanKind
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/Status.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/Status.scala
@@ -14,20 +14,23 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s
+package org.typelevel.otel4s.trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+/** The set of canonical status codes
+  */
+sealed trait Status extends Product with Serializable
 
-trait Otel4s[F[_]] {
+object Status {
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
+  /** The default status. */
+  case object Unset extends Status
+
+  /** The operation has been validated by an Application developers or Operator
+    * to have completed successfully.
     */
-  def meterProvider: MeterProvider[F]
+  case object Ok extends Status
 
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
+  /** The operation contains an error. */
+  case object Error extends Status
+
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/TraceProvider.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/TraceProvider.scala
@@ -15,19 +15,10 @@
  */
 
 package org.typelevel.otel4s
+package trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
-
-trait Otel4s[F[_]] {
-
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
-
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
+/** The entry point of the tracing API. It provides access to [[Tracer]].
+  */
+trait TraceProvider[F[_]] {
+  def tracer(name: String): TracerBuilder[F]
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.Applicative
+import cats.effect.kernel.Resource
+import org.typelevel.otel4s.meta.InstrumentMeta
+
+/** The API is responsible for creating [[Span]]'s.
+  */
+trait Tracer[F[_]] extends TracerMacro[F] { self =>
+
+  /** Instrument metadata. Indicates whether instrumentation is enabled or not.
+    */
+  def meta: Tracer.Meta[F]
+
+  /** Creates a new [[SpanBuilder]]. The builder can be used to make a fully
+    * customized [[Span]].
+    *
+    * @param name
+    *   the name of the span
+    */
+  def spanBuilder(name: String): SpanBuilder[F]
+
+  /** Creates a new tracer as a child of the given span.
+    *
+    * @example
+    *   {{{
+    * val tracer: Tracer[F] = ???
+    * val span: Span[F] = ???
+    * val customChild: Resource[F, Span[F]] = tracer.childOf(span).
+    *   }}}
+    * @param span
+    *   the parent span
+    */
+  def childOf(span: Span[F]): Tracer[F]
+
+}
+
+object Tracer {
+
+  trait Meta[F[_]] extends InstrumentMeta[F] {
+    def resourceNoopSpan: Resource[F, Span.Auto[F]]
+  }
+
+  object Meta {
+
+    def enabled[F[_]: Applicative]: Meta[F] = make(true)
+    def disabled[F[_]: Applicative]: Meta[F] = make(false)
+
+    private def make[F[_]: Applicative](enabled: Boolean): Meta[F] =
+      new Meta[F] {
+        val isEnabled: Boolean = enabled
+        val unit: F[Unit] = Applicative[F].unit
+        val resourceUnit: Resource[F, Unit] = Resource.unit
+        val resourceNoopSpan: Resource[F, Span.Auto[F]] =
+          Resource.pure(Span.noopAuto)
+      }
+
+  }
+
+  def noop[F[_]](implicit F: Applicative[F]): Tracer[F] =
+    new Tracer[F] {
+      private val builder = SpanBuilder.noop(Span.noopBackend)
+      val meta: Meta[F] = Meta.disabled
+      def spanBuilder(name: String): SpanBuilder[F] = builder
+      def childOf(span: Span[F]): Tracer[F] = this
+    }
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -50,6 +50,14 @@ trait Tracer[F[_]] extends TracerMacro[F] { self =>
     */
   def childOf(span: Span[F]): Tracer[F]
 
+  /** Returns trace identifier of a span that is available in a scope.
+    */
+  def traceId: F[Option[String]]
+
+  /** Returns span identifier of a span that is available in a scope.
+    */
+  def spanId: F[Option[String]]
+
 }
 
 object Tracer {
@@ -80,5 +88,7 @@ object Tracer {
       val meta: Meta[F] = Meta.disabled
       def spanBuilder(name: String): SpanBuilder[F] = builder
       def childOf(span: Span[F]): Tracer[F] = this
+      val traceId: F[Option[String]] = F.pure(None)
+      val spanId: F[Option[String]] = F.pure(None)
     }
 }

--- a/core/src/main/scala/org/typelevel/otel4s/trace/TracerBuilder.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/TracerBuilder.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.Applicative
+
+trait TracerBuilder[F[_]] {
+
+  /** Assigns a version to the resulting Meter.
+    *
+    * @param version
+    *   the version of the instrumentation scope
+    */
+  def withVersion(version: String): TracerBuilder[F]
+
+  /** Assigns an OpenTelemetry schema URL to the resulting Meter.
+    *
+    * @param schemaUrl
+    *   the URL of the OpenTelemetry schema
+    */
+  def withSchemaUrl(schemaUrl: String): TracerBuilder[F]
+
+  /** Creates a [[Tracer]] with the given `version` and `schemaUrl` (if any).
+    */
+  def get: F[Tracer[F]]
+
+}
+
+object TracerBuilder {
+  def noop[F[_]](implicit F: Applicative[F]): TracerBuilder[F] =
+    new TracerBuilder[F] {
+      def withVersion(version: String): TracerBuilder[F] = this
+      def withSchemaUrl(schemaUrl: String): TracerBuilder[F] = this
+      def get: F[Tracer[F]] = F.pure(Tracer.noop)
+    }
+}

--- a/core/src/main/scala/org/typelevel/otel4s/trace/TracerProvider.scala
+++ b/core/src/main/scala/org/typelevel/otel4s/trace/TracerProvider.scala
@@ -19,6 +19,6 @@ package trace
 
 /** The entry point of the tracing API. It provides access to [[Tracer]].
   */
-trait TraceProvider[F[_]] {
+trait TracerProvider[F[_]] {
   def tracer(name: String): TracerBuilder[F]
 }

--- a/core/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
+++ b/core/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package trace
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class TracerSuite extends CatsEffectSuite {
+
+  test("do not allocate attributes when instrument is noop") {
+    val tracer = Tracer.noop[IO]
+
+    var allocated = false
+
+    def allocateAttribute = {
+      allocated = true
+      List(Attribute(AttributeKey.string("key"), "value"))
+    }
+
+    def exception = {
+      allocated = true
+      new RuntimeException("exception")
+    }
+
+    for {
+      _ <- tracer.span("span", allocateAttribute: _*).use { span =>
+        for {
+          _ <- span.setAttributes(allocateAttribute: _*)
+          _ <- span.recordException(exception, allocateAttribute: _*)
+        } yield ()
+      }
+      _ <- tracer.rootSpan("span", allocateAttribute: _*).use { span =>
+        for {
+          _ <- span.setAttributes(allocateAttribute: _*)
+          _ <- span.recordException(exception, allocateAttribute: _*)
+        } yield ()
+      }
+    } yield assert(!allocated)
+  }
+
+}

--- a/examples/src/main/scala/com/example/tracing/JaegerTracing.scala
+++ b/examples/src/main/scala/com/example/tracing/JaegerTracing.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.tracing
+
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Resource
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.{Resource => OtelResource}
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.BatchSpanProcessor
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.AttributeKey
+import org.typelevel.otel4s.Otel4s
+import org.typelevel.otel4s.java.OtelJava
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.Tracer
+
+import scala.concurrent.duration._
+
+/** Run jaeger-all-in-one image:
+  * {{{
+  *  docker run -d --name jaeger-132 \
+  *    -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  *    -p 5775:5775/udp \
+  *    -p 6831:6831/udp \
+  *    -p 6832:6832/udp \
+  *    -p 5778:5778 \
+  *    -p 16686:16686 \
+  *    -p 14250:14250 \
+  *    -p 14268:14268 \
+  *    -p 14269:14269 \
+  *    -p 9411:9411 \
+  *    jaegertracing/all-in-one:1.32
+  * }}}
+  */
+object JaegerTracing extends IOApp.Simple {
+
+  def run: IO[Unit] =
+    makeOtel4s.use { otel =>
+      for {
+        tracer <- otel.tracerProvider
+          .tracer("my-tracer")
+          .get
+        _ <- tracer
+          .resourceSpan("resource-span")(makeImageLookup(tracer))
+          .use { case Span.Res(lookup) =>
+            lookup.exists("my-image")
+          }
+      } yield ()
+    }
+
+  private def makeImageLookup(tracer: Tracer[IO]): Resource[IO, ImageLookup] = {
+    val acquire = IO.delay {
+      new ImageLookup {
+        def exists(imageId: String): IO[Boolean] =
+          tracer
+            .span(
+              "image-exists",
+              Attribute(AttributeKey.string("image-id"), imageId)
+            )
+            .surround(IO.pure(false))
+      }
+    }
+
+    Resource.make(acquire.delayBy(200.millis))(_ => IO.sleep(300.millis))
+  }
+
+  trait ImageLookup {
+    def exists(imageId: String): IO[Boolean]
+  }
+
+  private def makeOtel4s: Resource[IO, Otel4s[IO]] = {
+    val mkTracerProvider = IO.delay {
+      val jaegerExporter = JaegerGrpcSpanExporter
+        .builder()
+        .setEndpoint("http://localhost:14250")
+        .build()
+
+      SdkTracerProvider
+        .builder()
+        .addSpanProcessor(BatchSpanProcessor.builder(jaegerExporter).build())
+        .setResource(
+          OtelResource.create(
+            Attributes
+              .builder()
+              .put(ResourceAttributes.SERVICE_NAME, "my-service")
+              .build()
+          )
+        )
+        .build()
+    }
+
+    for {
+      tracerProvider <- Resource.fromAutoCloseable(mkTracerProvider)
+      sdk <- Resource.pure {
+        OpenTelemetrySdk
+          .builder()
+          .setTracerProvider(tracerProvider)
+          .build()
+      }
+      otel <- Resource.eval(OtelJava.forSync(sdk))
+    } yield otel
+  }
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package java
+
+import io.opentelemetry.api.common.{AttributeKey => JAttributeKey}
+import io.opentelemetry.api.common.{AttributeType => JAttributeType}
+import io.opentelemetry.api.common.{Attributes => JAttributes}
+
+import scala.jdk.CollectionConverters._
+
+private[java] object Conversions {
+
+  def toJAttributes(attributes: Seq[Attribute[_]]): JAttributes = {
+    val builder = JAttributes.builder
+    def put(name: String, jType: JAttributeType, value: Any): Unit = {
+      val jKey = new JAttributeKey[Any] {
+        def getKey = name
+        def getType = jType
+        override def toString = name
+      }
+      builder.put[Any](jKey, value)
+      ()
+    }
+    def putList(name: String, jType: JAttributeType, values: Any): Unit = {
+      val jKey = new JAttributeKey[Any] {
+        def getKey = name
+        def getType = jType
+        override def toString = name
+      }
+      builder.put[Any](jKey, values.asInstanceOf[Seq[Any]].asJava)
+      ()
+    }
+    attributes.foreach { case Attribute(key, value) =>
+      key.`type` match {
+        case AttributeType.String =>
+          put(key.name, JAttributeType.STRING, value)
+        case AttributeType.Boolean =>
+          put(key.name, JAttributeType.BOOLEAN, value)
+        case AttributeType.Long =>
+          put(key.name, JAttributeType.LONG, value)
+        case AttributeType.Double =>
+          put(key.name, JAttributeType.DOUBLE, value)
+        case AttributeType.StringList =>
+          putList(key.name, JAttributeType.STRING_ARRAY, value)
+        case AttributeType.BooleanList =>
+          putList(key.name, JAttributeType.BOOLEAN_ARRAY, value)
+        case AttributeType.LongList =>
+          putList(key.name, JAttributeType.LONG_ARRAY, value)
+        case AttributeType.DoubleList =>
+          putList(key.name, JAttributeType.DOUBLE_ARRAY, value)
+      }
+    }
+    builder.build()
+  }
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/impl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/impl.scala
@@ -35,10 +35,10 @@ object OtelJava {
   def forSync[F[_]: LiftIO](
       jOtel: JOpenTelemetry
   )(implicit F: Sync[F]): F[Otel4s[F]] =
-    TraceProviderImpl.ioLocal(jOtel.getTracerProvider).map { provider =>
+    TracerProviderImpl.ioLocal(jOtel.getTracerProvider).map { provider =>
       new Otel4s[F] {
         val meterProvider: MeterProvider[F] = new MeterProviderImpl[F](jOtel)
-        val traceProvider: TraceProvider[F] = provider
+        val tracerProvider: TracerProvider[F] = provider
       }
     }
 

--- a/java/src/main/scala/org/typelevel/otel4s/java/impl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/impl.scala
@@ -35,7 +35,7 @@ object OtelJava {
   def forSync[F[_]: LiftIO](
       jOtel: JOpenTelemetry
   )(implicit F: Sync[F]): F[Otel4s[F]] =
-    TraceProviderImpl.ioLocal(jOtel).map { provider =>
+    TraceProviderImpl.ioLocal(jOtel.getTracerProvider).map { provider =>
       new Otel4s[F] {
         val meterProvider: MeterProvider[F] = new MeterProviderImpl[F](jOtel)
         val traceProvider: TraceProvider[F] = provider

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/ManualSpanImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/ManualSpanImpl.scala
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s
+package org.typelevel.otel4s.java.trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+import org.typelevel.otel4s.trace._
 
-trait Otel4s[F[_]] {
+private[trace] class ManualSpanImpl[F[_]](val backend: SpanBackendImpl[F])
+    extends Span.Manual[F]
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
-
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
-}
+private[trace] class AutoSpanImpl[F[_]](val backend: SpanBackendImpl[F])
+    extends Span.Auto[F]

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/ManualSpanImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/ManualSpanImpl.scala
@@ -16,10 +16,14 @@
 
 package org.typelevel.otel4s.java.trace
 
+import io.opentelemetry.context.{Context => JContext}
 import org.typelevel.otel4s.trace._
 
-private[trace] class ManualSpanImpl[F[_]](val backend: SpanBackendImpl[F])
-    extends Span.Manual[F]
+private[trace] class ManualSpanImpl[F[_]](
+    val backend: SpanBackendImpl[F]
+) extends Span.Manual[F]
 
-private[trace] class AutoSpanImpl[F[_]](val backend: SpanBackendImpl[F])
-    extends Span.Auto[F]
+private[trace] class AutoSpanImpl[F[_]](
+    val backend: SpanBackendImpl[F],
+    val ctx: JContext
+) extends Span.Auto[F]

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
@@ -69,6 +69,12 @@ private[otel4s] class SpanBackendImpl[F[_]](
 
   private[otel4s] def end(timestamp: FiniteDuration): F[Unit] =
     F.delay(jSpan.end(timestamp.length, timestamp.unit))
+
+  def traceId: String =
+    jSpan.getSpanContext.getTraceId
+
+  def spanId: String =
+    jSpan.getSpanContext.getSpanId
 }
 
 object SpanBackendImpl {

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
@@ -70,11 +70,11 @@ private[otel4s] class SpanBackendImpl[F[_]](
   private[otel4s] def end(timestamp: FiniteDuration): F[Unit] =
     F.delay(jSpan.end(timestamp.length, timestamp.unit))
 
-  def traceId: String =
-    jSpan.getSpanContext.getTraceId
+  def traceId: Option[String] =
+    Option(jSpan.getSpanContext).filter(_.isValid).map(_.getTraceId)
 
-  def spanId: String =
-    jSpan.getSpanContext.getSpanId
+  def spanId: Option[String] =
+    Option(jSpan.getSpanContext).filter(_.isValid).map(_.getSpanId)
 }
 
 object SpanBackendImpl {

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package java
+package trace
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.opentelemetry.api.trace.{Span => JSpan}
+import io.opentelemetry.api.trace.{StatusCode => JStatusCode}
+import io.opentelemetry.api.trace.{Tracer => JTracer}
+import org.typelevel.otel4s.meta.InstrumentMeta
+import org.typelevel.otel4s.trace._
+
+import scala.concurrent.duration.FiniteDuration
+
+private[otel4s] class SpanBackendImpl[F[_]](
+    jTracer: JTracer,
+    val jSpan: JSpan,
+    scope: TraceScope[F]
+)(implicit F: Sync[F])
+    extends Span.Backend[F] {
+
+  import SpanBackendImpl._
+
+  val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+
+  def recordException(
+      exception: Throwable,
+      attributes: Attribute[_]*
+  ): F[Unit] =
+    F.delay(
+      jSpan.recordException(exception, Conversions.toJAttributes(attributes))
+    ).void
+
+  def setAttributes(attributes: Attribute[_]*): F[Unit] =
+    F.delay(jSpan.setAllAttributes(Conversions.toJAttributes(attributes))).void
+
+  def setStatus(status: Status): F[Unit] =
+    F.delay(jSpan.setStatus(toJStatus(status))).void
+
+  def setStatus(status: Status, description: String): F[Unit] =
+    F.delay(jSpan.setStatus(toJStatus(status), description)).void
+
+  private[otel4s] def child(name: String): SpanBuilder[F] =
+    new SpanBuilderImpl[F](
+      jTracer,
+      name,
+      scope,
+      parent = SpanBuilderImpl.Parent.Explicit(jSpan)
+    )
+
+  private[otel4s] def end: F[Unit] =
+    F.delay(jSpan.end())
+
+  private[otel4s] def end(timestamp: FiniteDuration): F[Unit] =
+    F.delay(jSpan.end(timestamp.length, timestamp.unit))
+}
+
+object SpanBackendImpl {
+
+  private def toJStatus(status: Status): JStatusCode =
+    status match {
+      case Status.Unset => JStatusCode.UNSET
+      case Status.Ok    => JStatusCode.OK
+      case Status.Error => JStatusCode.ERROR
+    }
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java
+package trace
+
+import cats.effect.Clock
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import io.opentelemetry.api.trace.{Span => JSpan}
+import io.opentelemetry.api.trace.{SpanBuilder => JSpanBuilder}
+import io.opentelemetry.api.trace.{SpanContext => JSpanContext}
+import io.opentelemetry.api.trace.{SpanKind => JSpanKind}
+import io.opentelemetry.api.trace.{Tracer => JTracer}
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.context.{Context => JContext}
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.SpanBuilder
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.SpanKind
+import org.typelevel.otel4s.trace.Status
+
+import scala.concurrent.duration.FiniteDuration
+
+private[trace] final case class SpanBuilderImpl[F[_]](
+    jTracer: JTracer,
+    name: String,
+    scope: TraceScope[F],
+    parent: SpanBuilderImpl.Parent = SpanBuilderImpl.Parent.Auto,
+    kind: Option[SpanKind] = None,
+    links: Seq[(SpanContext, Seq[Attribute[_]])] = Nil,
+    attributes: Seq[Attribute[_]] = Nil,
+    startTimestamp: Option[FiniteDuration] = None
+)(implicit F: Sync[F], C: Clock[F])
+    extends SpanBuilder[F] {
+
+  import SpanBuilderImpl._
+
+  def withSpanKind(spanKind: SpanKind): SpanBuilder[F] =
+    copy(kind = Some(spanKind))
+
+  def withAttribute[A](attribute: Attribute[A]): SpanBuilder[F] =
+    copy(attributes = attributes :+ attribute)
+
+  def withAttributes(attributes: Attribute[_]*): SpanBuilder[F] =
+    copy(attributes = attributes ++ attributes)
+
+  def withLink(
+      spanContext: SpanContext,
+      attributes: Attribute[_]*
+  ): SpanBuilder[F] =
+    copy(links = links :+ (spanContext, attributes))
+
+  def root: SpanBuilder[F] =
+    copy(parent = Parent.Root)
+
+  def withStartTimestamp(timestamp: FiniteDuration): SpanBuilder[F] =
+    copy(startTimestamp = Some(timestamp))
+
+  def createManual: Resource[F, Span.Manual[F]] =
+    for {
+      parent <- Resource.eval(parentContext)
+      jBuilder <- Resource.pure(makeJBuilder(parent))
+      jSpan <- Resource.eval(F.delay(jBuilder.startSpan()))
+      _ <- scope.make(jSpan)
+    } yield new ManualSpanImpl(new SpanBackendImpl(jTracer, jSpan, scope))
+
+  def createAuto: Resource[F, Span.Auto[F]] = {
+    def acquire: F[ManualSpanImpl[F]] =
+      for {
+        now <- C.monotonic
+        parent <- parentContext
+        jSpan <- F.delay {
+          makeJBuilder(parent)
+            .setStartTimestamp(now.length, now.unit)
+            .startSpan()
+        }
+      } yield new ManualSpanImpl(new SpanBackendImpl(jTracer, jSpan, scope))
+
+    def reportStatus(span: Span[F], ec: Resource.ExitCase): F[Unit] =
+      ec match {
+        case Resource.ExitCase.Succeeded =>
+          F.unit
+
+        case Resource.ExitCase.Errored(e) =>
+          span.recordException(e) >> span.setStatus(Status.Error)
+
+        case Resource.ExitCase.Canceled =>
+          span.setStatus(Status.Error, "canceled")
+      }
+
+    def release(span: Span.Manual[F], ec: Resource.ExitCase): F[Unit] =
+      for {
+        now <- C.monotonic
+        _ <- reportStatus(span, ec)
+        _ <- span.end(now)
+      } yield ()
+
+    for {
+      manual <- Resource.makeCase(acquire) { case (span, ec) =>
+        release(span, ec)
+      }
+      _ <- scope.make(manual.backend.jSpan)
+    } yield new AutoSpanImpl[F](manual.backend)
+  }
+
+  private def makeJBuilder(parent: JContext): JSpanBuilder = {
+    val b = jTracer
+      .spanBuilder(name)
+      .setAllAttributes(Conversions.toJAttributes(attributes))
+      .setParent(parent)
+
+    kind.foreach(k => b.setSpanKind(toJSpanKind(k)))
+    b.setAllAttributes(Conversions.toJAttributes(attributes))
+    startTimestamp.foreach(d => b.setStartTimestamp(d.length, d.unit))
+    links.foreach { case (ctx, attributes) =>
+      b.addLink(toJSpanContext(ctx), Conversions.toJAttributes(attributes))
+    }
+
+    b
+  }
+
+  private def parentContext: F[JContext] =
+    parent match {
+      case Parent.Auto =>
+        scope.current
+      case Parent.Root =>
+        scope.root
+      case Parent.Explicit(parent) =>
+        scope.current.map(ctx => ctx.`with`(parent))
+    }
+}
+
+object SpanBuilderImpl {
+
+  sealed trait Parent
+
+  object Parent {
+    case object Auto extends Parent
+    case object Root extends Parent
+    final case class Explicit(parent: JSpan) extends Parent
+  }
+
+  private def toJSpanKind(spanKind: SpanKind): JSpanKind =
+    spanKind match {
+      case SpanKind.Internal => JSpanKind.INTERNAL
+      case SpanKind.Server   => JSpanKind.SERVER
+      case SpanKind.Client   => JSpanKind.CLIENT
+      case SpanKind.Producer => JSpanKind.PRODUCER
+      case SpanKind.Consumer => JSpanKind.CONSUMER
+    }
+
+  private def toJSpanContext(context: SpanContext): JSpanContext =
+    context match {
+      case ctx: WrappedSpanContext =>
+        ctx.jSpanContext
+
+      case other =>
+        JSpanContext.create(
+          other.traceId,
+          other.spanId,
+          TraceFlags.getDefault,
+          TraceState.getDefault
+        )
+    }
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceProviderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceProviderImpl.scala
@@ -19,27 +19,27 @@ package org.typelevel.otel4s.java.trace
 import cats.effect.LiftIO
 import cats.effect.Sync
 import cats.syntax.functor._
-import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import io.opentelemetry.context.{Context => JContext}
 import org.typelevel.otel4s.trace.TraceProvider
 import org.typelevel.otel4s.trace.TracerBuilder
 
 private[otel4s] class TraceProviderImpl[F[_]: Sync](
-    jOtel: JOpenTelemetry,
+    jTracerProvider: JTracerProvider,
     scope: TraceScope[F]
 ) extends TraceProvider[F] {
   def tracer(name: String): TracerBuilder[F] =
-    TracerBuilderImpl(jOtel, scope, name)
+    TracerBuilderImpl(jTracerProvider, scope, name)
 }
 
 object TraceProviderImpl {
 
   def ioLocal[F[_]: LiftIO: Sync](
-      jOtel: JOpenTelemetry,
+      jTracerProvider: JTracerProvider,
       default: JContext = JContext.root()
   ): F[TraceProviderImpl[F]] =
     TraceScope
       .fromIOLocal[F](default)
-      .map(scope => new TraceProviderImpl(jOtel, scope))
+      .map(scope => new TraceProviderImpl(jTracerProvider, scope))
 
 }

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceProviderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceProviderImpl.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import cats.effect.LiftIO
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+import io.opentelemetry.context.{Context => JContext}
+import org.typelevel.otel4s.trace.TraceProvider
+import org.typelevel.otel4s.trace.TracerBuilder
+
+private[otel4s] class TraceProviderImpl[F[_]: Sync](
+    jOtel: JOpenTelemetry,
+    scope: TraceScope[F]
+) extends TraceProvider[F] {
+  def tracer(name: String): TracerBuilder[F] =
+    TracerBuilderImpl(jOtel, scope, name)
+}
+
+object TraceProviderImpl {
+
+  def ioLocal[F[_]: LiftIO: Sync](
+      jOtel: JOpenTelemetry,
+      default: JContext = JContext.root()
+  ): F[TraceProviderImpl[F]] =
+    TraceScope
+      .fromIOLocal[F](default)
+      .map(scope => new TraceProviderImpl(jOtel, scope))
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import cats.effect.IOLocal
+import cats.effect.LiftIO
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.opentelemetry.api.trace.{Span => JSpan}
+import io.opentelemetry.context.{Context => JContext}
+
+trait TraceScope[F[_]] {
+  def root: F[JContext]
+  def current: F[JContext]
+  def make(span: JSpan): Resource[F, Unit]
+}
+
+object TraceScope {
+
+  def fromIOLocal[F[_]: LiftIO: Sync](
+      default: JContext
+  ): F[TraceScope[F]] = {
+    val lift = LiftIO.liftK
+
+    lift(IOLocal(default)).map { local =>
+      new TraceScope[F] {
+        val root: F[JContext] =
+          Sync[F].pure(default)
+
+        def current: F[JContext] =
+          lift(local.get)
+
+        def make(span: JSpan): Resource[F, Unit] =
+          for {
+            current <- Resource.eval(lift(local.get))
+            next <- Resource.pure(current.`with`(span))
+            _ <- Resource.make(lift(local.getAndSet(next)))(previous =>
+              lift(local.set(previous))
+            )
+          } yield ()
+      }
+    }
+  }
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
@@ -17,11 +17,11 @@
 package org.typelevel.otel4s.java.trace
 
 import cats.effect.Sync
-import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import org.typelevel.otel4s.trace._
 
 private[trace] final case class TracerBuilderImpl[F[_]](
-    jOtel: JOpenTelemetry,
+    jTracerProvider: JTracerProvider,
     scope: TraceScope[F],
     name: String,
     version: Option[String] = None,
@@ -36,7 +36,7 @@ private[trace] final case class TracerBuilderImpl[F[_]](
     copy(schemaUrl = Option(schemaUrl))
 
   def get: F[Tracer[F]] = F.delay {
-    val b = jOtel.tracerBuilder(name)
+    val b = jTracerProvider.tracerBuilder(name)
     version.foreach(b.setInstrumentationVersion)
     schemaUrl.foreach(b.setSchemaUrl)
     new TracerImpl(b.build(), scope)

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import cats.effect.Sync
+import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+import org.typelevel.otel4s.trace._
+
+private[trace] final case class TracerBuilderImpl[F[_]](
+    jOtel: JOpenTelemetry,
+    scope: TraceScope[F],
+    name: String,
+    version: Option[String] = None,
+    schemaUrl: Option[String] = None
+)(implicit F: Sync[F])
+    extends TracerBuilder[F] {
+
+  def withVersion(version: String): TracerBuilder[F] =
+    copy(version = Option(version))
+
+  def withSchemaUrl(schemaUrl: String): TracerBuilder[F] =
+    copy(schemaUrl = Option(schemaUrl))
+
+  def get: F[Tracer[F]] = F.delay {
+    val b = jOtel.tracerBuilder(name)
+    version.foreach(b.setInstrumentationVersion)
+    schemaUrl.foreach(b.setSchemaUrl)
+    new TracerImpl(b.build(), scope)
+  }
+
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
@@ -17,6 +17,8 @@
 package org.typelevel.otel4s.java.trace
 
 import cats.effect.Sync
+import cats.syntax.functor._
+import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.api.trace.{Tracer => JTracer}
 import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.SpanBuilder
@@ -38,4 +40,20 @@ private[trace] class TracerImpl[F[_]: Sync](
       override def spanBuilder(name: String): SpanBuilder[F] =
         s.backend.child(name)
     }
+
+  /** Returns trace identifier of a span that is available in a scope.
+    */
+  def traceId: F[Option[String]] =
+    for {
+      context <- scope.current
+    } yield Option(JSpan.fromContextOrNull(context))
+      .map(_.getSpanContext.getTraceId)
+
+  /** Returns span identifier of a span that is available in a scope.
+    */
+  def spanId: F[Option[String]] =
+    for {
+      context <- scope.current
+    } yield Option(JSpan.fromContextOrNull(context))
+      .map(_.getSpanContext.getSpanId)
 }

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import cats.effect.Sync
+import io.opentelemetry.api.trace.{Tracer => JTracer}
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.SpanBuilder
+import org.typelevel.otel4s.trace.Tracer
+
+private[trace] class TracerImpl[F[_]: Sync](
+    jTracer: JTracer,
+    scope: TraceScope[F]
+) extends Tracer[F] {
+
+  val meta: Tracer.Meta[F] =
+    Tracer.Meta.enabled
+
+  def spanBuilder(name: String): SpanBuilder[F] =
+    new SpanBuilderImpl[F](jTracer, name, scope)
+
+  def childOf(s: Span[F]): Tracer[F] =
+    new TracerImpl(jTracer, scope) {
+      override def spanBuilder(name: String): SpanBuilder[F] =
+        s.backend.child(name)
+    }
+}

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -21,25 +21,25 @@ import cats.effect.Sync
 import cats.syntax.functor._
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import io.opentelemetry.context.{Context => JContext}
-import org.typelevel.otel4s.trace.TraceProvider
 import org.typelevel.otel4s.trace.TracerBuilder
+import org.typelevel.otel4s.trace.TracerProvider
 
-private[otel4s] class TraceProviderImpl[F[_]: Sync](
+private[otel4s] class TracerProviderImpl[F[_]: Sync](
     jTracerProvider: JTracerProvider,
     scope: TraceScope[F]
-) extends TraceProvider[F] {
+) extends TracerProvider[F] {
   def tracer(name: String): TracerBuilder[F] =
     TracerBuilderImpl(jTracerProvider, scope, name)
 }
 
-object TraceProviderImpl {
+object TracerProviderImpl {
 
   def ioLocal[F[_]: LiftIO: Sync](
       jTracerProvider: JTracerProvider,
       default: JContext = JContext.root()
-  ): F[TraceProviderImpl[F]] =
+  ): F[TracerProviderImpl[F]] =
     TraceScope
       .fromIOLocal[F](default)
-      .map(scope => new TraceProviderImpl(jTracerProvider, scope))
+      .map(scope => new TracerProviderImpl(jTracerProvider, scope))
 
 }

--- a/java/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
+++ b/java/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s
+package org.typelevel.otel4s.java.trace
 
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TraceProvider
+import io.opentelemetry.api.trace.{SpanContext => JSpanContext}
+import org.typelevel.otel4s.trace.SpanContext
 
-trait Otel4s[F[_]] {
+private[trace] class WrappedSpanContext(val jSpanContext: JSpanContext)
+    extends SpanContext {
 
-  /** A registry for creating named
-    * [[org.typelevel.otel4s.metrics.Meter Meter]].
-    */
-  def meterProvider: MeterProvider[F]
+  def traceId: String = jSpanContext.getTraceId
+  def spanId: String = jSpanContext.getSpanId
 
-  /** The entry point of the tracing API. It provides access to
-    * [[org.typelevel.otel4s.trace.Tracer Tracer]].
-    */
-  def traceProvider: TraceProvider[F]
 }

--- a/java/src/test/scala/com/example/PoC.scala
+++ b/java/src/test/scala/com/example/PoC.scala
@@ -44,12 +44,6 @@ object Poc extends IOApp.Simple {
       Attribute(fish, List("one", "two", "red", "blue")),
       Attribute(numbers, List(1L, 2L, 3L, 4L))
     )
-    tracer <- otel4s.traceProvider.tracer("my-tracer").get
-    _ <- tracer.span("my-span").use { _ =>
-      tracer.span("span-2").use { _ =>
-        IO.println("my-span")
-      }
-    }
     provider = otel4j.getSdkMeterProvider
     _ <- IO.println(provider.forceFlush())
     _ <- IO.delay(otel4j.getSdkMeterProvider.close())

--- a/java/src/test/scala/com/example/PoC.scala
+++ b/java/src/test/scala/com/example/PoC.scala
@@ -52,5 +52,7 @@ object Poc extends IOApp.Simple {
     }
     provider = otel4j.getSdkMeterProvider
     _ <- IO.println(provider.forceFlush())
+    _ <- IO.delay(otel4j.getSdkMeterProvider.close())
+    _ <- IO.delay(otel4j.getSdkTracerProvider.close())
   } yield ()
 }

--- a/java/src/test/scala/org/typelevel/otel4s/java/trace/SpanNode.scala
+++ b/java/src/test/scala/org/typelevel/otel4s/java/trace/SpanNode.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import io.opentelemetry.sdk.trace.data.SpanData
+
+import scala.concurrent.duration._
+
+// Tree-like representation of a span
+final case class SpanNode(
+    name: String,
+    start: FiniteDuration,
+    end: FiniteDuration,
+    children: List[SpanNode]
+)
+
+object SpanNode {
+
+  def fromSpans(spans: List[SpanData]): List[SpanNode] = {
+    val spansByParent = spans.groupBy { span =>
+      Option.when(span.getParentSpanContext.isValid)(span.getParentSpanId)
+    }
+    val topNodes = spansByParent.getOrElse(None, Nil)
+    val bottomToTop = sortNodesByDepth(0, topNodes, spansByParent, Nil)
+    val maxDepth = bottomToTop.headOption.map(_.depth).getOrElse(0)
+    buildFromBottom(maxDepth, bottomToTop, spansByParent, Map.empty)
+  }
+
+  def render(tree: SpanNode): String = {
+    def loop(input: SpanNode, depth: Int): String = {
+      val prefix = " ".repeat(depth)
+      val next =
+        if (input.children.isEmpty) ""
+        else " =>\n" + input.children.map(loop(_, depth + 2)).mkString("\n")
+
+      s"$prefix${input.name} ${input.start.toNanos} -> ${input.end.toNanos}$next"
+    }
+
+    loop(tree, 0)
+  }
+
+  private case class EntryWithDepth(data: SpanData, depth: Int)
+
+  @annotation.tailrec
+  private def sortNodesByDepth(
+      depth: Int,
+      nodesInDepth: List[SpanData],
+      nodesByParent: Map[Option[String], List[SpanData]],
+      acc: List[EntryWithDepth]
+  ): List[EntryWithDepth] = {
+    val withDepth = nodesInDepth.map(n => EntryWithDepth(n, depth))
+    val calculated = withDepth ++ acc
+
+    val children =
+      nodesInDepth.flatMap(n => nodesByParent.getOrElse(Some(n.getSpanId), Nil))
+
+    children match {
+      case Nil =>
+        calculated
+
+      case _ =>
+        sortNodesByDepth(depth + 1, children, nodesByParent, calculated)
+    }
+  }
+
+  @annotation.tailrec
+  private def buildFromBottom(
+      depth: Int,
+      remaining: List[EntryWithDepth],
+      nodesByParent: Map[Option[String], List[SpanData]],
+      processedNodesById: Map[String, SpanNode]
+  ): List[SpanNode] = {
+    val (nodesOnCurrentDepth, rest) = remaining.span(_.depth == depth)
+    val newProcessedNodes = nodesOnCurrentDepth.map { n =>
+      val nodeId = n.data.getSpanId
+      val children = nodesByParent
+        .getOrElse(Some(nodeId), Nil)
+        .flatMap(c => processedNodesById.get(c.getSpanId))
+      val node = SpanNode(
+        n.data.getName,
+        n.data.getStartEpochNanos.nanos,
+        n.data.getEndEpochNanos.nanos,
+        children
+      )
+      nodeId -> node
+    }.toMap
+
+    if (depth > 0) {
+      buildFromBottom(
+        depth - 1,
+        rest,
+        nodesByParent,
+        processedNodesById ++ newProcessedNodes
+      )
+    } else {
+      // top nodes
+      newProcessedNodes.values.toList
+    }
+  }
+
+}

--- a/java/src/test/scala/org/typelevel/otel4s/java/trace/SpanNode.scala
+++ b/java/src/test/scala/org/typelevel/otel4s/java/trace/SpanNode.scala
@@ -42,7 +42,7 @@ object SpanNode {
 
   def render(tree: SpanNode): String = {
     def loop(input: SpanNode, depth: Int): String = {
-      val prefix = " ".repeat(depth)
+      val prefix = " " * depth
       val next =
         if (input.children.isEmpty) ""
         else " =>\n" + input.children.map(loop(_, depth + 2)).mkString("\n")

--- a/java/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -1,0 +1,204 @@
+package org.typelevel.otel4s.java.trace
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.syntax.functor._
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.testing.time.TestClock
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
+import io.opentelemetry.sdk.trace.SpanLimits
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.data.StatusData
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.AttributeKey
+
+import java.time.Instant
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.util.control.NoStackTrace
+
+class TracerSuite extends CatsEffectSuite {
+
+  test("propagate instrumentation info") {
+    val expected = InstrumentationScopeInfo.create(
+      "java.otel.tracer",
+      "1.0",
+      "https://localhost:8080"
+    )
+
+    for {
+      sdk <- makeSdk()
+      tracer <- sdk.provider
+        .tracer("java.otel.tracer")
+        .withVersion("1.0")
+        .withSchemaUrl("https://localhost:8080")
+        .get
+
+      _ <- tracer.span("span").use_
+
+      spans <- sdk.finishedSpans
+    } yield assertEquals(
+      spans.map(_.getInstrumentationScopeInfo),
+      List(expected)
+    )
+  }
+
+  test("propagate traceId and spanId") {
+    for {
+      sdk <- makeSdk()
+      tracer <- sdk.provider.tracer("java.otel.tracer").get
+      _ <- tracer.traceId.assertEquals(None)
+      _ <- tracer.spanId.assertEquals(None)
+      (span, span2) <- tracer.span("span").use { span =>
+        for {
+          _ <- tracer.traceId.assertEquals(Some(span.traceId))
+          _ <- tracer.spanId.assertEquals(Some(span.spanId))
+          span2 <- tracer.span("span-2").use { span2 =>
+            for {
+              _ <- tracer.traceId.assertEquals(Some(span2.traceId))
+              _ <- tracer.spanId.assertEquals(Some(span2.spanId))
+            } yield span2
+          }
+        } yield (span, span2)
+      }
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(span.traceId, span2.traceId)
+      assertEquals(spans.map(_.getTraceId), List(span2.traceId, span.traceId))
+      assertEquals(spans.map(_.getSpanId), List(span2.spanId, span.spanId))
+    }
+  }
+
+  test("propagate attributes") {
+    val attribute = Attribute(AttributeKey.string("string-attribute"), "value")
+
+    for {
+      sdk <- makeSdk()
+      tracer <- sdk.provider.tracer("java.otel.tracer").get
+      span <- tracer.span("span", attribute).use(IO.pure)
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(spans.map(_.getTraceId), List(span.traceId))
+      assertEquals(spans.map(_.getSpanId), List(span.spanId))
+    }
+  }
+
+  test("automatically start and stop span") {
+    val sleepDuration = 500.millis
+
+    TestControl.executeEmbed {
+      for {
+        sdk <- makeSdk()
+        tracer <- sdk.provider.tracer("java.otel.tracer").get
+        now <- IO.monotonic.delayBy(1.millis) // otherwise returns 0
+        _ <- tracer.span("span").surround(IO.sleep(sleepDuration))
+        spans <- sdk.finishedSpans
+      } yield {
+        assertEquals(spans.map(_.getStartEpochNanos), List(now.toNanos))
+        assertEquals(
+          spans.map(_.getEndEpochNanos),
+          List(now.plus(sleepDuration).toNanos)
+        )
+      }
+    }
+  }
+
+  test("set error status on abnormal termination (canceled)") {
+    for {
+      sdk <- makeSdk()
+      tracer <- sdk.provider.tracer("java.otel.tracer").get
+      fiber <- tracer.span("span").surround(IO.canceled).start
+      _ <- fiber.joinWith(IO.unit)
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(
+        spans.map(_.getStatus),
+        List(StatusData.create(StatusCode.ERROR, "canceled"))
+      )
+      assertEquals(spans.map(_.getEvents.isEmpty), List(true))
+    }
+  }
+
+  test("set error status on abnormal termination (exception)") {
+    val exception = new RuntimeException("error") with NoStackTrace
+
+    def expected(epoch: Long) =
+      ExceptionEventData.create(
+        SpanLimits.getDefault,
+        epoch,
+        exception,
+        Attributes.empty()
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        sdk <- makeSdk(
+          _.setClock(TestClock.create(Instant.ofEpochMilli(now.toMillis)))
+        )
+        tracer <- sdk.provider.tracer("java.otel.tracer").get
+        _ <- tracer.span("span").surround(IO.raiseError(exception)).attempt
+        spans <- sdk.finishedSpans
+      } yield {
+        assertEquals(spans.map(_.getStatus), List(StatusData.error()))
+        assertEquals(
+          spans.map(_.getEvents.asScala.toList),
+          List(List(expected(now.toNanos)))
+        )
+      }
+    }
+  }
+
+  test("create root span explicitly") {
+    for {
+      sdk <- makeSdk()
+      tracer <- sdk.provider.tracer("java.otel.tracer").get
+      (span, rootSpan) <- tracer.span("span").use { span =>
+        tracer.rootSpan("root-span").use(IO.pure).tupleRight(span)
+      }
+      spans <- sdk.finishedSpans
+    } yield {
+      assertNotEquals(rootSpan.spanId, span.spanId)
+      assertEquals(spans.map(_.getTraceId), List(span.traceId, rootSpan.traceId))
+      assertEquals(spans.map(_.getSpanId), List(span.spanId, rootSpan.spanId))
+    }
+  }
+
+  private def makeSdk(
+      customize: SdkTracerProviderBuilder => SdkTracerProviderBuilder = identity
+  ): IO[TracerSuite.Sdk] = {
+    val exporter = InMemorySpanExporter.create()
+
+    val builder = SdkTracerProvider
+      .builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+
+    val tracerProvider: SdkTracerProvider =
+      customize(builder).build()
+
+    for {
+      provider <- TraceProviderImpl.ioLocal[IO](tracerProvider)
+    } yield new TracerSuite.Sdk(provider, exporter)
+  }
+
+}
+
+object TracerSuite {
+
+  class Sdk(
+      val provider: TraceProviderImpl[IO],
+      exporter: InMemorySpanExporter
+  ) {
+
+    def finishedSpans: IO[List[SpanData]] =
+      IO.delay(exporter.getFinishedSpanItems.asScala.toList)
+
+  }
+}


### PR DESCRIPTION
This branch contains various experiments with OpenTelemetry tracing.

To simply the review process I made two different PRs:
1) Define API https://github.com/typelevel/otel4s/pull/36
2) Implementation https://github.com/typelevel/otel4s/pull/37

Currently, the state is stored in `IOLocal`. This approach has several drawbacks:
- https://github.com/typelevel/fs2/issues/2842
- https://github.com/typelevel/cats-effect/issues/3100


### The checklist from #11

- [x] Provide access to `spanId` and `traceId` from `Trace[F]` 
- [x] Allow creating a new root span from `Trace[F]`
- [x] Allow running an effect without tracing
- [x] Proper tracing of a `Resource`
- [ ] Ability to trace `fs2.Stream`
- [x] Memory pressure when `Trace` is not used
- [ ] Richer API