### PR TITLE
Fix resourceSpan surround

### DIFF
--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -116,7 +116,7 @@ private[java] final case class SpanBuilderImpl[F[_]: Sync, Res <: Span[F]](
       start.use_
 
     def surround[A](fa: F[A]): F[A] =
-      start.surround(fa)
+      use(_ => fa)
   }
 
   /*  private def start: Resource[F, (Span[F], F ~> F)] =

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/TracerSuite.scala
@@ -388,7 +388,7 @@ class TracerSuite extends CatsEffectSuite {
     }
   }
 
-  test("trace resource") {
+  test("trace resource with use") {
     val attribute = Attribute("string-attribute", "value")
 
     val acquireInnerDuration = 25.millis
@@ -467,6 +467,64 @@ class TracerSuite extends CatsEffectSuite {
         spans <- sdk.finishedSpans
         tree <- IO.pure(SpanNode.fromSpans(spans))
         // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  test("trace resource with surround") {
+    val acquireDuration = 25.millis
+    val bodyDuration = 100.millis
+    val releaseDuration = 300.millis
+
+    def mkRes: Resource[IO, Unit] =
+      Resource.make(IO.sleep(acquireDuration))(_ => IO.sleep(releaseDuration))
+
+    def expected(start: FiniteDuration) = {
+      val acquireEnd = start + acquireDuration
+      val (bodyStart, bodyEnd) = (acquireEnd, acquireEnd + bodyDuration)
+      val end = bodyEnd + releaseDuration
+
+      SpanNode(
+        "resource-span",
+        start,
+        end,
+        List(
+          SpanNode(
+            "acquire",
+            start,
+            acquireEnd,
+            Nil
+          ),
+          SpanNode(
+            "use",
+            bodyStart,
+            bodyEnd,
+            List(
+              SpanNode("body", bodyStart, bodyEnd, Nil)
+            )
+          ),
+          SpanNode(
+            "release",
+            bodyEnd,
+            end,
+            Nil
+          )
+        )
+      )
+    }
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        sdk <- makeSdk()
+        tracer <- sdk.provider.tracer("tracer").get
+        _ <- tracer
+          .resourceSpan("resource-span")(mkRes)
+          .surround(
+            tracer.span("body").surround(IO.sleep(100.millis))
+          )
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
       } yield assertEquals(tree, List(expected(now)))
     }
   }


### PR DESCRIPTION
Makes `resourceSpan.surround` and `resourceSpan.use_` consistent with `resourceSpan.use`.

Fixes #126.