### PR TITLE
Make Local instance for IOLocal public and add law tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ val CatsMtlVersion = "1.3.1"
 val FS2Version = "3.7.0"
 val MUnitVersion = "1.0.0-M7"
 val MUnitCatsEffectVersion = "2.0.0-M3"
+val MUnitDisciplineVersion = "2.0.0-M3"
 val OpenTelemetryVersion = "1.26.0"
 val ScodecVersion = "1.1.37"
 val VaultVersion = "3.5.0"
@@ -152,13 +153,16 @@ lazy val `java-common` = project
   .in(file("java/common"))
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(`core-common`.jvm, `testkit-common`.jvm)
+  .settings(munitDependencies)
   .settings(
     name := "otel4s-java-common",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect-kernel" % CatsEffectVersion,
       "org.typelevel" %%% "cats-mtl" % CatsMtlVersion,
       "io.opentelemetry" % "opentelemetry-sdk" % OpenTelemetryVersion,
-      "org.scalameta" %%% "munit" % MUnitVersion % Test
+      "org.typelevel" %%% "discipline-munit" % MUnitDisciplineVersion % Test,
+      "org.typelevel" %%% "cats-mtl-laws" % CatsMtlVersion % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % CatsEffectVersion % Test
     ),
     buildInfoPackage := "org.typelevel.otel4s.java",
     buildInfoOptions += sbtbuildinfo.BuildInfoOption.PackagePrivate,

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/instances.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/instances.scala
@@ -23,7 +23,7 @@ import cats.effect.LiftIO
 import cats.effect.MonadCancelThrow
 import cats.mtl.Local
 
-private[java] object instances {
+object instances {
   // We hope this instance is moved into Cats Effect.
   implicit def localForIoLocal[F[_]: MonadCancelThrow: LiftIO, E](implicit
       ioLocal: IOLocal[E]

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
@@ -1,0 +1,15 @@
+package org.typelevel.otel4s.java
+
+import cats.effect.testkit.TestInstances
+import cats.effect.{IO, IOLocal}
+import cats.mtl.laws.discipline.LocalTests
+import munit.{CatsEffectSuite, DisciplineSuite}
+import org.scalacheck.Arbitrary.arbString
+import org.typelevel.otel4s.java.instances._
+
+class InstancesSuite extends CatsEffectSuite with DisciplineSuite with TestInstances {
+  implicit val ticker: Ticker = Ticker()
+  implicit val ioLocal: IOLocal[String] = IOLocal("").unsafeRunSync()(munitIORuntime)
+
+  checkAll("IOLocal.LocalLaws", LocalTests[IO, String].local[String, Int])
+}

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
@@ -3,13 +3,16 @@ package org.typelevel.otel4s.java
 import cats.effect.testkit.TestInstances
 import cats.effect.{IO, IOLocal}
 import cats.mtl.laws.discipline.LocalTests
-import munit.{CatsEffectSuite, DisciplineSuite}
+import munit.DisciplineSuite
 import org.scalacheck.Arbitrary.arbString
 import org.typelevel.otel4s.java.instances._
 
-class InstancesSuite extends CatsEffectSuite with DisciplineSuite with TestInstances {
+class InstancesSuite extends DisciplineSuite with TestInstances {
   implicit val ticker: Ticker = Ticker()
-  implicit val ioLocal: IOLocal[String] = IOLocal("").unsafeRunSync()(munitIORuntime)
 
-  checkAll("IOLocal.LocalLaws", LocalTests[IO, String].local[String, Int])
+  unsafeRun {
+    IOLocal("").map {implicit ioLocal =>
+      checkAll("IOLocal.LocalLaws", LocalTests[IO, String].local[String, Int])
+    }
+  }
 }

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
@@ -16,8 +16,9 @@
 
 package org.typelevel.otel4s.java
 
+import cats.effect.IO
+import cats.effect.IOLocal
 import cats.effect.testkit.TestInstances
-import cats.effect.{IO, IOLocal}
 import cats.mtl.laws.discipline.LocalTests
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary.arbString

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
@@ -27,7 +27,7 @@ class InstancesSuite extends DisciplineSuite with TestInstances {
   implicit val ticker: Ticker = Ticker()
 
   unsafeRun {
-    IOLocal("").map {implicit ioLocal =>
+    IOLocal("").map { implicit ioLocal =>
       checkAll("IOLocal.LocalLaws", LocalTests[IO, String].local[String, Int])
     }
   }

--- a/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
+++ b/java/common/src/test/scala/org/typelevel/otel4s/java/InstancesSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.otel4s.java
 
 import cats.effect.testkit.TestInstances


### PR DESCRIPTION
Closes #195

This PR makes the Local instance for IO (backed by a IOLocal) public so users don't have to reimplement it themselves. Hopefully it will be added to Cats Effect but until then users can use this.