### PR TITLE
Add java-auto module and tracing example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p testkit/metrics/jvm/target java/metrics/target testkit/common/jvm/target core/trace/.js/target target core/common/.jvm/target java/trace/target .js/target core/metrics/.native/target core/all/.native/target site/target core/metrics/.jvm/target core/all/.js/target java/all/target java/common/target core/metrics/.js/target core/all/.jvm/target .jvm/target core/trace/.native/target .native/target core/trace/.jvm/target core/common/.native/target core/common/.js/target testkit/all/jvm/target project/target
+        run: mkdir -p testkit/metrics/jvm/target java/metrics/target testkit/common/jvm/target examples/target core/trace/.js/target target core/common/.jvm/target java/trace/target .js/target core/metrics/.native/target core/all/.native/target site/target core/metrics/.jvm/target core/all/.js/target java/all/target java/auto/target java/common/target core/metrics/.js/target core/all/.jvm/target .jvm/target core/trace/.native/target .native/target core/trace/.jvm/target core/common/.native/target core/common/.js/target testkit/all/jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar testkit/metrics/jvm/target java/metrics/target testkit/common/jvm/target core/trace/.js/target target core/common/.jvm/target java/trace/target .js/target core/metrics/.native/target core/all/.native/target site/target core/metrics/.jvm/target core/all/.js/target java/all/target java/common/target core/metrics/.js/target core/all/.jvm/target .jvm/target core/trace/.native/target .native/target core/trace/.jvm/target core/common/.native/target core/common/.js/target testkit/all/jvm/target project/target
+        run: tar cf targets.tar testkit/metrics/jvm/target java/metrics/target testkit/common/jvm/target examples/target core/trace/.js/target target core/common/.jvm/target java/trace/target .js/target core/metrics/.native/target core/all/.native/target site/target core/metrics/.jvm/target core/all/.js/target java/all/target java/auto/target java/common/target core/metrics/.js/target core/all/.jvm/target .jvm/target core/trace/.native/target .native/target core/trace/.jvm/target core/common/.native/target core/common/.js/target testkit/all/jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,9 @@ lazy val root = tlCrossRootProject
     `java-common`,
     `java-metrics`,
     `java-trace`,
-    java
+    java,
+    `java-auto`,
+    examples
   )
   .settings(name := "otel4s")
 
@@ -145,7 +147,8 @@ lazy val `java-common` = project
   .settings(
     name := "otel4s-java-common",
     libraryDependencies ++= Seq(
-      "io.opentelemetry" % "opentelemetry-api" % OpenTelemetryVersion
+      "org.typelevel" %%% "cats-effect-kernel" % CatsEffectVersion,
+      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion
     ),
     buildInfoPackage := "org.typelevel.otel4s.java",
     buildInfoOptions += sbtbuildinfo.BuildInfoOption.PackagePrivate,
@@ -161,7 +164,6 @@ lazy val `java-metrics` = project
   .settings(
     name := "otel4s-java-metrics",
     libraryDependencies ++= Seq(
-      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion % Test,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test
     )
   )
@@ -174,7 +176,6 @@ lazy val `java-trace` = project
     name := "otel4s-java-trace",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % CatsEffectVersion,
-      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion % Test,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % FS2Version % Test
@@ -186,6 +187,31 @@ lazy val java = project
   .dependsOn(core.jvm, `java-metrics`, `java-trace`)
   .settings(
     name := "otel4s-java"
+  )
+
+lazy val `java-auto` = project
+  .in(file("java/auto"))
+  .dependsOn(`java`)
+  .settings(munitDependencies)
+  .settings(
+    name := "otel4s-java-auto",
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${OpenTelemetryVersion}-alpha",
+    )
+  )
+
+lazy val examples = project
+  .enablePlugins(NoPublishPlugin)
+  .in(file("examples"))
+  .dependsOn(core.jvm, `java-auto`)
+  .settings(
+    name := "otel4s-examples",
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-exporter-otlp" % OpenTelemetryVersion,
+      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion,
+    ),
+    run / fork := true,
+    javaOptions += "-Dotel.java.global-autoconfigure.enabled=true",
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val `java-auto` = project
   .settings(
     name := "otel4s-java-auto",
     libraryDependencies ++= Seq(
-      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${OpenTelemetryVersion}-alpha",
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${OpenTelemetryVersion}-alpha"
     )
   )
 
@@ -208,10 +208,10 @@ lazy val examples = project
     name := "otel4s-examples",
     libraryDependencies ++= Seq(
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % OpenTelemetryVersion,
-      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion,
+      "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion
     ),
     run / fork := true,
-    javaOptions += "-Dotel.java.global-autoconfigure.enabled=true",
+    javaOptions += "-Dotel.java.global-autoconfigure.enabled=true"
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/examples/src/main/scala/TracingExample.scala
+++ b/examples/src/main/scala/TracingExample.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.MonadCancelThrow
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.syntax.all._
+import org.typelevel.otel4s.java.auto.OtelJavaAuto
+import org.typelevel.otel4s.trace.Tracer
+
+trait Work[F[_]] {
+  def doWork: F[Unit]
+}
+
+object Work {
+  def apply[F[_]: MonadCancelThrow: Tracer: Console]: Work[F] =
+    new Work[F] {
+      def doWork: F[Unit] =
+        Tracer[F].span("Work.DoWork").use { span =>
+          span.addEvent("Starting the work.") *>
+            doWorkInternal *>
+            span.addEvent("Finished working.")
+        }
+
+      def doWorkInternal =
+        Console[F].println("Doin' work")
+    }
+}
+
+object TracingExample extends IOApp.Simple {
+  def tracerResource: Resource[IO, Tracer[IO]] =
+    OtelJavaAuto.resource
+      .evalMap(_.tracerProvider.tracer("Example").get)
+
+  def run: IO[Unit] = {
+    tracerResource.use { implicit tracer: Tracer[IO] =>
+      Work[IO].doWork
+    }
+  }
+}

