### PR TITLE
Tracing with local semantics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ ThisBuild / scalaVersion := Scala213 // the default Scala
 
 val CatsVersion = "2.9.0"
 val CatsEffectVersion = "3.4.5"
+val CatsMtlVersion = "1.3.0"
 val FS2Version = "3.5.0"
 val MUnitVersion = "1.0.0-M7"
 val MUnitCatsEffectVersion = "2.0.0-M3"
@@ -176,6 +177,7 @@ lazy val `java-trace` = project
     name := "otel4s-java-trace",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % CatsEffectVersion,
+      "org.typelevel" %%% "cats-mtl" % CatsMtlVersion,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % FS2Version % Test

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -17,8 +17,6 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.effect.kernel.Resource
-
 private[otel4s] trait TracerMacro[F[_]] {
   self: Tracer[F] =>
 
@@ -54,7 +52,7 @@ private[otel4s] trait TracerMacro[F[_]] {
     * @param attributes
     *   the set of attributes to associate with the span
     */
-  def span(name: String, attributes: Attribute[_]*): Resource[F, Span[F]] =
+  def span(name: String, attributes: Attribute[_]*): SpanBuilder[F] =
     macro TracerMacro.span
 
   /** Creates a new root span. Even if a parent span is available in the scope,
@@ -75,9 +73,10 @@ private[otel4s] trait TracerMacro[F[_]] {
   def rootSpan(
       name: String,
       attributes: Attribute[_]*
-  ): Resource[F, Span[F]] =
+  ): SpanBuilder[F] =
     macro TracerMacro.rootSpan
 
+  /*
   /** Creates a new child span. The span is automatically attached to a parent
     * span (based on the scope).
     *
@@ -104,7 +103,8 @@ private[otel4s] trait TracerMacro[F[_]] {
   def resourceSpan[A](name: String, attributes: Attribute[_]*)(
       resource: Resource[F, A]
   ): Resource[F, Span.Res[F, A]] =
-    macro TracerMacro.resourceSpan[F, A]
+     macro TracerMacro.resourceSpan[F, A]
+   */
 }
 
 object TracerMacro {
@@ -115,9 +115,7 @@ object TracerMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
-    val meta = q"${c.prefix}.meta"
-
-    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).addAttributes(..$attributes).start else $meta.noopSpan"
+    q"${c.prefix}.spanBuilder($name).addAttributes(..$attributes)"
   }
 
   def rootSpan(c: blackbox.Context)(
@@ -127,9 +125,10 @@ object TracerMacro {
     import c.universe._
     val meta = q"${c.prefix}.meta"
 
-    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.addAttributes(..$attributes).start else $meta.noopSpan"
+    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.addAttributes(..$attributes) else $meta.noopSpan"
   }
 
+  /*
   def resourceSpan[F[_], A](c: blackbox.Context)(
       name: c.Expr[String],
       attributes: c.Expr[Attribute[_]]*
@@ -139,5 +138,6 @@ object TracerMacro {
 
     q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).addAttributes(..$attributes).startResource($resource) else $meta.noopResSpan($resource)"
   }
+   */
 
 }

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -125,7 +125,7 @@ object TracerMacro {
     import c.universe._
     val meta = q"${c.prefix}.meta"
 
-    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.addAttributes(..$attributes) else $meta.noopSpan"
+    q"if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).addAttributes(..$attributes) else $meta.noopSpan"
   }
 
   /*

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -197,6 +197,8 @@ trait SpanBuilder[F[_]] {
    */
 
   def use[A](f: Span[F] => F[A]): F[A]
