### PR TITLE
Scaladoc: Update max name length of a metric instrument

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableInstrumentBuilder.scala
@@ -29,7 +29,7 @@ trait ObservableInstrumentBuilder[F[_], A, Instrument] {
     *   Unit</a>
     *
     * @param unit
-    *   the measurement unit. Must be 63 or fewer ASCII characters.
+    *   the measurement unit. Must be 255 or fewer ASCII characters.
     */
   def withUnit(unit: String): Self
 

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/SyncInstrumentBuilder.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/SyncInstrumentBuilder.scala
@@ -27,7 +27,7 @@ trait SyncInstrumentBuilder[F[_], A] {
     *   Unit</a>
     *
     * @param unit
-    *   the measurement unit. Must be 63 or fewer ASCII characters.
+    *   the measurement unit. Must be 255 or fewer ASCII characters.
     */
   def withUnit(unit: String): Self
 


### PR DESCRIPTION
Starting from `1.30.0`, the max length of a metric instrument can be 255 ASCII characters.

https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.30.0