### PR TITLE
Basic reporting through toString 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,7 @@ lazy val java = project
   .settings(
     name := "otel4s-java",
     libraryDependencies ++= Seq(
-      "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test
     )
   )
   .settings(munitDependencies)

--- a/build.sbt
+++ b/build.sbt
@@ -216,8 +216,12 @@ lazy val java = project
   .in(file("java/all"))
   .dependsOn(core.jvm, `java-metrics`, `java-trace`)
   .settings(
-    name := "otel4s-java"
+    name := "otel4s-java",
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
+    )
   )
+  .settings(munitDependencies)
 
 lazy val benchmarks = project
   .enablePlugins(NoPublishPlugin)

--- a/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
+++ b/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
@@ -30,8 +30,7 @@ trait Otel4s[F[_]] {
     */
   def tracerProvider: TracerProvider[F]
 
-  /** TODO -- how do I write comments?
+  /** TODO -- write something nice
     */
-  override def toString(): String =
-    return "TODO -- what goes here?"
+  override def toString(): String
 }

--- a/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
+++ b/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
@@ -29,4 +29,9 @@ trait Otel4s[F[_]] {
   /** An entry point of the tracing API.
     */
   def tracerProvider: TracerProvider[F]
+
+  /** TODO -- how do I write comments?
+    */
+  override def toString(): String =
+    return "TODO -- what goes here?"
 }

--- a/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
+++ b/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
@@ -29,8 +29,4 @@ trait Otel4s[F[_]] {
   /** An entry point of the tracing API.
     */
   def tracerProvider: TracerProvider[F]
-
-  /** TODO -- write something nice
-    */
-  override def toString(): String
 }

--- a/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
+++ b/java/all/src/main/scala/org/typelevel/otel4s/java/OtelJava.scala
@@ -68,6 +68,8 @@ object OtelJava {
       def propagators: ContextPropagators[F] = contextPropagators
       def meterProvider: MeterProvider[F] = metrics.meterProvider
       def tracerProvider: TracerProvider[F] = traces.tracerProvider
+
+      override def toString: String = jOtel.toString()
     }
   }
 

--- a/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
+++ b/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
@@ -17,32 +17,19 @@
 package org.typelevel.otel4s.java
 
 import cats.effect.IO
-import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 import io.opentelemetry.sdk.{OpenTelemetrySdk => JOpenTelemetrySdk}
-import org.typelevel.otel4s.Otel4s
-import org.typelevel.otel4s.java.OtelJava
-import org.typelevel.otel4s.ContextPropagators
-import org.typelevel.otel4s.metrics.MeterProvider
-import org.typelevel.otel4s.trace.TracerProvider
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.java.OtelJava
 
 class OtelJavaSuite extends CatsEffectSuite {
 
   test("OtelJava toString returns useful info") {
-
-    val testSdk = JOpenTelemetrySdk.builder().build()
-    val testOtel4s = new Otel4s[IO] {
-      def propagators: ContextPropagators[IO] =
-        testSdk.getPropagators() // TODO: resolve
-      def meterProvider: MeterProvider[IO] = testSdk.getMeterProvider()
-      def tracerProvider: TracerProvider[IO] = testSdk.getTracerProvider()
-
-      override def toString: String = testSdk.toString()
-    }
-
-    assertEquals(
-      testOtel4s.toString(),
-      "some string here"
-    )
+    val testSdk: JOpenTelemetrySdk = JOpenTelemetrySdk.builder().build()
+    OtelJava
+      .forAsync[IO](testSdk)
+      .map(testOtel4s => {
+        val res = testOtel4s.toString()
+        assert(clue(res).startsWith("OpenTelemetrySdk"))
+      })
   }
 }

--- a/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
+++ b/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
@@ -16,15 +16,33 @@
 
 package org.typelevel.otel4s.java
 