+
+  def surround[A](f: F[A]): F[A]
 }
 
 object SpanBuilder {
@@ -228,6 +230,9 @@ object SpanBuilder {
 
       def use[A](f: Span[F] => F[A]): F[A] =
         f(span)
+
+      def surround[A](fa: F[A]): F[A] =
+        fa
 
       /*
       val start: Resource[F, Span[F]] =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -18,7 +18,7 @@ package org.typelevel.otel4s
 package trace
 
 import cats.Applicative
-import cats.effect.kernel.Resource
+// import cats.effect.kernel.Resource
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -140,6 +140,7 @@ trait SpanBuilder[F[_]] {
     */
   def startUnmanaged: F[Span[F]]
 
+  /*
   /** Creates a [[Span]]. Unlike [[startUnmanaged]] the lifecycle of the span is
     * managed by the [[cats.effect.kernel.Resource Resource]]. That means the
     * span is started upon resource allocation and ended upon finalization.
@@ -193,6 +194,9 @@ trait SpanBuilder[F[_]] {
     *   the resource to trace
     */
   def startResource[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]]
+   */
+
+  def use[A](f: Span[F] => F[A]): F[A]
 }
 
 object SpanBuilder {
@@ -222,6 +226,10 @@ object SpanBuilder {
       val startUnmanaged: F[Span[F]] =
         Applicative[F].pure(span)
 
+      def use[A](f: Span[F] => F[A]): F[A] =
+        f(span)
+
+      /*
       val start: Resource[F, Span[F]] =
         Resource.pure(span)
 
@@ -229,6 +237,7 @@ object SpanBuilder {
           resource: Resource[F, A]
       ): Resource[F, Span.Res[F, A]] =
         resource.map(a => Span.Res.fromBackend(a, back))
+       */
     }
 
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -18,7 +18,6 @@ package org.typelevel.otel4s
 package trace
 
 import cats.Applicative
-import cats.effect.kernel.Resource
 import org.typelevel.otel4s.meta.InstrumentMeta
 
 trait Tracer[F[_]] extends TracerMacro[F] {
@@ -106,8 +105,8 @@ object Tracer {
   def apply[F[_]](implicit ev: Tracer[F]): Tracer[F] = ev
 
   trait Meta[F[_]] extends InstrumentMeta[F] {
-    def noopSpan: Resource[F, Span[F]]
-    def noopResSpan[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]]
+    def noopSpanBuilder: SpanBuilder[F]
+    // def noopResSpan[A](resource: Resource[F, A]): Resource[F, Span.Res[F, A]]
   }
 
   object Meta {
@@ -121,13 +120,15 @@ object Tracer {
 
         val isEnabled: Boolean = enabled
         val unit: F[Unit] = Applicative[F].unit
-        val noopSpan: Resource[F, Span[F]] =
-          Resource.pure(Span.fromBackend(noopBackend))
+        val noopSpanBuilder: SpanBuilder[F] =
+          SpanBuilder.noop(noopBackend)
 
+        /*
         def noopResSpan[A](
             resource: Resource[F, A]
         ): Resource[F, Span.Res[F, A]] =
-          resource.map(a => Span.Res.fromBackend(a, Span.Backend.noop))
+           resource.map(a => Span.Res.fromBackend(a, Span.Backend.noop))
+        */
       }
   }
 

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -56,7 +56,7 @@ trait Tracer[F[_]] extends TracerMacro[F] {
     * @param parent
     *   the span context to use as a parent
     */
-  def childScope(parent: SpanContext): Resource[F, Unit]
+  def childScope[A](parent: SpanContext)(fa: F[A]): F[A]
 
   /** Creates a new root tracing scope. The parent span will not be available
     * inside. Thus, a span created inside of the scope will be a root one.
@@ -78,7 +78,7 @@ trait Tracer[F[_]] extends TracerMacro[F] {
     * }
     *   }}}
     */
-  def rootScope: Resource[F, Unit]
+  def rootScope[A](fa: F[A]): F[A]
 
   /** Creates a no-op tracing scope. The tracing operations inside of the scope
     * are no-op.
@@ -97,7 +97,7 @@ trait Tracer[F[_]] extends TracerMacro[F] {
     * }
     *   }}}
     */
-  def noopScope: Resource[F, Unit]
+  def noopScope[A](fa: F[A]): F[A]
 
 }
 
@@ -135,12 +135,11 @@ object Tracer {
     new Tracer[F] {
       private val noopBackend = Span.Backend.noop
       private val builder = SpanBuilder.noop(noopBackend)
-      private val resourceUnit = Resource.unit[F]
       val meta: Meta[F] = Meta.disabled
       val currentSpanContext: F[Option[SpanContext]] = Applicative[F].pure(None)
-      def rootScope: Resource[F, Unit] = resourceUnit
-      def noopScope: Resource[F, Unit] = resourceUnit
-      def childScope(parent: SpanContext): Resource[F, Unit] = resourceUnit
+      def rootScope[A](fa: F[A]): F[A] = fa
+      def noopScope[A](fa: F[A]): F[A] = fa
+      def childScope[A](parent: SpanContext)(fa: F[A]): F[A] = fa
       def spanBuilder(name: String): SpanBuilder[F] = builder
     }
 }

--- a/examples/src/main/scala/TracingExample.scala
+++ b/examples/src/main/scala/TracingExample.scala
@@ -39,7 +39,9 @@ object Work {
         }
 
       def doWorkInternal =
-        Console[F].println("Doin' work")
+        Tracer[F].span("Work.InternalWork").use { _ =>
+          Console[F].println("Doin' work")
+        }
     }
 }
 

