### PR TITLE
Immutable injection in TextMapPropagator

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/TextMapInjector.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/TextMapInjector.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+
+trait TextMapInjector[A] {
+  type Builder
+
+  def textMapSetter: TextMapSetter[Builder]
+
+  def toBuilder(carrier: A): Builder
+
+  def toCarrier(builder: Builder): A
+}

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/TextMapPropagatorImpl.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/TextMapPropagatorImpl.scala
@@ -39,4 +39,16 @@ private[java] class TextMapPropagatorImpl[F[_]: Sync](
     Sync[F].delay(
       jPropagator.inject(toJContext(ctx), carrier, fromTextMapSetter)
     )
+
+  def injected[A](ctx: Vault, carrier: A)(implicit
+      injector: TextMapInjector[A]
+  ): A = {
+    val builder = injector.toBuilder(carrier)
+    jPropagator.inject(
+      toJContext(ctx),
+      builder,
+      fromTextMapSetter(injector.textMapSetter)
+    )
+    injector.toCarrier(builder)
+  }
 }


### PR DESCRIPTION
Rough draft of immutable injection.  Adds `injected` as an extension to the TextMapPropagator interface while preserving compatibility with the standard injectors we get from a compliant SDK.

See #147, #180.