--- a/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
+++ b/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
@@ -29,7 +29,7 @@ object OtelJavaAuto {
 
   /** Creates an auto-configured [[org.typelevel.otel4s.Otel4s]] resource.
     *
-    * All SKD configuration options can be passed as Java system
+    * All SDK configuration options can be passed as Java system
     * properties, e.g., `-Dotel.traces.exporter=zipkin` or environment
     * variables, e.g., `OTEL_TRACES_EXPORTER=zipkin`. You can find
     * more details in the

--- a/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
+++ b/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
@@ -29,14 +29,12 @@ object OtelJavaAuto {
 
   /** Creates an auto-configured [[org.typelevel.otel4s.Otel4s]] resource.
     *
-    * All SDK configuration options can be passed as Java system
-    * properties, e.g., `-Dotel.traces.exporter=zipkin` or environment
-    * variables, e.g., `OTEL_TRACES_EXPORTER=zipkin`. You can find
-    * more details in the
-    * [[https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/
-    * OpenTelemetry Agent Configuration]] and
-    * [[https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
-    * Environment Variable Specification]]
+    * All SDK configuration options can be passed as Java system properties,
+    * e.g., `-Dotel.traces.exporter=zipkin` or environment variables, e.g.,
+    * `OTEL_TRACES_EXPORTER=zipkin`. You can find more details in the
+    * [[https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/ OpenTelemetry Agent Configuration]]
+    * and
+    * [[https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ Environment Variable Specification]]
     *
     * '''Note:''' `otel4s-java-auto` does not provide a specific OpenTelemetry
     * exporter.

--- a/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
+++ b/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
@@ -28,6 +28,24 @@ import org.typelevel.otel4s.java.OtelJava
 object OtelJavaAuto {
 
   /** Creates an auto-configured [[org.typelevel.otel4s.Otel4s]] resource.
+    *
+    * All SKD configuration options can be passed as Java system
+    * properties, e.g., `-Dotel.traces.exporter=zipkin` or environment
+    * variables, e.g., `OTEL_TRACES_EXPORTER=zipkin`. You can find
+    * more details in the
+    * [[https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/
+    * OpenTelemetry Agent Configuration]] and
+    * [[https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+    * Environment Variable Specification]]
+    *
+    * '''Note:''' `otel4s-java-auto` does not provide a specific OpenTelemetry
+    * exporter.
+    *
+    * You may include a dependency with a required exporter explicitly in your
+    * build.sbt:
+    * {{{
+    *   libraryDependencies += "io.opentelemetry" % "opentelemetry-exporter-otlp" % "x.y.z"
+    * }}}
     */
   def resource[F[_]: LiftIO: Async]: Resource[F, Otel4s[F]] =
     OtelJava.resource(

--- a/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
+++ b/java/auto/src/main/scala/org/typelevel/otel4s/java/auto/OtelJavaAuto.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.auto
+
+import cats.effect.Async
+import cats.effect.LiftIO
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+import org.typelevel.otel4s.Otel4s
+import org.typelevel.otel4s.java.OtelJava
+
+object OtelJavaAuto {
+
+  /** Creates an auto-configured [[org.typelevel.otel4s.Otel4s]] resource.
+    */
+  def resource[F[_]: LiftIO: Async]: Resource[F, Otel4s[F]] =
+    OtelJava.resource(
+      Sync[F]
+        .delay(
+          AutoConfiguredOpenTelemetrySdk.builder
+            .registerShutdownHook(false)
+            .setResultAsGlobal(false)
+            .build()
+        )
+        .map(_.getOpenTelemetrySdk)
+    )
+}

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
@@ -17,9 +17,12 @@
 package org.typelevel.otel4s
 package java
 
+import cats.effect.kernel.Async
+import cats.syntax.either._
 import io.opentelemetry.api.common.{AttributeKey => JAttributeKey}
 import io.opentelemetry.api.common.{AttributeType => JAttributeType}
 import io.opentelemetry.api.common.{Attributes => JAttributes}
+import io.opentelemetry.sdk.common.CompletableResultCode
 
 import scala.jdk.CollectionConverters._
 
@@ -71,4 +74,29 @@ private[java] object Conversions {
     builder.build()
   }
 
+  def asyncFromCompletableResultCode[F[_]](
+      codeF: F[CompletableResultCode],
+      msg: => Option[String] = None
+  )(implicit F: Async[F]): F[Unit] =
+    F.flatMap(codeF)(code =>
+      F.async[Unit](cb =>
+        F.delay {
+          code.whenComplete(() =>
+            if (code.isSuccess())
+              cb(Either.unit)
+            else
+              cb(
+                Left(
+                  new RuntimeException(
+                    msg.getOrElse(
+                      "OpenTelemetry SDK async operation failed"
+                    )
+                  )
+                )
+              )
+          )
+          None
+        }
+      )
+    )
 }


### PR DESCRIPTION
Proposes a new module based on the sdk-autoconfiguration.  This makes it much easier to get started and shuts everything down properly using Cats Effect.  This is an evolution of #90.