### PR TITLE
Add a way to get the current span

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -28,6 +28,11 @@ trait Tracer[F[_]] extends TracerMacro[F] {
     */
   def meta: Tracer.Meta[F]
 
+  /** Returns the span from the scope, falling back to a noop if none is
+    * available.
+    */
+  def currentSpan: F[Span[F]]
+
   /** Returns the context of a span when it is available in the scope.
     */
   def currentSpanContext: F[Option[SpanContext]]
@@ -137,6 +142,7 @@ object Tracer {
       private val builder = SpanBuilder.noop(noopBackend)
       private val resourceUnit = Resource.unit[F]
       val meta: Meta[F] = Meta.disabled
+      val currentSpan: F[Span[F]] = builder.startUnmanaged
       val currentSpanContext: F[Option[SpanContext]] = Applicative[F].pure(None)
       def rootScope: Resource[F, Unit] = resourceUnit
       def noopScope: Resource[F, Unit] = resourceUnit

--- a/examples/src/main/scala/TracingExample.scala
+++ b/examples/src/main/scala/TracingExample.scala
@@ -39,7 +39,13 @@ object Work {
         }
 
       def doWorkInternal =
-        Console[F].println("Doin' work")
+        Console[F].println("Doin' work") *>
+          summon
+
+      def summon =
+        Tracer[F].currentSpan.flatMap { span =>
+          span.addEvent("I've been summoned.")
+        }
     }
 }
 


### PR DESCRIPTION
I _think_ this is something we want.

* opentelemetry-java offers it in the form of `Span.current()`
* Natchez hides the span and flatMaps, but does similar through `Trace`

I don't know whether it's performant or correct, but I see it in my toy example.  If it's wanted, we can test and refine.