### PR TITLE
Add alternative way of constructing observable instruments

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.metrics
+
+import org.typelevel.otel4s.Attribute
+
+/** @param value
+  *   the value to record
+  *
+  * @param attributes
+  *   the set of attributes to associate with the value
+  */
+final case class Measurement[A](value: A, attributes: Attribute[_]*)

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
@@ -24,4 +24,4 @@ import org.typelevel.otel4s.Attribute
   * @param attributes
   *   the set of attributes to associate with the value
   */
-final case class Measurement[A](value: A, attributes: Attribute[_]*)
+final case class Measurement[A](value: A, attributes: List[Attribute[_]])

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
@@ -115,6 +115,10 @@ object Meter {
 
           def withUnit(unit: String): Self = this
           def withDescription(description: String): Self = this
+          def create(
+              measurements: F[List[Measurement[Double]]]
+          ): Resource[F, ObservableGauge] =
+            Resource.pure(new ObservableGauge {})
           def createWithCallback(
               cb: ObservableMeasurement[F, Double] => F[Unit]
           ): Resource[F, ObservableGauge] =
@@ -129,6 +133,10 @@ object Meter {
 
           def withUnit(unit: String): Self = this
           def withDescription(description: String): Self = this
+          def create(
+              measurements: F[List[Measurement[Long]]]
+          ): Resource[F, ObservableCounter] =
+            Resource.pure(new ObservableCounter {})
           def createWithCallback(
               cb: ObservableMeasurement[F, Long] => F[Unit]
           ): Resource[F, ObservableCounter] =
@@ -143,6 +151,10 @@ object Meter {
 
           def withUnit(unit: String): Self = this
           def withDescription(description: String): Self = this
+          def create(
+              measurements: F[List[Measurement[Long]]]
+          ): Resource[F, ObservableUpDownCounter] =
+            Resource.pure(new ObservableUpDownCounter {})
           def createWithCallback(
               cb: ObservableMeasurement[F, Long] => F[Unit]
           ): Resource[F, ObservableUpDownCounter] =

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
@@ -16,9 +16,7 @@
 
 package org.typelevel.otel4s.metrics
 
-import cats.Monad
 import cats.effect.Resource
-import cats.syntax.all._
 
 trait ObservableInstrumentBuilder[F[_], A, Instrument] {
   type Self <: ObservableInstrumentBuilder[F, A, Instrument]
@@ -78,12 +76,5 @@ trait ObservableInstrumentBuilder[F[_], A, Instrument] {
     * @param measurements
     *   Effect that produces a number of measurements
     */
-  def create(measurements: F[List[Measurement[A]]])(implicit
-      F: Monad[F]
-  ): Resource[F, Instrument] =
-    createWithCallback(cb =>
-      measurements.flatMap(
-        _.traverse_(m => cb.record(m.value, m.attributes: _*))
-      )
-    )
+  def create(measurements: F[List[Measurement[A]]]): Resource[F, Instrument]
 }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
@@ -64,8 +64,16 @@ trait ObservableInstrumentBuilder[F[_], A, Instrument] {
       cb: ObservableMeasurement[F, A] => F[Unit]
   ): Resource[F, Instrument]
 
-  /** Creates an asynchronous instrument that an effect that produces a number
-    * of measurements
+  /** Creates an asynchronous instrument based on an effect that produces a
+    * number of measurements.
+    *
+    * The measurement effect will be evaluted when the instrument is being
+    * observed.
+    *
+    * The measurement effect is expected to abide by the following restrictions:
+    *   - Short-living and (ideally) non-blocking
+    *   - Run in a finite amount of time
+    *   - Safe to call repeatedly, across multiple threads
     *
     * @param measurements
     *   Effect that produces a number of measurements

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
@@ -56,8 +56,8 @@ class ObservableSuite extends CatsEffectSuite {
             .getAndUpdate(_ + 1)
             .map(x =>
               List(
-                Measurement(x, Attribute("thing", "a")),
-                Measurement(x, Attribute("thing", "b"))
+                Measurement(x, List(Attribute("thing", "a"))),
+                Measurement(x, List(Attribute("thing", "b")))
               )
             )
         )

--- a/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableGaugeBuilderImpl.scala
+++ b/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableGaugeBuilderImpl.scala
@@ -23,6 +23,7 @@ import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import io.opentelemetry.api.metrics.{Meter => JMeter}
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement
 import org.typelevel.otel4s.metrics._
 
 private[java] case class ObservableGaugeBuilderImpl[F[_]](
@@ -39,8 +40,8 @@ private[java] case class ObservableGaugeBuilderImpl[F[_]](
   def withDescription(description: String): Self =
     copy(description = Option(description))
 
-  def createWithCallback(
-      cb: ObservableMeasurement[F, Double] => F[Unit]
+  private def createInternal(
+      cb: ObservableDoubleMeasurement => F[Unit]
   ): Resource[F, ObservableGauge] =
     Dispatcher.sequential.flatMap(dispatcher =>
       Resource
@@ -48,36 +49,29 @@ private[java] case class ObservableGaugeBuilderImpl[F[_]](
           val b = jMeter.gaugeBuilder(name)
           unit.foreach(b.setUnit)
           description.foreach(b.setDescription)
-          b.buildWithCallback { gauge =>
-            dispatcher.unsafeRunSync(cb(new ObservableDoubleImpl(gauge)))
+          b.buildWithCallback { odm =>
+            dispatcher.unsafeRunSync(cb(odm))
           }
-
         })
         .as(new ObservableGauge {})
     )
+
+  def createWithCallback(
+      cb: ObservableMeasurement[F, Double] => F[Unit]
+  ): Resource[F, ObservableGauge] =
+    createInternal(odm => cb(new ObservableDoubleImpl(odm)))
+
   def create(
       measurements: F[List[Measurement[Double]]]
   ): Resource[F, ObservableGauge] =
-    Dispatcher.sequential.flatMap(dispatcher =>
-      Resource
-        .fromAutoCloseable(F.delay {
-          val b = jMeter.gaugeBuilder(name)
-          unit.foreach(b.setUnit)
-          description.foreach(b.setDescription)
-          b.buildWithCallback { gauge =>
-            dispatcher.unsafeRunSync(
-              measurements.flatMap(ms =>
-                F.delay(
-                  ms.foreach(m =>
-                    gauge
-                      .record(m.value, Conversions.toJAttributes(m.attributes))
-                  )
-                )
-              )
-            )
-          }
-        })
-        .as(new ObservableGauge {})
+    createInternal(odm =>
+      measurements.flatMap(ms =>
+        F.delay(
+          ms.foreach(m =>
+            odm.record(m.value, Conversions.toJAttributes(m.attributes))
+          )
+        )
+      )
     )
 
 }

--- a/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableUpDownCounterBuilderImpl.scala
+++ b/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableUpDownCounterBuilderImpl.scala
@@ -23,6 +23,7 @@ import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import io.opentelemetry.api.metrics.{Meter => JMeter}
+import io.opentelemetry.api.metrics.ObservableLongMeasurement
 import org.typelevel.otel4s.metrics._
 
 private[java] case class ObservableUpDownCounterBuilderImpl[F[_]](
@@ -39,8 +40,8 @@ private[java] case class ObservableUpDownCounterBuilderImpl[F[_]](
   def withDescription(description: String): Self =
     copy(description = Option(description))
 
-  def createWithCallback(
-      cb: ObservableMeasurement[F, Long] => F[Unit]
+  private def createInternal(
+      cb: ObservableLongMeasurement => F[Unit]
   ): Resource[F, ObservableUpDownCounter] =
     Dispatcher.sequential.flatMap(dispatcher =>
       Resource
@@ -48,36 +49,29 @@ private[java] case class ObservableUpDownCounterBuilderImpl[F[_]](
           val b = jMeter.upDownCounterBuilder(name)
           unit.foreach(b.setUnit)
           description.foreach(b.setDescription)
-          b.buildWithCallback { gauge =>
-            dispatcher.unsafeRunSync(cb(new ObservableLongImpl(gauge)))
+          b.buildWithCallback { olm =>
+            dispatcher.unsafeRunSync(cb(olm))
           }
-
         })
         .as(new ObservableUpDownCounter {})
     )
+
+  def createWithCallback(
+      cb: ObservableMeasurement[F, Long] => F[Unit]
+  ): Resource[F, ObservableUpDownCounter] =
+    createInternal(olm => cb(new ObservableLongImpl(olm)))
+
   def create(
       measurements: F[List[Measurement[Long]]]
   ): Resource[F, ObservableUpDownCounter] =
-    Dispatcher.sequential.flatMap(dispatcher =>
-      Resource
-        .fromAutoCloseable(F.delay {
-          val b = jMeter.upDownCounterBuilder(name)
-          unit.foreach(b.setUnit)
-          description.foreach(b.setDescription)
-          b.buildWithCallback { gauge =>
-            dispatcher.unsafeRunSync(
-              measurements.flatMap(ms =>
-                F.delay(
-                  ms.foreach(m =>
-                    gauge
-                      .record(m.value, Conversions.toJAttributes(m.attributes))
-                  )
-                )
-              )
-            )
-          }
-        })
-        .as(new ObservableUpDownCounter {})
+    createInternal(olm =>
+      measurements.flatMap(ms =>
+        F.delay(
+          ms.foreach(m =>
+            olm.record(m.value, Conversions.toJAttributes(m.attributes))
+          )
+        )
+      )
     )
 
 }

--- a/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableUpDownCounterBuilderImpl.scala
+++ b/java/metrics/src/main/scala/org/typelevel/otel4s/java/metrics/ObservableUpDownCounterBuilderImpl.scala
@@ -55,5 +55,29 @@ private[java] case class ObservableUpDownCounterBuilderImpl[F[_]](
         })
         .as(new ObservableUpDownCounter {})
     )
+  def create(
+      measurements: F[List[Measurement[Long]]]
+  ): Resource[F, ObservableUpDownCounter] =
+    Dispatcher.sequential.flatMap(dispatcher =>
+      Resource
+        .fromAutoCloseable(F.delay {
+          val b = jMeter.upDownCounterBuilder(name)
+          unit.foreach(b.setUnit)
+          description.foreach(b.setDescription)
+          b.buildWithCallback { gauge =>
+            dispatcher.unsafeRunSync(
+              measurements.flatMap(ms =>
+                F.delay(
+                  ms.foreach(m =>
+                    gauge
+                      .record(m.value, Conversions.toJAttributes(m.attributes))
+                  )
+                )
+              )
+            )
+          }
+        })
+        .as(new ObservableUpDownCounter {})
+    )
 
 }

--- a/java/metrics/src/test/scala/org/typelevel/otel4s/java/metrics/ObservableSuite.scala
+++ b/java/metrics/src/test/scala/org/typelevel/otel4s/java/metrics/ObservableSuite.scala
@@ -20,6 +20,7 @@ package metrics
 
 import cats.effect.IO
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.metrics.Measurement
 import org.typelevel.otel4s.testkit.metrics.MetricsSdk
 
 class ObservableSuite extends CatsEffectSuite {
@@ -44,6 +45,31 @@ class ObservableSuite extends CatsEffectSuite {
           sdk.metrics
             .map(_.flatMap(_.data.points.map(x => (x.value, x.attributes))))
             .assertEquals(List((42.0, List(Attribute("foo", "bar")))))
+        )
+
+      _ <- meter
+        .observableGauge("gauge")
+        .withUnit("unit")
+        .withDescription("description")
+        .create(
+          IO.pure(
+            List(
+              Measurement(1336.0, List(Attribute("1", "2"))),
+              Measurement(1337.0, List(Attribute("a", "b")))
+            )
+          )
+        )
+        .use(_ =>
+          sdk.metrics
+            .map(
+              _.flatMap(_.data.points.map(x => (x.value, x.attributes)))
+            )
+            .assertEquals(
+              List(
+                (1336.0, List(Attribute("1", "2"))),
+                (1337.0, List(Attribute("a", "b")))
+              )
+            )
         )
 
     } yield ()
@@ -71,6 +97,31 @@ class ObservableSuite extends CatsEffectSuite {
             .assertEquals(List((1234, List(Attribute("number", 42L)))))
         )
 
+      _ <- meter
+        .observableCounter("counter")
+        .withUnit("unit")
+        .withDescription("description")
+        .create(
+          IO.pure(
+            List(
+              Measurement(1336, List(Attribute("1", "2"))),
+              Measurement(1337, List(Attribute("a", "b")))
+            )
+          )
+        )
+        .use(_ =>
+          sdk.metrics
+            .map(
+              _.flatMap(_.data.points.map(x => (x.value, x.attributes)))
+            )
+            .assertEquals(
+              List(
+                (1336, List(Attribute("1", "2"))),
+                (1337, List(Attribute("a", "b")))
+              )
+            )
+        )
+
     } yield ()
   }
 
@@ -96,6 +147,31 @@ class ObservableSuite extends CatsEffectSuite {
           sdk.metrics
             .map(_.flatMap(_.data.points.map(x => (x.value, x.attributes))))
             .assertEquals(List((1234, List(Attribute("is_false", true)))))
+        )
+
+      _ <- meter
+        .observableUpDownCounter("updowncounter")
+        .withUnit("unit")
+        .withDescription("description")
+        .create(
+          IO.pure(
+            List(
+              Measurement(1336, List(Attribute("1", "2"))),
+              Measurement(1336, List(Attribute("a", "b")))
+            )
+          )
+        )
+        .use(_ =>
+          sdk.metrics
+            .map(
+              _.flatMap(_.data.points.map(x => (x.value, x.attributes)))
+            )
+            .assertEquals(
+              List(
+                (1336, List(Attribute("1", "2"))),
+                (1336, List(Attribute("a", "b")))
+              )
+            )
         )
 
     } yield ()


### PR DESCRIPTION
I think this would be a good addition even though the approaches seem equivalent.

From the [docs](https://opentelemetry.io/docs/reference/specification/metrics/api/#asynchronous-instrument-api)

> 
> [OpenTelemetry API](https://opentelemetry.io/docs/reference/specification/overview/#api) authors MAY decide what is the idiomatic approach for capturing measurements from callback functions. Here are some examples:
> - Return a list (or tuple, generator, enumerator, etc.) of individual Measurement values.
> - Pass an Observable Result as a formal parameter of the callback, where result.Observe() captures individual Measurement values.

The only thing I am not sure of is the naming, and whether to include the default implementation.