--- a/examples/src/main/scala/TracingExample.scala
+++ b/examples/src/main/scala/TracingExample.scala
@@ -39,9 +39,9 @@ object Work {
         }
 
       def doWorkInternal =
-        Tracer[F].span("Work.InternalWork").use { _ =>
+        Tracer[F].span("Work.InternalWork").surround(
           Console[F].println("Doin' work")
-        }
+        )
     }
 }
 

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -97,6 +97,9 @@ private[java] final case class SpanBuilderImpl[F[_]: Sync](
   def use[A](f: Span[F] => F[A]): F[A] =
     start.use { case (span, nt) => nt(f(span)) }
 
+  def surround[A](fa: F[A]): F[A] =
+    start.surround(fa)
+
   private def start: Resource[F, (Span[F], F ~> F)] =
     Resource.eval(parentContext).flatMap {
       case Some(parent) =>

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
@@ -16,8 +16,8 @@
 
 package org.typelevel.otel4s.java.trace
 
-import cats.effect.Resource
 import cats.effect.Sync
+import cats.syntax.flatMap._
 import cats.syntax.functor._
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.api.trace.{Tracer => JTracer}
@@ -45,12 +45,14 @@ private[java] class TracerImpl[F[_]: Sync](
   def spanBuilder(name: String): SpanBuilder[F] =
     new SpanBuilderImpl[F](jTracer, name, scope)
 
-  def childScope(parent: SpanContext): Resource[F, Unit] =
-    scope.makeScope(JSpan.wrap(WrappedSpanContext.unwrap(parent)))
+  def childScope[A](parent: SpanContext)(fa: F[A]): F[A] =
+    scope
+      .makeScope(JSpan.wrap(WrappedSpanContext.unwrap(parent)))
+      .flatMap(_(fa))
 
-  def rootScope: Resource[F, Unit] =
-    scope.rootScope
+  def rootScope[A](fa: F[A]): F[A] =
+    scope.rootScope.flatMap(_(fa))
 
-  def noopScope: Resource[F, Unit] =
-    scope.noopScope
+  def noopScope[A](fa: F[A]): F[A] =
+    scope.noopScope(fa)
 }


### PR DESCRIPTION
This reimagines `Tracer` with local semantics, which works around the issues with `IOLocal` and race (including stream interrupt scopes) corrupting the state.  All tracing methods need to be passed an effect, in which a specified span is scoped into the Tracer.

Fixes #85 and #88.  Supersedes #102.