### PR TITLE
Reduce exposure of `end` methods for spans

### DIFF
--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -20,7 +20,7 @@ package trace
 import scala.concurrent.duration.FiniteDuration
 
 private[otel4s] trait SpanMacro[F[_]] {
-  self: Span[F] =>
+  self: SpanAPI[F] =>
 
   /** Adds an attribute to the span. If the span previously contained a mapping
     * for the key, the old value is replaced by the specified value.

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.quoted.*
 
 private[otel4s] trait SpanMacro[F[_]] {
-  self: Span[F] =>
+  self: SpanAPI[F] =>
 
   /** Adds an attribute to the span. If the span previously contained a mapping
     * for the key, the old value is replaced by the specified value.
@@ -124,7 +124,7 @@ private[otel4s] trait SpanMacro[F[_]] {
 object SpanMacro {
 
   def addAttribute[F[_], A](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       attribute: Expr[Attribute[A]]
   )(using Quotes, Type[F], Type[A]) =
     '{
@@ -134,7 +134,7 @@ object SpanMacro {
     }
 
   def addAttributes[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       attributes: Expr[Seq[Attribute[_]]]
   )(using Quotes, Type[F]) =
     '{
@@ -144,7 +144,7 @@ object SpanMacro {
     }
 
   def addEvent[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       name: Expr[String],
       attributes: Expr[Seq[Attribute[_]]]
   )(using Quotes, Type[F]) =
@@ -155,7 +155,7 @@ object SpanMacro {
     }
 
   def addEvent[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       name: Expr[String],
       timestamp: Expr[FiniteDuration],
       attributes: Expr[Seq[Attribute[_]]]
@@ -167,7 +167,7 @@ object SpanMacro {
     }
 
   def recordException[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       exception: Expr[Throwable],
       attributes: Expr[Seq[Attribute[_]]]
   )(using Quotes, Type[F]) =
@@ -178,7 +178,7 @@ object SpanMacro {
     }
 
   def setStatus[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       status: Expr[Status]
   )(using Quotes, Type[F]) =
     '{
@@ -188,7 +188,7 @@ object SpanMacro {
     }
 
   def setStatus[F[_]](
-      span: Expr[Span[F]],
+      span: Expr[SpanAPI[F]],
       status: Expr[Status],
       description: Expr[String]
   )(using Quotes, Type[F]) =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
@@ -24,8 +24,8 @@ import cats.~>
 
 trait SpanOps[F[_]] {
 
-  /** Creates a [[Span]]. The span requires to be ended '''explicitly''' by
-    * invoking `end`.
+  /** Creates a [[Span.Manual]]. The span requires to be ended '''explicitly'''
+    * by invoking `end`.
     *
     * This strategy can be used when it's necessary to end a span outside of the
     * scope (e.g. async callback). Make sure the span is ended properly.
@@ -54,7 +54,7 @@ trait SpanOps[F[_]] {
     * @see
     *   [[use]], [[use_]], [[surround]], or [[resource]] for a managed lifecycle
     */
-  def startUnmanaged: F[Span[F]]
+  def startUnmanaged: F[Span.Manual[F]]
 
   /** Creates a [[Span]] and a [[cats.effect.kernel.Resource Resource]] for
     * using it. Unlike [[startUnmanaged]], the lifecycle of the span is fully
@@ -193,7 +193,7 @@ object SpanOps {
       ops: SpanOps[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanOps[G] {
-    def startUnmanaged: G[Span[G]] =
+    def startUnmanaged: G[Span.Manual[G]] =
       kt.liftK(ops.startUnmanaged).map(_.mapK[G])
 
     def resource: Resource[G, Res[G]] =

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanBuilderImpl.scala
@@ -83,7 +83,7 @@ private[java] final case class SpanBuilderImpl[F[_]: Sync](
     copy(finalizationStrategy = strategy)
 
   def build: SpanOps[F] = new SpanOps[F] {
-    def startUnmanaged: F[Span[F]] =
+    def startUnmanaged: F[Span.Manual[F]] =
       runnerContext.flatMap(ctx => SpanRunner.startUnmanaged(ctx))
 
     def resource: Resource[F, SpanOps.Res[F]] =

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanRunner.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/SpanRunner.scala
@@ -63,15 +63,17 @@ private[java] object SpanRunner {
       }
     }
 
-  def startUnmanaged[F[_]: Sync](context: Option[RunnerContext]): F[Span[F]] =
+  def startUnmanaged[F[_]: Sync](
+      context: Option[RunnerContext]
+  ): F[Span.Manual[F]] =
     context match {
       case Some(RunnerContext(builder, _, ts, _)) =>
         for {
           back <- SpanRunner.startSpan(builder, ts)
-        } yield Span.fromBackend(back)
+        } yield Span.Manual.fromBackend(back)
 
       case None =>
-        Sync[F].pure(Span.fromBackend(Span.Backend.noop))
+        Sync[F].pure(Span.Manual.fromBackend(Span.Backend.noop))
     }
 
   private def startSpan[F[_]: Sync](


### PR DESCRIPTION
Reduce the exposure of `end` methods for spans by creating a separate `Span.Manual` type returned only by
`SpanOps#startUnmanaged` that contains the `end` methods and removing the `end` methods from `Span`. Neither type inherits from the other, so `Span.Manual` instances must be explicitly converted to `Span` instances for use in general operations.

Resolves #347 