### PR TITLE
`Tracer#joinOrRoot` - propagate extracted headers downstream

### DIFF
--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/ContextConversions.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/ContextConversions.scala
@@ -24,33 +24,27 @@ import org.typelevel.vault.Vault
 
 private[otel4s] object ContextConversions {
 
-  def toJContext(context: Vault): JContext = {
-    var jContext = JContext.root()
-    jContext = Scope.fromContext(context) match {
-      case Scope.Root(_) =>
-        jContext
-      case Scope.Span(_, jSpan) =>
-        jSpan.storeInContext(jContext)
+  def toJContext(context: Vault): JContext =
+    Scope.fromContext(context) match {
+      case Scope.Root(ctx) =>
+        ctx
+      case Scope.Span(ctx, jSpan) =>
+        jSpan.storeInContext(ctx)
       case Scope.Noop =>
-        JSpan.getInvalid.storeInContext(jContext)
+        JSpan.getInvalid.storeInContext(JContext.root())
     }
-    jContext
-  }
 
-  def fromJContext(jContext: JContext): Vault = {
-    var context = Vault.empty
+  def fromJContext(jContext: JContext): Vault =
     JSpan.fromContextOrNull(jContext) match {
       case null =>
-        context = Scope.root.storeInContext(context)
+        Scope.Root(jContext).storeInContext(Vault.empty)
       case jSpan =>
         if (jSpan.getSpanContext.isValid) {
+          var context = Vault.empty
           context = Scope.Span(jContext, jSpan).storeInContext(context)
-          context =
-            new WrappedSpanContext(jSpan.getSpanContext).storeInContext(context)
+          new WrappedSpanContext(jSpan.getSpanContext).storeInContext(context)
         } else {
-          context = Scope.Noop.storeInContext(context)
+          Scope.Noop.storeInContext(Vault.empty)
         }
     }
-    context
-  }
 }

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerBuilderImpl.scala
@@ -19,10 +19,10 @@ package org.typelevel.otel4s.java.trace
 import cats.effect.Sync
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import org.typelevel.otel4s.ContextPropagators
-import org.typelevel.otel4s.context.AskVault
+import org.typelevel.otel4s.context.LocalVault
 import org.typelevel.otel4s.trace._
 
-private[java] final case class TracerBuilderImpl[F[_]: Sync: AskVault](
+private[java] final case class TracerBuilderImpl[F[_]: Sync: LocalVault](
     jTracerProvider: JTracerProvider,
     propagators: ContextPropagators[F],
     scope: TraceScope[F],

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/TracerProviderImpl.scala
@@ -20,12 +20,12 @@ import cats.effect.Sync
 import cats.mtl.Local
 import io.opentelemetry.api.trace.{TracerProvider => JTracerProvider}
 import org.typelevel.otel4s.ContextPropagators
-import org.typelevel.otel4s.context.AskVault
+import org.typelevel.otel4s.context.LocalVault
 import org.typelevel.otel4s.trace.TracerBuilder
 import org.typelevel.otel4s.trace.TracerProvider
 import org.typelevel.vault.Vault
 
-private[java] class TracerProviderImpl[F[_]: Sync: AskVault](
+private[java] class TracerProviderImpl[F[_]: Sync: LocalVault](
     jTracerProvider: JTracerProvider,
     propagators: ContextPropagators[F],
     scope: TraceScope[F]


### PR DESCRIPTION
Closes #277.

While reviewing the #291, I spotted the reason behind #277.