+import cats.effect.IO
+import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 import io.opentelemetry.sdk.{OpenTelemetrySdk => JOpenTelemetrySdk}
+import org.typelevel.otel4s.Otel4s
+import org.typelevel.otel4s.java.OtelJava
+import org.typelevel.otel4s.ContextPropagators
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.trace.TracerProvider
 import munit.CatsEffectSuite
 
 class OtelJavaSuite extends CatsEffectSuite {
 
-  test("JOtelSDK toString returns useful info") {
+  test("OtelJava toString returns useful info") {
+
+    val testSdk = JOpenTelemetrySdk.builder().build()
+    val testOtel4s = new Otel4s[IO] {
+      def propagators: ContextPropagators[IO] =
+        testSdk.getPropagators() // TODO: resolve
+      def meterProvider: MeterProvider[IO] = testSdk.getMeterProvider()
+      def tracerProvider: TracerProvider[IO] = testSdk.getTracerProvider()
+
+      override def toString: String = testSdk.toString()
+    }
+
     assertEquals(
-      JOpenTelemetrySdk.builder().build().toString(),
-      "OpenTelemetrySdk{tracerProvider=SdkTracerProvider{clock=SystemClock{}, idGenerator=RandomIdGenerator{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, spanProcessor=NoopSpanProcessor{}}, meterProvider=SdkMeterProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, metricReaders=[], views=[]}, loggerProvider=SdkLoggerProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, logLimits=LogLimits{maxNumberOfAttributes=128, maxAttributeValueLength=2147483647}, logRecordProcessor=io.opentelemetry.sdk.logs.NoopLogRecordProcessor@59364403}, propagators=DefaultContextPropagators{textMapPropagator=NoopTextMapPropagator}}"
+      testOtel4s.toString(),
+      "some string here"
     )
   }
 }

--- a/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
+++ b/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
@@ -1,0 +1,11 @@
+package org.typelevel.otel4s.java
+
+import munit.CatsEffectSuite
+import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+
+class OtelJavaSuite extends CatsEffectSuite {
+
+  test("toString implementation") {
+    assertEquals(JOpenTelemetry.noop().toString(), "noop?")
+  }
+}

--- a/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
+++ b/java/all/src/test/scala/org/typelevel/otel4s/java/OtelJavaSuite.scala
@@ -1,11 +1,30 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.otel4s.java
 
+import io.opentelemetry.sdk.{OpenTelemetrySdk => JOpenTelemetrySdk}
 import munit.CatsEffectSuite
-import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
 
 class OtelJavaSuite extends CatsEffectSuite {
 
-  test("toString implementation") {
-    assertEquals(JOpenTelemetry.noop().toString(), "noop?")
+  test("JOtelSDK toString returns useful info") {
+    assertEquals(
+      JOpenTelemetrySdk.builder().build().toString(),
+      "OpenTelemetrySdk{tracerProvider=SdkTracerProvider{clock=SystemClock{}, idGenerator=RandomIdGenerator{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, sampler=ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, spanProcessor=NoopSpanProcessor{}}, meterProvider=SdkMeterProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, metricReaders=[], views=[]}, loggerProvider=SdkLoggerProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name=\"unknown_service:java\", telemetry.sdk.language=\"java\", telemetry.sdk.name=\"opentelemetry\", telemetry.sdk.version=\"1.26.0\"}}, logLimits=LogLimits{maxNumberOfAttributes=128, maxAttributeValueLength=2147483647}, logRecordProcessor=io.opentelemetry.sdk.logs.NoopLogRecordProcessor@59364403}, propagators=DefaultContextPropagators{textMapPropagator=NoopTextMapPropagator}}"
+    )
   }
 }


### PR DESCRIPTION
This is super not ready, just opening an early draft for visibility. Meant for #188. 

I think I realized after this first commit that since Otel4s is a trait, the implementation of `toString` shouldn't lie here (instead, it should just specify that a String is returned) -- is this correct? (And we leave the implementation to all the things with type `Otel4s[F[_]]` / all the things that extend `Otel4s[F[_]]`?) 

