### PR TITLE
Apply `@threadUnsafe3` annotation to `lazy val`s

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceState.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/TraceState.scala
@@ -18,6 +18,7 @@ package org.typelevel.otel4s.trace
 
 import cats.Show
 import cats.kernel.Hash
+import org.typelevel.scalaccompat.annotation.threadUnsafe3
 
 import scala.collection.immutable.ListMap
 import scala.collection.immutable.SeqMap
@@ -140,6 +141,7 @@ object TraceState {
   ) extends TraceState {
     import Validation._
 
+    @threadUnsafe3
     lazy val asMap: SeqMap[String, String] =
       ListMap.from(entries)
 

--- a/java/common/src/main/scala/org/typelevel/otel4s/java/TextMapPropagatorImpl.scala
+++ b/java/common/src/main/scala/org/typelevel/otel4s/java/TextMapPropagatorImpl.scala
@@ -25,12 +25,14 @@ import org.typelevel.otel4s.context.propagation.TextMapPropagator
 import org.typelevel.otel4s.context.propagation.TextMapUpdater
 import org.typelevel.otel4s.java.Conversions._
 import org.typelevel.otel4s.java.context.Context
+import org.typelevel.scalaccompat.annotation.threadUnsafe3
 
 import scala.jdk.CollectionConverters._
 
 private[java] class TextMapPropagatorImpl(
     jPropagator: JTextMapPropagator
 ) extends TextMapPropagator[Context] {
+  @threadUnsafe3
   lazy val fields: Iterable[String] =
     jPropagator.fields().asScala
 

--- a/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
+++ b/java/trace/src/main/scala/org/typelevel/otel4s/java/trace/WrappedSpanContext.scala
@@ -22,27 +22,32 @@ import io.opentelemetry.api.trace.{TraceState => JTraceState}
 import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.TraceFlags
 import org.typelevel.otel4s.trace.TraceState
+import org.typelevel.scalaccompat.annotation.threadUnsafe3
 import scodec.bits.ByteVector
 
 private[java] final case class WrappedSpanContext(
     jSpanContext: JSpanContext
 ) extends SpanContext {
 
+  @threadUnsafe3
   lazy val traceId: ByteVector =
     ByteVector(jSpanContext.getTraceIdBytes)
 
   def traceIdHex: String =
     jSpanContext.getTraceId
 
+  @threadUnsafe3
   lazy val spanId: ByteVector =
     ByteVector(jSpanContext.getSpanIdBytes)
 
   def spanIdHex: String =
     jSpanContext.getSpanId
 
+  @threadUnsafe3
   lazy val traceFlags: TraceFlags =
     TraceFlags.fromByte(jSpanContext.getTraceFlags.asByte)
 
+  @threadUnsafe3
   lazy val traceState: TraceState = {
     val entries = Vector.newBuilder[(String, String)]
     jSpanContext.getTraceState.forEach((k, v) => entries.addOne(k -> v))


### PR DESCRIPTION
To avoid unnecessary synchronization for lazily initializing pure values.

https://scala-lang.org/api/3.x/scala/annotation/threadUnsafe.html#