### PR TITLE
Move `SpanRunner` outside  `SpanBuilderImpl`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.1"
+ThisBuild / tlBaseVersion := "0.2"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 ThisBuild / tlBaseVersion := "0.1"
 
 ThisBuild / organization := "org.typelevel"
@@ -179,6 +181,26 @@ lazy val `java-trace` = project
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % FS2Version % Test
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$Runner"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$Runner$"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$TimestampSelect"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$TimestampSelect$"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$TimestampSelect$Delegate$"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.typelevel.otel4s.java.trace.SpanBuilderImpl$TimestampSelect$Explicit$"
+      )
     )
   )
 

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -75,6 +75,8 @@ trait Span[F[_]] extends SpanMacro[F] {
     *
     * Only the timing of the first end call for a given span will be recorded,
     * the subsequent calls will be ignored.
+    *
+    * The end timestamp is based on the `Clock[F].realTime`.
     */
   final def end: F[Unit] =
     backend.end

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -180,10 +180,7 @@ object SpanBuilder {
 
       def addAttributes(attributes: Attribute[_]*): Builder = this
 
-      def addLink(
-          spanContext: SpanContext,
-          attributes: Attribute[_]*
-      ): Builder = this
+      def addLink(ctx: SpanContext, attributes: Attribute[_]*): Builder = this
 
       def root: Builder = this
 
@@ -196,7 +193,7 @@ object SpanBuilder {
 
       def withStartTimestamp(timestamp: FiniteDuration): Builder = this
 
-      def build = new SpanOps[F] {
+      def build: SpanOps.Aux[F, Result] = new SpanOps[F] {
         type Result = Res
 
         def startUnmanaged(implicit ev: Result =:= Span[F]): F[Span[F]] =

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBackendImpl.scala
@@ -19,6 +19,7 @@ package java
 package trace
 
 import cats.effect.Sync
+import cats.syntax.flatMap._
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.api.trace.{StatusCode => JStatusCode}
 import org.typelevel.otel4s.Attribute
@@ -89,7 +90,7 @@ private[java] class SpanBackendImpl[F[_]: Sync](
     }
 
   private[otel4s] def end: F[Unit] =
-    Sync[F].delay(jSpan.end())
+    Sync[F].realTime.flatMap(now => end(now))
 
   private[otel4s] def end(timestamp: FiniteDuration): F[Unit] =
     Sync[F].delay(jSpan.end(timestamp.length, timestamp.unit))

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanRunner.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanRunner.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java
+package trace
+
+import cats.arrow.FunctionK
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.~>
+import io.opentelemetry.api.trace.{SpanBuilder => JSpanBuilder}
+import io.opentelemetry.api.trace.{Tracer => JTracer}
+import io.opentelemetry.context.{Context => JContext}
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.SpanFinalizer
+
+private[java] sealed trait SpanRunner[F[_], Res <: Span[F]] {
+  def start(ctx: Option[SpanRunner.RunnerContext]): Resource[F, (Res, F ~> F)]
+}
+
+private[java] object SpanRunner {
+
+  final case class RunnerContext(
+      builder: JSpanBuilder,
+      parent: JContext,
+      hasStartTimestamp: Boolean,
+      finalizationStrategy: SpanFinalizer.Strategy
+  )
+
+  def span[F[_]: Sync](scope: TraceScope[F]): SpanRunner[F, Span[F]] =
+    new SpanRunner[F, Span[F]] {
+      def start(ctx: Option[RunnerContext]): Resource[F, (Span[F], F ~> F)] = {
+        ctx match {
+          case Some(RunnerContext(builder, _, hasStartTs, finalization)) =>
+            startManaged(
+              builder = builder,
+              hasStartTimestamp = hasStartTs,
+              finalizationStrategy = finalization,
+              scope = scope
+            ).map { case (back, nt) => (Span.fromBackend(back), nt) }
+
+          case None =>
+            Resource.pure((Span.fromBackend(Span.Backend.noop), FunctionK.id))
+        }
+      }
+    }
+
+  def resource[F[_]: Sync, A](
+      scope: TraceScope[F],
+      resource: Resource[F, A],
+      jTracer: JTracer
+  ): SpanRunner[F, Span.Res[F, A]] =
+    new SpanRunner[F, Span.Res[F, A]] {
+      def start(
+          ctx: Option[RunnerContext]
+      ): Resource[F, (Span.Res[F, A], F ~> F)] =
+        ctx match {
+          case Some(RunnerContext(builder, parent, hasStartTimestamp, fin)) =>
+            def child(
+                name: String,
+                parent: JContext
+            ): Resource[F, (SpanBackendImpl[F], F ~> F)] =
+              startManaged(
+                builder = jTracer.spanBuilder(name).setParent(parent),
+                hasStartTimestamp = false,
+                finalizationStrategy = fin,
+                scope = scope
+              )
+
+            for {
+              rootBackend <- startManaged(
+                builder = builder,
+                hasStartTimestamp = hasStartTimestamp,
+                finalizationStrategy = fin,
+                scope = scope
+              )
+
+              rootCtx <- Resource.pure(parent.`with`(rootBackend._1.jSpan))
+
+              pair <- Resource.make(
+                child("acquire", rootCtx).use(b => b._2(resource.allocated))
+              ) { case (_, release) =>
+                child("release", rootCtx).use(b => b._2(release))
+              }
+              (value, _) = pair
+
+              pair2 <- child("use", rootCtx)
+              (useSpanBackend, nt) = pair2
+            } yield (Span.Res.fromBackend(value, useSpanBackend), nt)
+
+          case None =>
+            resource.map(a =>
+              (Span.Res.fromBackend(a, Span.Backend.noop), FunctionK.id)
+            )
+        }
+
+    }
+
+  def startUnmanaged[F[_]: Sync](context: Option[RunnerContext]): F[Span[F]] =
+    context match {
+      case Some(RunnerContext(builder, _, ts, _)) =>
+        for {
+          back <- SpanRunner.startSpan(builder, ts)
+        } yield Span.fromBackend(back)
+
+      case None =>
+        Sync[F].pure(Span.fromBackend(Span.Backend.noop))
+    }
+
+  private def startSpan[F[_]: Sync](
+      b: JSpanBuilder,
+      hasStartTimestamp: Boolean
+  ): F[SpanBackendImpl[F]] =
+    for {
+      builder <-
+        if (hasStartTimestamp) Sync[F].pure(b)
+        else Sync[F].realTime.map(t => b.setStartTimestamp(t.length, t.unit))
+      jSpan <- Sync[F].delay(builder.startSpan())
+    } yield new SpanBackendImpl(
+      jSpan,
+      WrappedSpanContext(jSpan.getSpanContext)
+    )
+
+  private def startManaged[F[_]: Sync](
+      builder: JSpanBuilder,
+      hasStartTimestamp: Boolean,
+      finalizationStrategy: SpanFinalizer.Strategy,
+      scope: TraceScope[F]
+  ): Resource[F, (SpanBackendImpl[F], F ~> F)] = {
+
+    def acquire: F[SpanBackendImpl[F]] =
+      startSpan(builder, hasStartTimestamp)
+
+    def release(backend: Span.Backend[F], ec: Resource.ExitCase): F[Unit] =
+      for {
+        _ <- finalizationStrategy
+          .lift(ec)
+          .foldMapM(SpanFinalizer.run(backend, _))
+        _ <- backend.end
+      } yield ()
+
+    for {
+      backend <- Resource.makeCase(acquire) { case (b, ec) => release(b, ec) }
+      nt <- Resource.eval(scope.makeScope(backend.jSpan))
+    } yield (backend, nt)
+  }
+
+}

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
@@ -31,7 +31,7 @@ private[java] class TracerImpl[F[_]: Sync](
     scope: TraceScope[F]
 ) extends Tracer[F] {
 
-  private val simple = SpanBuilderImpl.Runner.span
+  private val runner: SpanRunner[F, Span[F]] = SpanRunner.span(scope)
 
   val meta: Tracer.Meta[F] =
     Tracer.Meta.enabled
@@ -46,7 +46,7 @@ private[java] class TracerImpl[F[_]: Sync](
     }
 
   def spanBuilder(name: String): SpanBuilder.Aux[F, Span[F]] =
-    new SpanBuilderImpl[F, Span[F]](jTracer, name, scope, simple)
+    new SpanBuilderImpl[F, Span[F]](jTracer, name, scope, runner)
 
   def childScope[A](parent: SpanContext)(fa: F[A]): F[A] =
     scope

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -76,7 +76,7 @@ class TracerSuite extends CatsEffectSuite {
 
     for {
       sdk <- makeSdk()
-      tracer <- sdk.provider.tracer("tracer").get
+      tracer <- sdk.provider.get("tracer")
       _ <- tracer.span("span", attribute).use_
       spans <- sdk.finishedSpans
     } yield {
@@ -91,7 +91,7 @@ class TracerSuite extends CatsEffectSuite {
   test("propagate traceId and spanId") {
     for {
       sdk <- makeSdk()
-      tracer <- sdk.provider.tracer("tracer").get
+      tracer <- sdk.provider.get("tracer")
       _ <- tracer.currentSpanContext.assertEquals(None)
       result <- tracer.span("span").use { span =>
         for {
@@ -123,7 +123,7 @@ class TracerSuite extends CatsEffectSuite {
 
     for {
       sdk <- makeSdk()
-      tracer <- sdk.provider.tracer("tracer").get
+      tracer <- sdk.provider.get("tracer")
       span <- tracer.span("span", attribute).use(IO.pure)
       spans <- sdk.finishedSpans
     } yield {
@@ -138,7 +138,7 @@ class TracerSuite extends CatsEffectSuite {
     TestControl.executeEmbed {
       for {
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         now <- IO.monotonic.delayBy(1.millis) // otherwise returns 0
         _ <- tracer.span("span").surround(IO.sleep(sleepDuration))
         spans <- sdk.finishedSpans
@@ -155,7 +155,7 @@ class TracerSuite extends CatsEffectSuite {
   test("set error status on abnormal termination (canceled)") {
     for {
       sdk <- makeSdk()
-      tracer <- sdk.provider.tracer("tracer").get
+      tracer <- sdk.provider.get("tracer")
       fiber <- tracer.span("span").surround(IO.canceled).start
       _ <- fiber.joinWith(IO.unit)
       spans <- sdk.finishedSpans
@@ -185,7 +185,7 @@ class TracerSuite extends CatsEffectSuite {
         sdk <- makeSdk(
           _.setClock(TestClock.create(Instant.ofEpochMilli(now.toMillis)))
         )
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.span("span").surround(IO.raiseError(exception)).attempt
         spans <- sdk.finishedSpans
       } yield {
@@ -209,7 +209,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.span("span-1").use { span1 =>
           tracer.rootSpan("span-2").use { span2 =>
             for {
@@ -236,7 +236,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.currentSpanContext.assertEquals(None)
         _ <- tracer.span("span-1").use { span1 =>
           for {
@@ -268,7 +268,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.currentSpanContext.assertEquals(None)
         _ <- tracer.span("span-1").use { span =>
           for {
@@ -316,7 +316,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.currentSpanContext.assertEquals(None)
         _ <- tracer.span("span").use { span =>
           for {
@@ -362,7 +362,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.currentSpanContext.assertEquals(None)
         _ <- tracer.span("span").use { span =>
           for {
@@ -454,7 +454,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer
           .resourceSpan("resource-span", attribute)(mkRes(tracer))
           .use { _ =>
@@ -464,6 +464,63 @@ class TracerSuite extends CatsEffectSuite {
               _ <- tracer.span("body-3").surround(IO.sleep(50.millis))
             } yield ()
           }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  test("startUnmanaged: respect builder start time") {
+    val expected = SpanNode(
+      name = "span",
+      start = 100.millis,
+      end = 200.millis,
+      children = Nil
+    )
+
+    TestControl.executeEmbed {
+      for {
+        sdk <- makeSdk()
+        tracer <- sdk.provider.get("tracer")
+        span <- tracer
+          .spanBuilder("span")
+          .withStartTimestamp(100.millis)
+          .build
+          .startUnmanaged
+
+        // the sleep time should be ignored since the end timestamp is specified explicitly
+        _ <- IO.sleep(100.millis)
+
+        _ <- span.end(200.millis)
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected))
+    }
+  }
+
+  test(
+    "startUnmanaged: use Clock[F].realTime to set start and end if builder's time is undefined"
+  ) {
+    def expected(now: FiniteDuration) =
+      SpanNode(
+        name = "span",
+        start = now,
+        end = now.plus(100.millis),
+        children = Nil
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        sdk <- makeSdk()
+        tracer <- sdk.provider.get("tracer")
+        span <- tracer.spanBuilder("span").build.startUnmanaged
+
+        _ <- IO.sleep(100.millis)
+
+        _ <- span.end
         spans <- sdk.finishedSpans
         tree <- IO.pure(SpanNode.fromSpans(spans))
         // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
@@ -506,7 +563,7 @@ class TracerSuite extends CatsEffectSuite {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         sdk <- makeSdk()
-        tracer <- sdk.provider.tracer("tracer").get
+        tracer <- sdk.provider.get("tracer")
         _ <- tracer.currentSpanContext.assertEquals(None)
         _ <- flow(tracer).compile.drain
         _ <- tracer.currentSpanContext.assertEquals(None)


### PR DESCRIPTION
While cleaning up the internal implementation, I spotted a few inconsistencies regarding start/end time selections.

Before (main branch):

|                                          | start_timestamp     | end_timestamp       |
|------------------------------------------|---------------------|---------------------|
| `ops.use`. builder has start time            | builder_start       | `Clock[F].realTime` |
| `ops.use`                                    | `Clock[F].realTime` | `Clock[F].realTime` |
| `ops.startUnmanaged`. builder has start time | builder_start       | **j_span.end**          |
| `ops.startUnmanaged`                         | **j_span.start**        | **j_span.end**          |

After (this branch):

|                                          | start_timestamp     | end_timestamp       |
|------------------------------------------|---------------------|---------------------|
| `ops.use`. builder has start time            | builder_start       | `Clock[F].realTime` |
| `ops.use`                                    | `Clock[F].realTime` | `Clock[F].realTime` |
| `ops.startUnmanaged`. builder has start time | builder_start       | `Clock[F].realTime` |
| `ops.startUnmanaged`                         | `Clock[F].realTime` | `Clock[F].realTime` |

We can also introduce `TimestampStrategy` to allow choosing between `Clock[F].realTime` and `j_span.start / j_span.end`. 
It feels like overkill, but it may be helpful in applications when otel4s and some Java libs use the same OpenTelementry SDK.