### PR TITLE
Conversions: use builder methods rather than creating an anonymous class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,8 @@ lazy val `java-common` = project
   .settings(
     name := "otel4s-java-common",
     libraryDependencies ++= Seq(
-      "io.opentelemetry" % "opentelemetry-api" % OpenTelemetryVersion
+      "io.opentelemetry" % "opentelemetry-api" % OpenTelemetryVersion,
+      "org.scalameta" %%% "munit" % MUnitVersion % Test
     ),
     buildInfoPackage := "org.typelevel.otel4s.java",
     buildInfoOptions += sbtbuildinfo.BuildInfoOption.PackagePrivate,

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/Conversions.scala
@@ -17,57 +17,34 @@
 package org.typelevel.otel4s
 package java
 
-import io.opentelemetry.api.common.{AttributeKey => JAttributeKey}
-import io.opentelemetry.api.common.{AttributeType => JAttributeType}
 import io.opentelemetry.api.common.{Attributes => JAttributes}
-
-import scala.jdk.CollectionConverters._
 
 private[java] object Conversions {
 
   def toJAttributes(attributes: Seq[Attribute[_]]): JAttributes = {
     val builder = JAttributes.builder
 
-    def put(name: String, jType: JAttributeType, value: Any): Unit = {
-      val jKey = new JAttributeKey[Any] {
-        def getKey: String = name
-        def getType: JAttributeType = jType
-        override def toString: String = name
-      }
-      builder.put[Any](jKey, value)
-      ()
-    }
-
-    def putList(name: String, jType: JAttributeType, values: Any): Unit = {
-      val jKey = new JAttributeKey[Any] {
-        def getKey: String = name
-        def getType: JAttributeType = jType
-        override def toString: String = name
-      }
-      builder.put[Any](jKey, values.asInstanceOf[Seq[Any]].asJava)
-      ()
-    }
-
     attributes.foreach { case Attribute(key, value) =>
       key.`type` match {
         case AttributeType.String =>
-          put(key.name, JAttributeType.STRING, value)
+          builder.put(key.name, value.asInstanceOf[String])
         case AttributeType.Boolean =>
-          put(key.name, JAttributeType.BOOLEAN, value)
+          builder.put(key.name, value.asInstanceOf[Boolean])
         case AttributeType.Long =>
-          put(key.name, JAttributeType.LONG, value)
+          builder.put(key.name, value.asInstanceOf[Long])
         case AttributeType.Double =>
-          put(key.name, JAttributeType.DOUBLE, value)
+          builder.put(key.name, value.asInstanceOf[Double])
         case AttributeType.StringList =>
-          putList(key.name, JAttributeType.STRING_ARRAY, value)
+          builder.put(key.name, value.asInstanceOf[List[String]]: _*)
         case AttributeType.BooleanList =>
-          putList(key.name, JAttributeType.BOOLEAN_ARRAY, value)
+          builder.put(key.name, value.asInstanceOf[List[Boolean]]: _*)
         case AttributeType.LongList =>
-          putList(key.name, JAttributeType.LONG_ARRAY, value)
+          builder.put(key.name, value.asInstanceOf[List[Long]]: _*)
         case AttributeType.DoubleList =>
-          putList(key.name, JAttributeType.DOUBLE_ARRAY, value)
+          builder.put(key.name, value.asInstanceOf[List[Double]]: _*)
       }
     }
+
     builder.build()
   }
 

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/ConversionsSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/ConversionsSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package java
+
+import io.opentelemetry.api.common.{Attributes => JAttributes}
+import munit.FunSuite
+
+class ConversionsSuite extends FunSuite {
+
+  test("proper conversion to OpenTelemetry Attributes") {
+    val attributes = List(
+      Attribute(AttributeKey.string("string"), "string"),
+      Attribute(AttributeKey.boolean("boolean"), false),
+      Attribute(AttributeKey.long("long"), 0L),
+      Attribute(AttributeKey.double("double"), 0.0),
+      Attribute(
+        AttributeKey.stringList("string"),
+        List("string 1", "string 2")
+      ),
+      Attribute(
+        AttributeKey.booleanList("boolean"),
+        List(false, true)
+      ),
+      Attribute(
+        AttributeKey.longList("long"),
+        List(Long.MinValue, Long.MaxValue)
+      ),
+      Attribute(
+        AttributeKey.doubleList("double"),
+        List(Double.MinValue, Double.MaxValue)
+      )
+    )
+
+    val expected = JAttributes
+      .builder()
+      .put("string", "string")
+      .put("boolean", false)
+      .put("long", 0L)
+      .put("double", 0.0)
+      .put("string", "string 1", "string 2")
+      .put("boolean", false, true)
+      .put("long", Long.MinValue, Long.MaxValue)
+      .put("double", Double.MinValue, Double.MaxValue)
+      .build()
+
+    assertEquals(Conversions.toJAttributes(attributes), expected)
+  }
+
+}

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -198,7 +198,6 @@ private[java] final case class SpanBuilderImpl[F[_]: Sync](
       .setParent(parent)
 
     kind.foreach(k => b.setSpanKind(toJSpanKind(k)))
-    b.setAllAttributes(Conversions.toJAttributes(attributes))
     startTimestamp.foreach(d => b.setStartTimestamp(d.length, d.unit))
     links.foreach { case (ctx, attributes) =>
       b.addLink(


### PR DESCRIPTION
An anonymous class has different hashing logic. Therefore, identical attribute keys were not equal. 