### PR TITLE
Add `Tracer#propagate`

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -170,6 +170,20 @@ trait Tracer[F[_]] extends TracerMacro[F] {
     */
   def noopScope[A](fa: F[A]): F[A]
 
+  /** Propagates this tracer's context into an immutable carrier.
+    *
+    * @param carrier
+    *   the immutable carrier to append the context to
+    * @tparam C
+    *   the type of the carrier
+    * @return
+    *   a copy of the immutable carrier with this tracer's context appended to
+    *   it
+    * @see
+    *   [[org.typelevel.otel4s.TextMapPropagator.injected TextMapPropagator#injected]]
+    */
+  def propagate[C: TextMapUpdater](carrier: C): F[C]
+
 }
 
 object Tracer {
@@ -207,6 +221,8 @@ object Tracer {
       def childScope[A](parent: SpanContext)(fa: F[A]): F[A] = fa
       def spanBuilder(name: String): SpanBuilder[F] = builder
       def joinOrRoot[A, C: TextMapGetter](carrier: C)(fa: F[A]): F[A] = fa
+      def propagate[C: TextMapUpdater](carrier: C): F[C] =
+        Applicative[F].pure(carrier)
     }
 
   object Implicits {

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
@@ -19,9 +19,10 @@ package org.typelevel.otel4s.java.trace
 import cats.effect.Sync
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import org.typelevel.otel4s.ContextPropagators
+import org.typelevel.otel4s.context.AskVault
 import org.typelevel.otel4s.trace._
 
-private[java] final case class TracerBuilderImpl[F[_]: Sync](
+private[java] final case class TracerBuilderImpl[F[_]: Sync: AskVault](
     jTracerProvider: JTracerProvider,
     propagators: ContextPropagators[F],
     scope: TraceScope[F],

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -20,11 +20,12 @@ import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import org.typelevel.otel4s.ContextPropagators
+import org.typelevel.otel4s.context.AskVault
 import org.typelevel.otel4s.trace.TracerBuilder
 import org.typelevel.otel4s.trace.TracerProvider
 import org.typelevel.vault.Vault
 
-private[java] class TracerProviderImpl[F[_]: Sync](
+private[java] class TracerProviderImpl[F[_]: Sync: AskVault](
     jTracerProvider: JTracerProvider,
     propagators: ContextPropagators[F],
     scope: TraceScope[F]


### PR DESCRIPTION
Add `Tracer#propagate` for propagating to an arbitrary carrier without having to carry around the context `Vault` yourself.

Addresses request in #89

- [x] scaladocs
- [x] `rebase -i --autosquash`