### PR TITLE
Stateful tracing, revisted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,6 +196,7 @@ lazy val examples = project
   .settings(
     name := "otel4s-examples",
     libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % FS2Version,
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % OpenTelemetryVersion,
       "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion,
       "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${OpenTelemetryVersion}-alpha"

--- a/examples/src/main/scala/TracingExample.scala
+++ b/examples/src/main/scala/TracingExample.scala
@@ -25,8 +25,6 @@ import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.java.OtelJava
 import org.typelevel.otel4s.trace.Tracer
 
-import scala.concurrent.duration._
-
 trait Work[F[_]] {
   def doWork(i: Int): F[Unit]
 }

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
@@ -21,8 +21,7 @@ import cats.effect.LiftIO
 import cats.effect.Ref
 import cats.effect.Resource
 import cats.effect.Sync
-import cats.syntax.flatMap._
-import cats.syntax.functor._
+import cats.syntax.all._
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.context.{Context => JContext}
 import org.typelevel.otel4s.trace.SpanContext
@@ -84,12 +83,21 @@ private[java] object TraceScope {
           def noopScope: Resource[F, Unit] =
             createScope(Scope.Noop)
 
-          private def createScope(scope: Scope): Resource[F, Unit] =
-            Resource
-              .make(local.get.to[F].flatMap(_.getAndSet(scope)))(p =>
-                local.get.to[F].flatMap(_.set(p))
-              )
-              .void
+          private def createScope(scope: Scope): Resource[F, Unit] = {
+            val acquire =
+              local.get.to[F].product(Ref.of[F, Scope](scopeRoot)).flatTap {
+                case (_, nextRef) =>
+                  local.set(nextRef).to[F]
+              }
+            def release(oldRef: (Ref[F, Scope], Any)): F[Unit] =
+              local.set(oldRef._1).to[F]
+            Resource.make(acquire)(release) >>
+              Resource
+                .make(local.get.to[F].flatMap(_.getAndSet(scope)))(p =>
+                  local.get.to[F].flatMap(_.set(p))
+                )
+                .void
+          }
 
           private def nextScope(scope: Scope, span: JSpan): Scope =
             scope match {


### PR DESCRIPTION
Inspired by @djspiewak's [toot](https://social.rossabaker.com/@djspiewak@fosstodon.org/109797973016543255), here's `IOLocal[Ref[IO, Scope]]`.  This structure passes the following:

```scala
  statefulIO(0).flatMap {
    (stateful: cats.mtl.Stateful[IO, Int]) =>
      stateful.set(1).race(IO.never) >>
      stateful.get.flatMap(IO.println)
  }
```

In so doing, it puts @iRevive's original stateful design back on the table, at the expense of Kleisli et al.

Performance is probably hot trash, and there are probably dragons with `Resource#allocated` and releasing in an order abominable unto the acquisitions.  But it passes the interruptedScope test!