### PR TITLE
trace core: add `TraceState`

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/TraceStateBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/TraceStateBenchmark.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.benchmarks
+
+import io.opentelemetry.api.trace.{TraceState => JTraceState}
+import org.openjdk.jmh.annotations._
+import org.typelevel.otel4s.trace.TraceState
+
+import java.util.concurrent.TimeUnit
+
+// benchmarks/Jmh/run org.typelevel.otel4s.benchmarks.TraceStateBenchmark -prof gc
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Measurement(iterations = 15, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+class TraceStateBenchmark {
+
+  @Benchmark
+  def java_oneItem(): JTraceState = {
+    val builder = JTraceState.builder()
+    builder.put("key1", "val")
+    builder.build()
+  }
+
+  @Benchmark
+  def java_fiveItems(): JTraceState = {
+    val builder = JTraceState.builder()
+    builder.put("key1", "val")
+    builder.put("key2", "val")
+    builder.put("key3", "val")
+    builder.put("key4", "val")
+    builder.put("key5", "val")
+    builder.build()
+  }
+
+  @Benchmark
+  def java_fiveItemsWithRemoval(): JTraceState = {
+    val builder = JTraceState.builder()
+    builder.put("key1", "val")
+    builder.put("key2", "val")
+    builder.put("key3", "val")
+    builder.remove("key2")
+    builder.remove("key3")
+    builder.put("key2", "val")
+    builder.put("key3", "val")
+    builder.put("key4", "val")
+    builder.put("key5", "val")
+    builder.build()
+  }
+
+  @Benchmark
+  def otel4s_oneItem(): TraceState = {
+    TraceState.empty.updated("key1", "val")
+  }
+
+  @Benchmark
+  def otel4s_fiveItems(): TraceState = {
+    TraceState.empty
+      .updated("key1", "val")
+      .updated("key2", "val")
+      .updated("key3", "val")
+      .updated("key4", "val")
+      .updated("key5", "val")
+  }
+
+  @Benchmark
+  def otel4s_fiveItemsWithRemoval(): TraceState = {
+    TraceState.empty
+      .updated("key1", "val")
+      .updated("key2", "val")
+      .updated("key3", "val")
+      .removed("key2")
+      .removed("key3")
+      .updated("key2", "val")
+      .updated("key3", "val")
+      .updated("key4", "val")
+      .updated("key5", "val")
+  }
+}

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanContext.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanContext.scala
@@ -52,6 +52,10 @@ trait SpanContext {
     */
   def traceFlags: TraceFlags
 
+  /** Returns the trace state associated with this [[SpanContext]].
+    */
+  def traceState: TraceState
+
   /** Return `true` if this [[SpanContext]] is sampled.
     */
   final def isSampled: Boolean =
@@ -106,6 +110,7 @@ object SpanContext {
       val spanIdHex: String = SpanId.InvalidHex
       val spanId: ByteVector = ByteVector.fromValidHex(spanIdHex)
       val traceFlags: TraceFlags = TraceFlags.Default
+      val traceState: TraceState = TraceState.empty
       val isValid: Boolean = false
       val isRemote: Boolean = false
     }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceState.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceState.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import cats.Show
+import cats.kernel.Hash
+
+import scala.collection.immutable.ListMap
+import scala.collection.immutable.SeqMap
+
+/** An '''immutable''' representation of the key-value pairs defined by the W3C
+  * Trace Context specification.
+  *
+  * Trace state allows different vendors propagate additional information and
+  * interoperate with their legacy Id formats.
+  *
+  *   - Key is opaque string up to 256 characters printable. It MUST begin with
+  *     a lowercase letter, and can only contain lowercase letters a-z, digits
+  *     0-9, underscores _, dashes -, asterisks *, and forward slashes /.
+  *
+  *   - Value is opaque string up to 256 characters printable ASCII RFC0020
+  *     characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate]]
+  *   [[https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field]]
+  *   [[https://www.w3.org/TR/trace-context/#tracestate-header-field-values]]
+  */
+sealed trait TraceState {
+
+  /** Returns the value to which the specified key is mapped, or `None` if this
+    * map contains no mapping for the key.
+    *
+    * @param key
+    *   with which the specified value is to be associated
+    */
+  def get(key: String): Option[String]
+
+  /** Adds or updates the entry that has the given `key` if it is present. If
+    * either the key or the value is invalid, the entry will not be added.
+    *
+    * @param key
+    *   the key for the entry to be added. Key is an opaque string up to 256
+    *   characters printable. It MUST begin with a lowercase letter, and can
+    *   only contain lowercase letters a-z, digits 0-9, underscores _, dashes -,
+    *   asterisks *, and forward slashes /. For multi-tenant vendor scenarios,
+    *   an at sign (@) can be used to prefix the vendor name. The tenant id
+    *   (before the '@') is limited to 240 characters and the vendor id is
+    *   limited to 13 characters. If in the multi-tenant vendor format, then the
+    *   first character may additionally be numeric.
+    *
+    * @param value
+    *   the value for the entry to be added. Value is opaque string up to 256
+    *   characters printable ASCII RFC0020 characters (i.e., the range 0x20 to
+    *   0x7E) except comma , and =.
+    *
+    * @return
+    *   a new instance of [[TraceState]] with added entry
+    */
+  def updated(key: String, value: String): TraceState
+
+  /** Removes the entry that has the given `key` if it is present.
+    *
+    * @param key
+    *   the key for the entry to be removed.
+    *
+    * @return
+    *   a new instance of [[TraceState]] with removed entry
+    */
+  def removed(key: String): TraceState
+
+  /** Returns the number of entries in this state. */
+  def size: Int
+
+  /** Returns whether this state is empty, containing no entries. */
+  def isEmpty: Boolean
+
+  /** Returns a map representation of this state. */
+  def asMap: SeqMap[String, String]
+
+  override final def hashCode(): Int =
+    Hash[TraceState].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: TraceState => Hash[TraceState].eqv(this, other)
+      case _                 => false
+    }
+
+  override final def toString: String =
+    Show[TraceState].show(this)
+}
+
+object TraceState {
+
+  private val Empty: TraceState = MapBasedTraceState(Vector.empty)
+
+  /** An empty [[TraceState]]. */
+  def empty: TraceState = Empty
+
+  implicit val traceStateHash: Hash[TraceState] =
+    Hash.by((_: TraceState).asMap)(Hash.fromUniversalHashCode)
+
+  implicit val traceStateShow: Show[TraceState] =
+    Show.show { state =>
+      val entries = state.asMap
+        .map { case (key, value) => s"$key=$value" }
+        .mkString("{", ",", "}")
+
+      s"TraceState{entries=$entries}"
+    }
+
+  /** Creates [[TraceState]] from the given map.
+    *
+    * '''Important''': the map entries will not be validated. Use this method
+    * when you 100% sure the entries are valid. For example, when you wrap
+    * OpenTelemetry Java trace state.
+    */
+  private[otel4s] def fromVectorUnsafe(
+      entries: Vector[(String, String)]
+  ): TraceState =
+    MapBasedTraceState(entries)
+
+  private final case class MapBasedTraceState(
+      private val entries: Vector[(String, String)]
+  ) extends TraceState {
+    import Validation._
+
+    lazy val asMap: SeqMap[String, String] =
+      ListMap.from(entries)
+
+    def updated(key: String, value: String): TraceState =
+      if (isKeyValid(key) && isValueValid(value)) {
+        val withoutKey = entries.filterNot(_._1 == key)
+        if (withoutKey.sizeIs < MaxEntries) {
+          copy(entries = withoutKey.prepended(key -> value))
+        } else {
+          this
+        }
+      } else {
+        this
+      }
+
+    def removed(key: String): TraceState =
+      copy(entries = entries.filterNot(_._1 == key))
+
+    def get(key: String): Option[String] =
+      entries.collectFirst { case (k, value) if k == key => value }
+
+    def size: Int = entries.size
+    def isEmpty: Boolean = entries.isEmpty
+  }
+
+  private object Validation {
+    final val MaxEntries = 32
+    private final val KeyMaxSize = 256
+    private final val ValueMaxSize = 256
+    private final val TenantIdMaxSize = 240
+    private final val VendorIdSize = 13
+
+    /** Key is an opaque string up to 256 characters printable. It MUST begin
+      * with a lowercase letter, and can only contain lowercase letters a-z,
+      * digits 0-9, underscores _, dashes -, asterisks *, and forward slashes /.
+      * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix
+      * the vendor name. The tenant id (before the '@') is limited to 240
+      * characters and the vendor id is limited to 13 characters. If in the
+      * multi-tenant vendor format, then the first character may additionally be
+      * numeric.
+      *
+      * @see
+      *   [[https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate]]
+      *   [[https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field]]
+      *   [[https://www.w3.org/TR/trace-context/#tracestate-header-field-values]]
+      */
+    def isKeyValid(key: String): Boolean = {
+      val length = key.length
+
+      // _1 - valid or not
+      // _2 - isMultiTenant
+      @scala.annotation.tailrec
+      def loop(idx: Int, isMultiTenant: Boolean): (Boolean, Boolean) = {
+        if (idx < length) {
+          val char = key.charAt(idx)
+
+          if (char == '@') {
+            // you can't have 2 '@' signs
+            if (isMultiTenant) {
+              (false, isMultiTenant)
+              // tenant id (the part to the left of the '@' sign) must be 240 characters or less
+            } else if (idx > TenantIdMaxSize) {
+              (false, isMultiTenant)
+            } else {
+              // vendor id (the part to the right of the '@' sign) must be 1-13 characters long
+              val remaining = length - idx - 1
+              if (remaining > VendorIdSize || remaining == 0)
+                (false, isMultiTenant)
+              else loop(idx + 1, isMultiTenant = true)
+            }
+          } else {
+            if (isValidKeyChar(char)) loop(idx + 1, isMultiTenant)
+            else (false, isMultiTenant)
+          }
+        } else {
+          (true, isMultiTenant)
+        }
+      }
+
+      @inline def isValidFirstChar: Boolean =
+        key.charAt(0).isDigit || isLowercaseLetter(key.charAt(0))
+
+      @inline def isValidKey: Boolean = {
+        val (isValid, isMultiTenant) = loop(1, isMultiTenant = false)
+        // if it's not the vendor format (with an '@' sign), the key must start with a letter
+        isValid && (isMultiTenant || isLowercaseLetter(key.charAt(0)))
+      }
+
+      length > 0 && length <= KeyMaxSize && isValidFirstChar && isValidKey
+    }
+
+    @inline private def isLowercaseLetter(char: Char): Boolean =
+      char >= 'a' && char <= 'z'
+
+    @inline private def isValidKeyChar(char: Char): Boolean =
+      char.isDigit ||
+        isLowercaseLetter(char) ||
+        char == '_' ||
+        char == '-' ||
+        char == '*' ||
+        char == '/'
+
+    /** Value is opaque string up to 256 characters printable ASCII RFC0020
+      * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+      */
+    @inline def isValueValid(value: String): Boolean = {
+      val length = value.length
+      length > 0 && length <= ValueMaxSize && value.forall { char =>
+        char >= 0x20 && char <= 0x7e && char != ',' && char != '='
+      }
+    }
+  }
+
+}

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceStateSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TraceStateSuite.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+
+class TraceStateSuite extends DisciplineSuite {
+
+  private val MaxEntries = 32
+  private val StrMaxSize = 256
+
+  private val keyAllowedFirstChar: Gen[Char] =
+    Gen.alphaLowerChar
+
+  private val keyAllowedChars: Gen[Char] =
+    Gen.oneOf(
+      Gen.alphaLowerChar,
+      Gen.numChar,
+      Gen.const('_'),
+      Gen.const('-'),
+      Gen.const('*'),
+      Gen.const('/')
+    )
+
+  private val keyGen: Gen[String] =
+    for {
+      first <- keyAllowedFirstChar
+      rest <- Gen.stringOfN(StrMaxSize - 1, keyAllowedChars)
+    } yield first +: rest
+
+  /** Value is opaque string up to 256 characters printable ASCII RFC0020
+    * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+    */
+  private val valueGen: Gen[String] = {
+    val comma = ','.toInt
+    val eq = '='.toInt
+
+    val allowed =
+      Gen.oneOf(0x20.to(0x7e).filter(c => c != comma && c != eq).map(_.toChar))
+
+    Gen.stringOfN(StrMaxSize, allowed)
+  }
+
+  private val keyValueGen: Gen[(String, String)] =
+    for {
+      key <- keyGen
+      value <- valueGen
+    } yield (key, value)
+
+  private implicit val traceStateArbitrary: Arbitrary[TraceState] =
+    Arbitrary(
+      for {
+        entries <- Gen.listOfN(5, keyValueGen)
+      } yield entries.foldLeft(TraceState.empty)((b, v) =>
+        b.updated(v._1, v._2)
+      )
+    )
+
+  private implicit val traceStateCogen: Cogen[TraceState] =
+    Cogen[Map[String, String]].contramap(_.asMap)
+
+  checkAll("TraceState.HashLaws", HashTests[TraceState].hash)
+
+  test("add entries") {
+    Prop.forAll(keyGen, valueGen) { (key, value) =>
+      val state = TraceState.empty.updated(key, value)
+
+      assertEquals(state.asMap, Map(key -> value))
+      assertEquals(state.size, 1)
+      assertEquals(state.isEmpty, false)
+      assertEquals(state.get(key), Some(value))
+    }
+  }
+
+  test("update entries") {
+    Prop.forAll(keyGen, valueGen, valueGen) { (key, value1, value2) =>
+      val state = TraceState.empty.updated(key, value1).updated(key, value2)
+
+      assertEquals(state.asMap, Map(key -> value2))
+      assertEquals(state.size, 1)
+      assertEquals(state.isEmpty, false)
+      assertEquals(state.get(key), Some(value2))
+    }
+  }
+
+  test("remove entries") {
+    Prop.forAll(keyGen, valueGen) { (key, value) =>
+      val state = TraceState.empty.updated(key, value).removed(key)
+
+      assertEquals(state.asMap, Map.empty[String, String])
+      assertEquals(state.size, 0)
+      assertEquals(state.isEmpty, true)
+      assertEquals(state.get(key), None)
+    }
+  }
+
+  test("ignore 'put' once the limit of entries is reached") {
+    Prop.forAll(Gen.listOfN(50, keyValueGen)) { entries =>
+      val state = entries.foldLeft(TraceState.empty) {
+        case (builder, (key, value)) => builder.updated(key, value)
+      }
+
+      assertEquals(state.asMap, entries.take(MaxEntries).toMap)
+      assertEquals(state.size, MaxEntries)
+      assertEquals(state.isEmpty, false)
+
+      entries.take(MaxEntries).foreach { case (key, value) =>
+        assertEquals(state.get(key), Some(value))
+      }
+    }
+  }
+
+  test("ignore invalid keys: empty string") {
+    val state = TraceState.empty.updated("", "some-value")
+    assertEquals(state.isEmpty, true)
+  }
+
+  // a digit is only allowed if the key is in the tenant format (with an '@')
+  test("ignore invalid keys: first char is digit") {
+    Prop.forAll(Gen.numStr, valueGen) { (key, value) =>
+      val state = TraceState.empty.updated(key, value)
+      assertEquals(state.isEmpty, true)
+    }
+  }
+
+  test("ignore invalid keys: vendor id length > 13") {
+    val state = TraceState.empty.updated("1@abcdefghijklmn", "value")
+    assertEquals(state.isEmpty, true)
+  }
+
+  test("ignore invalid keys: key length > 256") {
+    val key = new String(Array.fill(StrMaxSize + 1)('a'))
+    val state = TraceState.empty.updated(key, "value")
+    assertEquals(state.isEmpty, true)
+  }
+
+  test("ignore invalid keys: multiple @ signs") {
+    val state = TraceState.empty.updated("1@b@c", "value")
+    assertEquals(state.isEmpty, true)
+  }
+
+  test("allow valid keys: first digit is char (tenant format)") {
+    Prop.forAll(Gen.numChar, valueGen) { (key, value) =>
+      val state = TraceState.empty.updated(s"$key@tenant", value)
+
+      assertEquals(state.isEmpty, false)
+      assertEquals(state.get(s"$key@tenant"), Some(value))
+    }
+  }
+
+  test("allow valid keys: vendor id length <= 13") {
+    val state = TraceState.empty.updated("1@abcdefghijklm", "value")
+    assertEquals(state.size, 1)
+  }
+
+  test("ignore invalid values: value length > 256") {
+    val value = new String(Array.fill(StrMaxSize + 1)('a'))
+    val state = TraceState.empty.updated("key", value)
+    assertEquals(state.isEmpty, true)
+  }
+
+  test("preserve order of inserted entries") {
+    val state = TraceState.empty
+      .updated("a", "value_a")
+      .updated("b", "value_b")
+      .updated("c", "value_c")
+      .updated("a", "value_a_2")
+
+    val expected = List(
+      "a" -> "value_a_2",
+      "c" -> "value_c",
+      "b" -> "value_b"
+    )
+
+    assertEquals(state.asMap.toList, expected)
+  }
+
+  test("Show[TraceState]") {
+    Prop.forAll(Gen.listOfN(5, keyValueGen)) { entries =>
+      val state = entries.foldLeft(TraceState.empty) {
+        case (builder, (key, value)) => builder.updated(key, value)
+      }
+
+      val entriesString = entries.reverse
+        .map { case (key, value) => s"$key=$value" }
+        .mkString("{", ",", "}")
+
+      val expected = s"TraceState{entries=$entriesString}"
+
+      assertEquals(Show[TraceState].show(state), expected)
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate </br> https://www.w3.org/TR/trace-context/#tracestate-header-field-values |
| Java implementation | [TraceState.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/trace/TraceState.java) </br> [ArrayBasedTraceStateBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/trace/ArrayBasedTraceStateBuilder.java) |

____

### Benchmarks

Our implementation is ~30-40% slower than Java.   
Also, for whatever reason, `otel4s_oneItem` is 10 times faster ¯\_(ツ)_/¯.
I would say the current performance is acceptable. And we can always rewrite it using an array under the hood if we want. 

```
[info] Benchmark                                       Mode  Cnt      Score     Error   Units
[info] TraceStateBenchmark.java_oneItem                avgt   15     23.276 ±   0.159   ns/op
[info] TraceStateBenchmark.java_fiveItems              avgt   15    103.876 ±   2.339   ns/op
[info] TraceStateBenchmark.java_fiveItemsWithRemoval   avgt   15    140.407 ±   0.746   ns/op
[info] TraceStateBenchmark.otel4s_oneItem              avgt   15      2.238 ±   0.058   ns/op
[info] TraceStateBenchmark.otel4s_fiveItems            avgt   15    148.937 ±   2.777   ns/op
[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval avgt   15    226.421 ±   2.082   ns/op
```

<details>
<summary>
Benchmarks with memory usage
</summary>

```
[info] TraceStateBenchmark.java_oneItem                                    avgt   15     23.276 ±   0.159   ns/op
[info] TraceStateBenchmark.java_oneItem:gc.alloc.rate                      avgt   15   6882.467 ±  46.973  MB/sec
[info] TraceStateBenchmark.java_oneItem:gc.alloc.rate.norm                 avgt   15    168.000 ±   0.001    B/op
[info] TraceStateBenchmark.java_oneItem:gc.count                           avgt   15    243.000            counts
[info] TraceStateBenchmark.java_oneItem:gc.time                            avgt   15    119.000                ms

[info] TraceStateBenchmark.otel4s_oneItem                                  avgt   15      2.238 ±   0.058   ns/op
[info] TraceStateBenchmark.otel4s_oneItem:gc.alloc.rate                    avgt   15  17046.819 ± 429.056  MB/sec
[info] TraceStateBenchmark.otel4s_oneItem:gc.alloc.rate.norm               avgt   15     40.000 ±   0.001    B/op
[info] TraceStateBenchmark.otel4s_oneItem:gc.count                         avgt   15    422.000            counts
[info] TraceStateBenchmark.otel4s_oneItem:gc.time                          avgt   15    238.000                ms



[info] Benchmark                                                           Mode  Cnt      Score     Error   Units
[info] TraceStateBenchmark.java_fiveItems                                  avgt   15    103.876 ±   2.339   ns/op
[info] TraceStateBenchmark.java_fiveItems:gc.alloc.rate                    avgt   15   1836.585 ±  40.067  MB/sec
[info] TraceStateBenchmark.java_fiveItems:gc.alloc.rate.norm               avgt   15    200.000 ±   0.001    B/op
[info] TraceStateBenchmark.java_fiveItems:gc.count                         avgt   15     93.000            counts
[info] TraceStateBenchmark.java_fiveItems:gc.time                          avgt   15     66.000                ms

[info] TraceStateBenchmark.otel4s_fiveItems                                avgt   15    148.937 ±   2.777   ns/op
[info] TraceStateBenchmark.otel4s_fiveItems:gc.alloc.rate                  avgt   15   5071.861 ±  92.596  MB/sec
[info] TraceStateBenchmark.otel4s_fiveItems:gc.alloc.rate.norm             avgt   15    792.000 ±   0.001    B/op
[info] TraceStateBenchmark.otel4s_fiveItems:gc.count                       avgt   15    255.000            counts
[info] TraceStateBenchmark.otel4s_fiveItems:gc.time                        avgt   15    120.000                ms



[info] TraceStateBenchmark.java_fiveItemsWithRemoval                       avgt   15    140.407 ±   0.746   ns/op
[info] TraceStateBenchmark.java_fiveItemsWithRemoval:gc.alloc.rate         avgt   15   1358.169 ±   7.128  MB/sec
[info] TraceStateBenchmark.java_fiveItemsWithRemoval:gc.alloc.rate.norm    avgt   15    200.000 ±   0.001    B/op
[info] TraceStateBenchmark.java_fiveItemsWithRemoval:gc.count              avgt   15     68.000            counts
[info] TraceStateBenchmark.java_fiveItemsWithRemoval:gc.time               avgt   15     33.000                ms

[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval                     avgt   15    226.421 ±   2.082   ns/op
[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval:gc.alloc.rate       avgt   15   3133.237 ±  28.502  MB/sec
[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval:gc.alloc.rate.norm  avgt   15    744.000 ±   0.001    B/op
[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval:gc.count            avgt   15    158.000            counts
[info] TraceStateBenchmark.otel4s_fiveItemsWithRemoval:gc.time             avgt   15     75.000                ms
```

</details>