### PR TITLE
Revert to opentelemetry-java-1.22.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val CatsMtlVersion = "1.3.0"
 val FS2Version = "3.6.1"
 val MUnitVersion = "1.0.0-M7"
 val MUnitCatsEffectVersion = "2.0.0-M3"
-val OpenTelemetryVersion = "1.23.0"
+val OpenTelemetryVersion = "1.22.0"
 val ScodecVersion = "1.1.34"
 val VaultVersion = "3.5.0"
 

--- a/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
+++ b/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
@@ -24,6 +24,7 @@ import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 import io.opentelemetry.sdk.{OpenTelemetrySdk => JOpenTelemetrySdk}
+import io.opentelemetry.sdk.common.CompletableResultCode
 import org.typelevel.otel4s.Otel4s
 import org.typelevel.otel4s.java.Conversions.asyncFromCompletableResultCode
 import org.typelevel.otel4s.java.instances._
@@ -32,6 +33,8 @@ import org.typelevel.otel4s.java.trace.Traces
 import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.trace.TracerProvider
 import org.typelevel.vault.Vault
+
+import scala.jdk.CollectionConverters._
 
 object OtelJava {
 
@@ -76,7 +79,19 @@ object OtelJava {
   ): Resource[F, Otel4s[F]] =
     Resource
       .make(acquire)(sdk =>
-        asyncFromCompletableResultCode(Sync[F].delay(sdk.shutdown()))
+        asyncFromCompletableResultCode(
+          Sync[F].delay(
+            // The answer could have been traverse...
+            // A proper shutdown will be in the next opentelemetry-java release.
+            CompletableResultCode.ofAll(
+              List(
+                sdk.getSdkTracerProvider.shutdown(),
+                sdk.getSdkMeterProvider.shutdown(),
+                sdk.getSdkLoggerProvider.shutdown()
+              ).asJava
+            )
+          )
+        )
       )
       .evalMap(forSync[F])
 }


### PR DESCRIPTION
Temporary downgrade until we get a handle on #139.  We'll roll forward when it's fixed or when we understand what we're doing wrong.