### PR TITLE
Add `traceFlags` to `SpanContext`

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SamplingDecision.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SamplingDecision.scala
@@ -28,11 +28,15 @@ object SamplingDecision {
     */
   case object Drop extends SamplingDecision(false)
 
+  /** Span is recorded only. The resulting span will record all information like
+    * timings and attributes but will not be exported. Downstream parent-based
+    * samplers will not sample the span.
+    */
+  case object RecordOnly extends SamplingDecision(false)
+
   /** Span is recorded and sampled. The resulting span will record all
     * information like timings and attributes and will be exported.
     */
-  case object Record extends SamplingDecision(true)
+  case object RecordAndSample extends SamplingDecision(true)
 
-  def fromBoolean(isSampled: Boolean): SamplingDecision =
-    if (isSampled) Record else Drop
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceFlags.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceFlags.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import cats.Hash
+import cats.Show
+import scodec.bits.ByteVector
+
+/** A valid trace flags is a byte or 2 character lowercase hex (base16) String.
+  *
+  * These options are propagated to all child spans. These determine features
+  * such as whether a Span should be traced.
+  */
+sealed trait TraceFlags {
+
+  /** Returns the byte representation of this [[TraceFlags]].
+    */
+  def asByte: Byte
+
+  /** Returns the lowercase hex (base16) representation of this [[TraceFlags]].
+    */
+  def asHex: String
+
+  /** Returns `true` if the sampling bit is on, otherwise `false`.
+    */
+  def isSampled: Boolean
+
+  override final def hashCode(): Int =
+    Hash[TraceFlags].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: TraceFlags => Hash[TraceFlags].eqv(this, other)
+      case _                 => false
+    }
+
+  override final def toString: String =
+    Show[TraceFlags].show(this)
+}
+
+object TraceFlags {
+  private val SampledMask = 0x01
+
+  val HexLength = 2
+
+  val Default: TraceFlags = fromByte(0x00)
+  val Sampled: TraceFlags = fromByte(0x01)
+
+  /** Creates the [[TraceFlags]] from the given byte representation.
+    */
+  def fromByte(byte: Byte): TraceFlags =
+    TraceFlagsImpl(byte)
+
+  /** Creates the [[TraceFlags]] from the given hex representation.
+    *
+    * Returns `None` if input string has invalid (non-hex) characters.
+    */
+  def fromHex(hex: String): Option[TraceFlags] =
+    ByteVector.fromHex(hex).map(b => TraceFlagsImpl(b.toByte()))
+
+  implicit val traceFlagsHash: Hash[TraceFlags] =
+    Hash.by(_.asByte)
+
+  implicit val traceFlagsShow: Show[TraceFlags] =
+    Show.show(_.asHex)
+
+  private final case class TraceFlagsImpl(byte: Byte) extends TraceFlags {
+    def asByte: Byte = byte
+    def asHex: String = ByteVector.fromByte(byte).toHex
+
+    def isSampled: Boolean =
+      (byte & TraceFlags.SampledMask) == TraceFlags.SampledMask
+  }
+
+}

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceFlags.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceFlags.scala
@@ -53,12 +53,13 @@ sealed trait TraceFlags {
 }
 
 object TraceFlags {
-  private val SampledMask = 0x01
+  private val SampledMask: Byte = 0x01
 
-  val HexLength = 2
-
+  // The default trace flags (not sampled): with all flag bits off
   val Default: TraceFlags = fromByte(0x00)
-  val Sampled: TraceFlags = fromByte(0x01)
+
+  // The sampled trace flags: the sampled bit is on
+  val Sampled: TraceFlags = fromByte(SampledMask)
 
   /** Creates the [[TraceFlags]] from the given byte representation.
     */

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SamplingDecisionSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SamplingDecisionSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import munit._
+
+class SamplingDecisionSuite extends FunSuite {
+
+  test("Drop should have isSampled = false") {
+    assertEquals(SamplingDecision.Drop.isSampled, false)
+  }
+
+  test("RecordOnly should have isSampled = false") {
+    assertEquals(SamplingDecision.RecordOnly.isSampled, false)
+  }
+
+  test("RecordAndSample should have isSampled = true") {
+    assertEquals(SamplingDecision.RecordAndSample.isSampled, true)
+  }
+
+}

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanContextSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanContextSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import munit._
+import org.typelevel.otel4s.trace.SpanContext.SpanId
+import org.typelevel.otel4s.trace.SpanContext.TraceId
+
+class SpanContextSuite extends FunSuite {
+
+  test("invalid span context") {
+    assertEquals(SpanContext.invalid.traceId, TraceId.Invalid)
+    assertEquals(SpanContext.invalid.traceIdHex, TraceId.InvalidHex)
+    assertEquals(SpanContext.invalid.spanId, SpanId.Invalid)
+    assertEquals(SpanContext.invalid.spanIdHex, SpanId.InvalidHex)
+    assertEquals(SpanContext.invalid.traceFlags, TraceFlags.Default)
+    assertEquals(SpanContext.invalid.isValid, false)
+    assertEquals(SpanContext.invalid.isRemote, false)
+  }
+
+}

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanIdSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanIdSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import munit._
+import org.typelevel.otel4s.trace.SpanContext.SpanId
+import scodec.bits.ByteVector
+
+class SpanIdSuite extends FunSuite {
+
+  private val first =
+    ByteVector.fromValidHex("0000000000000061")
+
+  private val second =
+    ByteVector.fromValidHex("ff00000000000041")
+
+  test("invalid") {
+    assertEquals(SpanId.Invalid, ByteVector(Array.ofDim[Byte](8)))
+    assertEquals(SpanId.InvalidHex, "0000000000000000")
+  }
+
+  test("is valid") {
+    assertEquals(SpanId.isValid(ByteVector.empty), false)
+
+    // too short
+    assertEquals(SpanId.isValid(ByteVector.fromValidHex("001")), false)
+
+    // too long
+    assertEquals(
+      SpanId.isValid(
+        ByteVector.fromValidHex("00000000000000411110000000000000016")
+      ),
+      false
+    )
+
+    assertEquals(SpanId.isValid(SpanId.Invalid), false)
+
+    assertEquals(SpanId.isValid(first), true)
+    assertEquals(SpanId.isValid(second), true)
+  }
+
+  test("create from long") {
+    assertEquals(SpanId.fromLong(0), SpanId.Invalid)
+    assertEquals(SpanId.fromLong(0x61), first)
+    assertEquals(SpanId.fromLong(0xff00000000000041L), second)
+  }
+
+}

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceFlagsSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceFlagsSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import munit._
+
+class TraceFlagsSuite extends FunSuite {
+
+  test("default instances") {
+    assertEquals(TraceFlags.Default.asHex, "00")
+    assertEquals(TraceFlags.Sampled.asHex, "01")
+  }
+
+  test("is sampled") {
+    assertEquals(TraceFlags.fromByte(0xff.toByte).isSampled, true)
+    assertEquals(TraceFlags.fromByte(0x01).isSampled, true)
+    assertEquals(TraceFlags.fromByte(0x05).isSampled, true)
+    assertEquals(TraceFlags.fromByte(0x00).isSampled, false)
+  }
+
+  test("create from byte") {
+    (0 until 256).foreach { i =>
+      assertEquals(TraceFlags.fromByte(i.toByte).asByte, i.toByte)
+    }
+  }
+
+  test("create from hex") {
+    (0 until 256).foreach { i =>
+      val hex = Integer.toHexString(i)
+      val input = if (hex.length == 1) "0" + hex else hex
+
+      assertEquals(TraceFlags.fromHex(input).map(_.asHex), Some(input))
+    }
+  }
+
+  test("create from hex (invalid)") {
+    assertEquals(TraceFlags.fromHex("zxc"), None)
+  }
+
+}

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceIdSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceIdSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import munit._
+import org.typelevel.otel4s.trace.SpanContext.TraceId
+import scodec.bits.ByteVector
+
+class TraceIdSuite extends FunSuite {
+
+  private val first =
+    ByteVector.fromValidHex("00000000000000000000000000000061")
+
+  private val second =
+    ByteVector.fromValidHex("ff000000000000000000000000000041")
+
+  test("invalid") {
+    assertEquals(TraceId.Invalid, ByteVector(Array.ofDim[Byte](16)))
+    assertEquals(TraceId.InvalidHex, "00000000000000000000000000000000")
+  }
+
+  test("is valid") {
+    assertEquals(TraceId.isValid(ByteVector.empty), false)
+
+    // too short
+    assertEquals(TraceId.isValid(ByteVector.fromValidHex("001")), false)
+
+    // too long
+    assertEquals(
+      TraceId.isValid(
+        ByteVector.fromValidHex("00000000000000411110000000000000016")
+      ),
+      false
+    )
+
+    assertEquals(TraceId.isValid(TraceId.Invalid), false)
+
+    assertEquals(TraceId.isValid(first), true)
+    assertEquals(TraceId.isValid(second), true)
+  }
+
+  test("create from longs") {
+    assertEquals(TraceId.fromLongs(0, 0), TraceId.Invalid)
+    assertEquals(TraceId.fromLongs(0, 0x61), first)
+    assertEquals(TraceId.fromLongs(0xff00000000000000L, 0x41), second)
+    assertEquals(
+      TraceId.fromLongs(0xff01020304050600L, 0xff0a0b0c0d0e0f00L),
+      ByteVector.fromValidHex("ff01020304050600ff0a0b0c0d0e0f00")
+    )
+  }
+
+}

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
@@ -17,10 +17,10 @@
 package org.typelevel.otel4s.java.trace
 
 import io.opentelemetry.api.trace.{SpanContext => JSpanContext}
-import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.{TraceFlags => JTraceFlags}
 import io.opentelemetry.api.trace.TraceState
-import org.typelevel.otel4s.trace.SamplingDecision
 import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.TraceFlags
 import scodec.bits.ByteVector
 
 private[java] final case class WrappedSpanContext(
@@ -39,8 +39,8 @@ private[java] final case class WrappedSpanContext(
   def spanIdHex: String =
     jSpanContext.getSpanId
 
-  lazy val samplingDecision: SamplingDecision =
-    SamplingDecision.fromBoolean(jSpanContext.isSampled)
+  lazy val traceFlags: TraceFlags =
+    TraceFlags.fromByte(jSpanContext.getTraceFlags.asByte)
 
   def isValid: Boolean =
     jSpanContext.isValid
@@ -52,9 +52,7 @@ private[java] final case class WrappedSpanContext(
 private[trace] object WrappedSpanContext {
 
   def unwrap(context: SpanContext): JSpanContext = {
-    def flags =
-      if (context.samplingDecision.isSampled) TraceFlags.getSampled
-      else TraceFlags.getDefault
+    def flags = JTraceFlags.fromByte(context.traceFlags.asByte)
 
     context match {
       case ctx: WrappedSpanContext =>

--- a/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/SpanContextSuite.scala
+++ b/java/trace/src/test/scala/org/typelevel/otel4s/java/trace/SpanContextSuite.scala
@@ -29,7 +29,7 @@ class SpanContextSuite extends CatsEffectSuite {
     assertEquals(context.traceIdHex, jContext.getTraceId)
     assert(context.spanId.toArray.sameElements(jContext.getSpanIdBytes))
     assertEquals(context.spanIdHex, jContext.getSpanId)
-    assertEquals(context.samplingDecision.isSampled, jContext.isSampled)
+    assertEquals(context.isSampled, jContext.isSampled)
     assertEquals(context.isValid, jContext.isValid)
     assertEquals(context.isRemote, jContext.isRemote)
   }


### PR DESCRIPTION
As an ongoing effort to minimize #325, I will decouple some independent changes into small PRs. This PR adopts several ideas from the https://github.com/typelevel/otel4s/pull/236.