### PR TITLE
Make Vault the top-level context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ val MUnitVersion = "1.0.0-M7"
 val MUnitCatsEffectVersion = "2.0.0-M3"
 val OpenTelemetryVersion = "1.22.0"
 val ScodecVersion = "1.1.34"
+val VaultVersion = "3.5.0"
 
 lazy val scalaReflectDependency = Def.settings(
   libraryDependencies ++= {
@@ -71,6 +72,7 @@ lazy val `core-common` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "otel4s-core-common",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % CatsVersion,
+      "org.typelevel" %%% "vault" % VaultVersion,
       "org.scalameta" %%% "munit" % MUnitVersion % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ ThisBuild / scalaVersion := Scala213 // the default Scala
 
 val CatsVersion = "2.9.0"
 val CatsEffectVersion = "3.4.5"
+val CatsMtlVersion = "1.3.0"
 val FS2Version = "3.5.0"
 val MUnitVersion = "1.0.0-M7"
 val MUnitCatsEffectVersion = "2.0.0-M3"
@@ -177,6 +178,7 @@ lazy val `java-trace` = project
     name := "otel4s-java-trace",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % CatsEffectVersion,
+      "org.typelevel" %%% "cats-mtl" % CatsMtlVersion,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % FS2Version % Test

--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ lazy val `java-common` = project
     name := "otel4s-java-common",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect-kernel" % CatsEffectVersion,
+      "org.typelevel" %%% "cats-mtl" % CatsMtlVersion,
       "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion,
       "org.scalameta" %%% "munit" % MUnitVersion % Test
     ),
@@ -181,7 +182,6 @@ lazy val `java-trace` = project
     name := "otel4s-java-trace",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % CatsEffectVersion,
-      "org.typelevel" %%% "cats-mtl" % CatsMtlVersion,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
       "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % FS2Version % Test

--- a/examples/src/main/scala/KleisliExample.scala
+++ b/examples/src/main/scala/KleisliExample.scala
@@ -29,7 +29,10 @@ object KleisliExample extends IOApp.Simple {
   def work[F[_]: Sync: Tracer] =
     Tracer[F].span("work").surround(Sync[F].delay(println("I'm working")))
 
-  def tracerResource[F[_]: Sync: Local[*[_], Scope]]: Resource[F, Tracer[F]] =
+  def tracerResource[F[_]](implicit
+      F: Sync[F],
+      L: Local[F, Scope]
+  ): Resource[F, Tracer[F]] =
     Resource
       .eval(Sync[F].delay(GlobalOpenTelemetry.get))
       .map(Traces.local[F])

--- a/examples/src/main/scala/KleisliExample.scala
+++ b/examples/src/main/scala/KleisliExample.scala
@@ -21,7 +21,7 @@ import cats.effect.Resource
 import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.GlobalOpenTelemetry
-import org.typelevel.otel4s.java.trace.Traces
+import org.typelevel.otel4s.java.OtelJava
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.vault.Vault
 
@@ -35,7 +35,7 @@ object KleisliExample extends IOApp.Simple {
   ): Resource[F, Tracer[F]] =
     Resource
       .eval(Sync[F].delay(GlobalOpenTelemetry.get))
-      .map(Traces.local[F])
+      .map(OtelJava.local[F])
       .evalMap(_.tracerProvider.get("kleisli-example"))
 
   def run: IO[Unit] =

--- a/examples/src/main/scala/KleisliExample.scala
+++ b/examples/src/main/scala/KleisliExample.scala
@@ -21,9 +21,9 @@ import cats.effect.Resource
 import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.GlobalOpenTelemetry
-import org.typelevel.otel4s.java.trace.Scope
 import org.typelevel.otel4s.java.trace.Traces
 import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.vault.Vault
 
 object KleisliExample extends IOApp.Simple {
   def work[F[_]: Sync: Tracer] =
@@ -31,7 +31,7 @@ object KleisliExample extends IOApp.Simple {
 
   def tracerResource[F[_]](implicit
       F: Sync[F],
-      L: Local[F, Scope]
+      L: Local[F, Vault]
   ): Resource[F, Tracer[F]] =
     Resource
       .eval(Sync[F].delay(GlobalOpenTelemetry.get))
@@ -39,9 +39,9 @@ object KleisliExample extends IOApp.Simple {
       .evalMap(_.tracerProvider.get("kleisli-example"))
 
   def run: IO[Unit] =
-    tracerResource[Kleisli[IO, Scope, *]]
-      .use { implicit tracer: Tracer[Kleisli[IO, Scope, *]] =>
-        work[Kleisli[IO, Scope, *]]
+    tracerResource[Kleisli[IO, Vault, *]]
+      .use { implicit tracer: Tracer[Kleisli[IO, Vault, *]] =>
+        work[Kleisli[IO, Vault, *]]
       }
-      .run(Scope.root)
+      .run(Vault.empty)
 }

--- a/examples/src/main/scala/KleisliExample.scala
+++ b/examples/src/main/scala/KleisliExample.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cats.data.Kleisli
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.mtl.Local
+import io.opentelemetry.api.GlobalOpenTelemetry
+import org.typelevel.otel4s.java.trace.Scope
+import org.typelevel.otel4s.java.trace.Traces
+import org.typelevel.otel4s.trace.Tracer
+
+object KleisliExample extends IOApp.Simple {
+  def work[F[_]: Sync: Tracer] =
+    Tracer[F].span("work").surround(Sync[F].delay(println("I'm working")))
+
+  def tracerResource[F[_]: Sync: Local[*[_], Scope]]: Resource[F, Tracer[F]] =
+    Resource
+      .eval(Sync[F].delay(GlobalOpenTelemetry.get))
+      .map(Traces.local[F])
+      .evalMap(_.tracerProvider.get("kleisli-example"))
+
+  def run: IO[Unit] =
+    tracerResource[Kleisli[IO, Scope, *]]
+      .use { implicit tracer: Tracer[Kleisli[IO, Scope, *]] =>
+        work[Kleisli[IO, Scope, *]]
+      }
+      .run(Scope.root)
+}

--- a/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
+++ b/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
@@ -17,20 +17,22 @@
 package org.typelevel.otel4s.java
 
 import cats.effect.Async
+import cats.effect.IOLocal
 import cats.effect.LiftIO
 import cats.effect.Resource
 import cats.effect.Sync
-import cats.syntax.flatMap._
-import cats.syntax.functor._
+import cats.mtl.Local
 import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 import io.opentelemetry.sdk.{OpenTelemetrySdk => JOpenTelemetrySdk}
 import io.opentelemetry.sdk.common.CompletableResultCode
 import org.typelevel.otel4s.Otel4s
 import org.typelevel.otel4s.java.Conversions.asyncFromCompletableResultCode
+import org.typelevel.otel4s.java.instances._
 import org.typelevel.otel4s.java.metrics.Metrics
 import org.typelevel.otel4s.java.trace.Traces
 import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.vault.Vault
 
 import scala.jdk.CollectionConverters._
 
@@ -46,11 +48,19 @@ object OtelJava {
     * @return
     *   An effect of an [[org.typelevel.otel4s.Otel4s]] resource.
     */
-  def forSync[F[_]: LiftIO: Sync](jOtel: JOpenTelemetry): F[Otel4s[F]] = {
-    for {
-      metrics <- Sync[F].pure(Metrics.forSync(jOtel))
-      traces <- Traces.ioLocal(jOtel)
-    } yield new Otel4s[F] {
+  def forSync[F[_]: LiftIO: Sync](jOtel: JOpenTelemetry): F[Otel4s[F]] =
+    IOLocal(Vault.empty)
+      .map { implicit ioLocal: IOLocal[Vault] =>
+        local[F](jOtel)
+      }
+      .to[F]
+
+  def local[F[_]](
+      jOtel: JOpenTelemetry
+  )(implicit F: Sync[F], L: Local[F, Vault]): Otel4s[F] = {
+    val metrics = Metrics.forSync(jOtel)
+    val traces = Traces.local(jOtel)
+    new Otel4s[F] {
       def meterProvider: MeterProvider[F] = metrics.meterProvider
       def tracerProvider: TracerProvider[F] = traces.tracerProvider
     }

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/instances.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/instances.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.java.trace
+package org.typelevel.otel4s.java
 
 import cats.Applicative
 import cats.Functor
@@ -23,7 +23,7 @@ import cats.effect.LiftIO
 import cats.effect.MonadCancelThrow
 import cats.mtl.Local
 
-private[trace] object instances {
+private[java] object instances {
   // We hope this instance is moved into Cats Effect.
   implicit def localForIoLocal[F[_]: MonadCancelThrow: LiftIO, E](implicit
       ioLocal: IOLocal[E]

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
@@ -16,8 +16,8 @@
 
 package org.typelevel.otel4s.java.trace
 
-import io.opentelemetry.context.{Context => JContext}
 import io.opentelemetry.api.trace.{Span => JSpan}
+import io.opentelemetry.context.{Context => JContext}
 import org.typelevel.otel4s.trace.SpanContext
 
 sealed trait Scope

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
@@ -1,0 +1,19 @@
+package org.typelevel.otel4s.java.trace
+
+import io.opentelemetry.context.{Context => JContext}
+import io.opentelemetry.api.trace.{Span => JSpan}
+import org.typelevel.otel4s.trace.SpanContext
+
+sealed trait Scope
+
+object Scope {
+  val root: Scope = Root(JContext.root)
+
+  private[trace] final case class Root(ctx: JContext) extends Scope
+  private[trace] final case class Span(
+      ctx: JContext,
+      span: JSpan,
+      spanContext: SpanContext
+  ) extends Scope
+  private[trace] case object Noop extends Scope
+}

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.otel4s.java.trace
 
 import io.opentelemetry.context.{Context => JContext}

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Scope.scala
@@ -19,9 +19,9 @@ package org.typelevel.otel4s.java.trace
 import cats.effect.SyncIO
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.context.{Context => JContext}
+import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.vault.Key
 import org.typelevel.vault.Vault
-import org.typelevel.otel4s.trace.SpanContext
 
 private[trace] sealed trait Scope {
   def storeInContext(context: Vault): Vault =

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -161,29 +161,29 @@ private[java] final case class SpanBuilderImpl[F[_]: Sync, Res <: Span[F]](
     parent match {
       case Parent.Root =>
         scope.current.flatMap {
-          case TraceScope.Scope.Root(ctx) =>
+          case Scope.Root(ctx) =>
             Sync[F].pure(Some(ctx))
 
-          case TraceScope.Scope.Span(_, _, _) =>
+          case Scope.Span(_, _, _) =>
             scope.root.map(s => Some(s.ctx))
 
-          case TraceScope.Scope.Noop =>
+          case Scope.Noop =>
             Sync[F].pure(None)
         }
 
       case Parent.Propagate =>
         scope.current.map {
-          case TraceScope.Scope.Root(ctx)       => Some(ctx)
-          case TraceScope.Scope.Span(ctx, _, _) => Some(ctx)
-          case TraceScope.Scope.Noop            => None
+          case Scope.Root(ctx)       => Some(ctx)
+          case Scope.Span(ctx, _, _) => Some(ctx)
+          case Scope.Noop            => None
         }
 
       case Parent.Explicit(parent) =>
         def parentSpan = JSpan.wrap(WrappedSpanContext.unwrap(parent))
         scope.current.map {
-          case TraceScope.Scope.Root(ctx)       => Some(ctx.`with`(parentSpan))
-          case TraceScope.Scope.Span(ctx, _, _) => Some(ctx.`with`(parentSpan))
-          case TraceScope.Scope.Noop            => None
+          case Scope.Root(ctx)       => Some(ctx.`with`(parentSpan))
+          case Scope.Span(ctx, _, _) => Some(ctx.`with`(parentSpan))
+          case Scope.Noop            => None
         }
     }
 }

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
@@ -109,7 +109,7 @@ private[java] object TraceScope {
 
   private implicit def localForIoLocal[F[_]: MonadCancelThrow: LiftIO, E](
       implicit ioLocal: IOLocal[E]
-  ) =
+  ): Local[F, E] =
     new Local[F, E] {
       def applicative =
         Applicative[F]

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
@@ -20,10 +20,8 @@ import cats.mtl.Local
 import cats.~>
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.context.{Context => JContext}
-import org.typelevel.otel4s.trace.SpanContext
 
 private[java] trait TraceScope[F[_]] {
-  import TraceScope.Scope
   def root: F[Scope.Root]
   def current: F[Scope]
   def makeScope(span: JSpan): F[F ~> F]
@@ -32,17 +30,6 @@ private[java] trait TraceScope[F[_]] {
 }
 
 private[java] object TraceScope {
-
-  sealed trait Scope
-  object Scope {
-    final case class Root(ctx: JContext) extends Scope
-    final case class Span(
-        ctx: JContext,
-        span: JSpan,
-        spanContext: SpanContext
-    ) extends Scope
-    case object Noop extends Scope
-  }
 
   def fromLocal[F[_]](
       default: JContext

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TraceScope.scala
@@ -16,14 +16,10 @@
 
 package org.typelevel.otel4s.java.trace
 
-import cats.effect.IOLocal
-import cats.effect.LiftIO
-import cats.effect.MonadCancelThrow
 import cats.mtl.Local
 import cats.~>
 import io.opentelemetry.api.trace.{Span => JSpan}
 import io.opentelemetry.context.{Context => JContext}
-import org.typelevel.otel4s.java.trace.instances._
 import org.typelevel.otel4s.trace.SpanContext
 
 private[java] trait TraceScope[F[_]] {
@@ -104,14 +100,5 @@ private[java] object TraceScope {
             Scope.Noop
         }
     }
-  }
-
-  def fromIOLocal[F[_]: MonadCancelThrow: LiftIO](
-      default: JContext
-  ): F[TraceScope[F]] = {
-    val scopeRoot = Scope.Root(default)
-    IOLocal[Scope](scopeRoot)
-      .map(implicit ioLocal => fromLocal[F](default))
-      .to[F]
   }
 }

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerImpl.scala
@@ -38,7 +38,7 @@ private[java] class TracerImpl[F[_]: Sync](
 
   def currentSpanContext: F[Option[SpanContext]] =
     scope.current.map {
-      case TraceScope.Scope.Span(_, _, spanCtx) if spanCtx.isValid =>
+      case Scope.Span(_, _, spanCtx) if spanCtx.isValid =>
         Some(spanCtx)
 
       case _ =>

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -19,9 +19,9 @@ package org.typelevel.otel4s.java.trace
 import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
-import io.opentelemetry.context.{Context => JContext}
 import org.typelevel.otel4s.trace.TracerBuilder
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.vault.Vault
 
 private[java] class TracerProviderImpl[F[_]: Sync](
     jTracerProvider: JTracerProvider,
@@ -34,10 +34,9 @@ private[java] class TracerProviderImpl[F[_]: Sync](
 private[java] object TracerProviderImpl {
 
   def local[F[_]](
-      jTracerProvider: JTracerProvider,
-      default: JContext = JContext.root()
-  )(implicit F: Sync[F], L: Local[F, Scope]): TracerProvider[F] = {
-    val traceScope = TraceScope.fromLocal[F](default)
+      jTracerProvider: JTracerProvider
+  )(implicit F: Sync[F], L: Local[F, Vault]): TracerProvider[F] = {
+    val traceScope = TraceScope.fromLocal[F]
     new TracerProviderImpl(jTracerProvider, traceScope)
   }
 

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -33,7 +33,7 @@ private[java] class TracerProviderImpl[F[_]: Sync](
 
 private[java] object TracerProviderImpl {
 
-  def local[F[_]: Sync: Local[*[_], TraceScope.Scope]](
+  def local[F[_]: Sync: Local[*[_], Scope]](
       jTracerProvider: JTracerProvider,
       default: JContext = JContext.root()
   ): TracerProvider[F] = {

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -33,10 +33,10 @@ private[java] class TracerProviderImpl[F[_]: Sync](
 
 private[java] object TracerProviderImpl {
 
-  def local[F[_]: Sync: Local[*[_], Scope]](
+  def local[F[_]](
       jTracerProvider: JTracerProvider,
       default: JContext = JContext.root()
-  ): TracerProvider[F] = {
+  )(implicit F: Sync[F], L: Local[F, Scope]): TracerProvider[F] = {
     val traceScope = TraceScope.fromLocal[F](default)
     new TracerProviderImpl(jTracerProvider, traceScope)
   }

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
@@ -21,7 +21,7 @@ import cats.effect.LiftIO
 import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
-import org.typelevel.otel4s.java.trace.instances._
+import org.typelevel.otel4s.java.instances._
 import org.typelevel.otel4s.trace.TracerProvider
 import org.typelevel.vault.Vault
 

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
@@ -23,6 +23,7 @@ import cats.mtl.Local
 import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 import org.typelevel.otel4s.java.trace.instances._
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.vault.Vault
 
 trait Traces[F[_]] {
   def tracerProvider: TracerProvider[F]
@@ -32,7 +33,7 @@ object Traces {
 
   def local[F[_]](
       jOtel: JOpenTelemetry
-  )(implicit F: Sync[F], L: Local[F, Scope]): Traces[F] = {
+  )(implicit F: Sync[F], L: Local[F, Vault]): Traces[F] = {
     val provider = TracerProviderImpl.local(jOtel.getTracerProvider)
     new Traces[F] {
       def tracerProvider: TracerProvider[F] = provider
@@ -40,8 +41,8 @@ object Traces {
   }
 
   def ioLocal[F[_]: LiftIO: Sync](jOtel: JOpenTelemetry): F[Traces[F]] =
-    IOLocal(Scope.root)
-      .map { implicit ioLocal: IOLocal[Scope] =>
+    IOLocal(Vault.empty)
+      .map { implicit ioLocal: IOLocal[Vault] =>
         local(jOtel)
       }
       .to[F]

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/Traces.scala
@@ -30,9 +30,9 @@ trait Traces[F[_]] {
 
 object Traces {
 
-  def local[F[_]: Sync: Local[*[_], Scope]](
+  def local[F[_]](
       jOtel: JOpenTelemetry
-  ): Traces[F] = {
+  )(implicit F: Sync[F], L: Local[F, Scope]): Traces[F] = {
     val provider = TracerProviderImpl.local(jOtel.getTracerProvider)
     new Traces[F] {
       def tracerProvider: TracerProvider[F] = provider

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/instances.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/instances.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.java.trace
+
+import cats.Applicative
+import cats.Functor
+import cats.effect.IOLocal
+import cats.effect.LiftIO
+import cats.effect.MonadCancelThrow
+import cats.mtl.Local
+
+private[trace] object instances {
+  // We hope this instance is moved into Cats Effect.
+  implicit def localForIoLocal[F[_]: MonadCancelThrow: LiftIO, E](implicit
+      ioLocal: IOLocal[E]
+  ): Local[F, E] =
+    new Local[F, E] {
+      def applicative =
+        Applicative[F]
+      def ask[E2 >: E] =
+        Functor[F].widen[E, E2](ioLocal.get.to[F])
+      def local[A](fa: F[A])(f: E => E): F[A] =
+        MonadCancelThrow[F].bracket(ioLocal.modify(e => (f(e), e)).to[F])(_ =>
+          fa
+        )(ioLocal.set(_).to[F])
+    }
+}

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -23,7 +23,6 @@ import cats.effect.testkit.TestControl
 import io.opentelemetry.api.common.{AttributeKey => JAttributeKey}
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.context.{Context => JContext}
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.testing.time.TestClock
@@ -538,10 +537,9 @@ class TracerSuite extends CatsEffectSuite {
     val tracerProvider: SdkTracerProvider =
       customize(builder).build()
 
-    IOLocal[TraceScope.Scope](TraceScope.Scope.Root(JContext.root)).map {
-      implicit ioLocal =>
-        val provider = TracerProviderImpl.local[IO](tracerProvider)
-        new TracerSuite.Sdk(provider, exporter)
+    IOLocal(Scope.root).map { implicit ioLocal =>
+      val provider = TracerProviderImpl.local[IO](tracerProvider)
+      new TracerSuite.Sdk(provider, exporter)
     }
   }
 

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -39,6 +39,7 @@ import org.typelevel.otel4s.java.trace.instances._
 import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.vault.Vault
 
 import java.time.Instant
 import scala.concurrent.duration._
@@ -594,7 +595,7 @@ class TracerSuite extends CatsEffectSuite {
     val tracerProvider: SdkTracerProvider =
       customize(builder).build()
 
-    IOLocal(Scope.root).map { implicit ioLocal =>
+    IOLocal(Vault.empty).map { implicit ioLocal: IOLocal[Vault] =>
       val provider = TracerProviderImpl.local[IO](tracerProvider)
       new TracerSuite.Sdk(provider, exporter)
     }

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -35,7 +35,7 @@ import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData
 import munit.CatsEffectSuite
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.java.trace.instances._
+import org.typelevel.otel4s.java.instances._
 import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider


### PR DESCRIPTION
Extends #119, but is more experimental.

Instead of exposing `Scope`, this pivots back toward the Otel spec of having a well-known "context" object.  We choose Typelevel Vault.  The operation names aren't quite right (`lookup` vs. `get`, `insert` vs. `set`), but it has the correct properties:

* immutable
* typed, unique keys

As alluded to on other PRs, the Vault gets messy if we ever need a key with a type parameter, but maybe we can avoid that!