### PR TITLE
sdk-trace: add `SpanData`

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk
+package trace
+package data
+
+import cats.Hash
+import cats.Show
+import cats.syntax.foldable._
+import cats.syntax.show._
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.SpanKind
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Immutable representation of all data collected by the
+  * [[org.typelevel.otel4s.trace.Span Span]].
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/trace/api/#span]]
+  */
+sealed trait SpanData {
+
+  /** The name of the span.
+    */
+  def name: String
+
+  /** The span context associated with this span.
+    */
+  def spanContext: SpanContext
+
+  /** The parent span context, if any.
+    */
+  def parentSpanContext: Option[SpanContext]
+
+  /** The kind of the span.
+    */
+  def kind: SpanKind
+
+  /** The start timestamp of the span.
+    */
+  def startTimestamp: FiniteDuration
+
+  /** The end time of the span.
+    */
+  def endTimestamp: Option[FiniteDuration]
+
+  /** The status data of the span.
+    */
+  def status: StatusData
+
+  /** The attributes associated with the span.
+    */
+  def attributes: Attributes
+
+  /** The events associated with the span.
+    */
+  def events: List[EventData]
+
+  /** The links associated with the span.
+    */
+  def links: List[LinkData]
+
+  /** The instrumentation scope associated with the span.
+    */
+  def instrumentationScope: InstrumentationScope
+
+  /** The resource associated with the span.
+    */
+  def resource: Resource
+
+  /** Whether the span has ended.
+    */
+  final def hasEnded: Boolean = endTimestamp.isDefined
+
+  override final def hashCode(): Int =
+    Hash[SpanData].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: SpanData => Hash[SpanData].eqv(this, other)
+      case _               => false
+    }
+
+  override final def toString: String =
+    Show[SpanData].show(this)
+}
+
+object SpanData {
+
+  /** Creates [[SpanData]] with the given arguments.
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param spanContext
+    *   the span context associated with the span
+    *
+    * @param parentSpanContext
+    *   an optional parent span context. Use `None` if there is no parent span
+    *   context
+    *
+    * @param kind
+    *   the kind of the span
+    *
+    * @param startTimestamp
+    *   the start timestamp of the span
+    *
+    * @param endTimestamp
+    *   the end timestamp of the span. Use `None` is the span hasn't ended yet
+    *
+    * @param status
+    *   the status data of the span
+    *
+    * @param attributes
+    *   the attributes associated with the span
+    *
+    * @param events
+    *   the events associated with the span
+    *
+    * @param links
+    *   the links associated with the span
+    *
+    * @param instrumentationScope
+    *   the instrumentation scope associated with the span
+    *
+    * @param resource
+    *   the resource associated with the span
+    */
+  def apply(
+      name: String,
+      spanContext: SpanContext,
+      parentSpanContext: Option[SpanContext],
+      kind: SpanKind,
+      startTimestamp: FiniteDuration,
+      endTimestamp: Option[FiniteDuration],
+      status: StatusData,
+      attributes: Attributes,
+      events: List[EventData],
+      links: List[LinkData],
+      instrumentationScope: InstrumentationScope,
+      resource: Resource
+  ): SpanData =
+    Impl(
+      name = name,
+      spanContext = spanContext,
+      parentSpanContext = parentSpanContext,
+      kind = kind,
+      startTimestamp = startTimestamp,
+      endTimestamp = endTimestamp,
+      status = status,
+      attributes = attributes,
+      events = events,
+      links = links,
+      instrumentationScope = instrumentationScope,
+      resource = resource
+    )
+
+  implicit val spanDataHash: Hash[SpanData] =
+    Hash.by { data =>
+      (
+        data.name,
+        data.spanContext,
+        data.parentSpanContext,
+        data.kind,
+        data.startTimestamp,
+        data.endTimestamp,
+        data.status,
+        data.attributes,
+        data.events,
+        data.links,
+        data.instrumentationScope,
+        data.resource
+      )
+    }
+
+  implicit val spanDataShow: Show[SpanData] =
+    Show.show { data =>
+      val endTimestamp =
+        data.endTimestamp.foldMap(ts => show"endTimestamp=$ts, ")
+
+      show"SpanData{" +
+        show"name=${data.name}, " +
+        show"spanContext=${data.spanContext}, " +
+        show"parentSpanContext=${data.parentSpanContext}, " +
+        show"kind=${data.kind}, " +
+        show"startTimestamp=${data.startTimestamp}, " +
+        endTimestamp +
+        show"hasEnded=${data.hasEnded}, " +
+        show"status=${data.status}, " +
+        show"attributes=${data.attributes}, " +
+        show"events=${data.events}, " +
+        show"links=${data.links}, " +
+        show"instrumentationScope=${data.instrumentationScope}, " +
+        show"resource=${data.resource}}"
+    }
+
+  private final case class Impl(
+      name: String,
+      spanContext: SpanContext,
+      parentSpanContext: Option[SpanContext],
+      kind: SpanKind,
+      startTimestamp: FiniteDuration,
+      endTimestamp: Option[FiniteDuration],
+      status: StatusData,
+      attributes: Attributes,
+      events: List[EventData],
+      links: List[LinkData],
+      instrumentationScope: InstrumentationScope,
+      resource: Resource
+  ) extends SpanData
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LinkDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LinkDataSuite.scala
@@ -22,34 +22,18 @@ import cats.kernel.laws.discipline.HashTests
 import cats.syntax.show._
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary
-import org.scalacheck.Cogen
-import org.scalacheck.Gen
 import org.scalacheck.Prop
-import org.typelevel.otel4s.sdk.Attributes
-import org.typelevel.otel4s.trace.SpanContext
 
 class LinkDataSuite extends DisciplineSuite {
-  import Cogens.attributesCogen
-  import Cogens.spanContextCogen
-
-  private val linkDataGen: Gen[LinkData] =
-    for {
-      spanContext <- Gens.spanContext
-      attributes <- Gens.attributes
-    } yield LinkData(spanContext, attributes)
+  import Cogens.linkDataCogen
 
   private implicit val linkDataArbitrary: Arbitrary[LinkData] =
-    Arbitrary(linkDataGen)
-
-  private implicit val linkDataCogen: Cogen[LinkData] =
-    Cogen[(SpanContext, Attributes)].contramap(s =>
-      (s.spanContext, s.attributes)
-    )
+    Arbitrary(Gens.linkData)
 
   checkAll("LinkData.HashLaws", HashTests[LinkData].hash)
 
   test("Show[LinkData]") {
-    Prop.forAll(linkDataGen) { data =>
+    Prop.forAll(Gens.linkData) { data =>
       val expected =
         show"LinkData{spanContext=${data.spanContext}, attributes=${data.attributes}}"
 
@@ -58,7 +42,7 @@ class LinkDataSuite extends DisciplineSuite {
   }
 
   test("create LinkData with given arguments") {
-    Prop.forAll(linkDataGen) { data =>
+    Prop.forAll(Gens.linkData) { data =>
       assertEquals(LinkData(data.spanContext, data.attributes), data)
     }
   }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/SpanDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/SpanDataSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+package data
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import cats.syntax.foldable._
+import cats.syntax.show._
+import munit.DisciplineSuite
+import munit.internal.PlatformCompat
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Test
+
+class SpanDataSuite extends DisciplineSuite {
+  import Cogens.spanDataCogen
+
+  private implicit val spanDataArbitrary: Arbitrary[SpanData] =
+    Arbitrary(Gens.spanData)
+
+  checkAll("SpanData.HashLaws", HashTests[SpanData].hash)
+
+  test("Show[SpanData]") {
+    Prop.forAll(Gens.spanData) { data =>
+      val endedEpoch = data.endTimestamp.foldMap(ts => show"endTimestamp=$ts, ")
+
+      val expected =
+        show"SpanData{" +
+          show"name=${data.name}, " +
+          show"spanContext=${data.spanContext}, " +
+          show"parentSpanContext=${data.parentSpanContext}, " +
+          show"kind=${data.kind}, " +
+          show"startTimestamp=${data.startTimestamp}, " +
+          endedEpoch +
+          show"hasEnded=${data.hasEnded}, " +
+          show"status=${data.status}, " +
+          show"attributes=${data.attributes}, " +
+          show"events=${data.events}, " +
+          show"links=${data.links}, " +
+          show"instrumentationScope=${data.instrumentationScope}, " +
+          show"resource=${data.resource}}"
+
+      assertEquals(Show[SpanData].show(data), expected)
+    }
+  }
+
+  test("create SpanData with given arguments") {
+    Prop.forAll(Gens.spanData) { data =>
+      val created = SpanData(
+        name = data.name,
+        spanContext = data.spanContext,
+        parentSpanContext = data.parentSpanContext,
+        kind = data.kind,
+        startTimestamp = data.startTimestamp,
+        endTimestamp = data.endTimestamp,
+        status = data.status,
+        attributes = data.attributes,
+        events = data.events,
+        links = data.links,
+        instrumentationScope = data.instrumentationScope,
+        resource = data.resource
+      )
+
+      assertEquals(created, data)
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    if (PlatformCompat.isJVM)
+      super.scalaCheckTestParameters
+    else
+      super.scalaCheckTestParameters
+        .withMinSuccessfulTests(10)
+        .withMaxSize(10)
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/StatusDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/StatusDataSuite.scala
@@ -14,45 +14,27 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.sdk.trace.data
+package org.typelevel.otel4s.sdk.trace
+package data
 
 import cats.Show
 import cats.kernel.laws.discipline.HashTests
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary
-import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.scalacheck.Prop
 import org.typelevel.otel4s.trace.Status
 
 class StatusDataSuite extends DisciplineSuite {
-
-  private val statusGen: Gen[Status] =
-    Gen.oneOf(Status.Ok, Status.Error, Status.Unset)
-
-  private val statusDataGen: Gen[StatusData] =
-    for {
-      description <- Gen.alphaNumStr
-      data <- Gen.oneOf(
-        StatusData.Ok,
-        StatusData.Unset,
-        StatusData.Error(Some(description))
-      )
-    } yield data
+  import Cogens.statusDataCogen
 
   private implicit val statusDataArbitrary: Arbitrary[StatusData] =
-    Arbitrary(statusDataGen)
-
-  private implicit val statusCogen: Cogen[Status] =
-    Cogen[String].contramap(_.toString)
-
-  private implicit val statusDataCogen: Cogen[StatusData] =
-    Cogen[(Status, Option[String])].contramap(s => (s.status, s.description))
+    Arbitrary(Gens.statusData)
 
   checkAll("StatusData.HashLaws", HashTests[StatusData].hash)
 
   test("Show[StatusData]") {
-    Prop.forAll(statusDataGen) { data =>
+    Prop.forAll(Gens.statusData) { data =>
       val expected = data match {
         case StatusData.Ok          => "StatusData{status=Ok}"
         case StatusData.Unset       => "StatusData{status=Unset}"
@@ -86,7 +68,7 @@ class StatusDataSuite extends DisciplineSuite {
   }
 
   test("create StatusData from a given status") {
-    Prop.forAll(statusGen) { status =>
+    Prop.forAll(Gens.status) { status =>
       val expected = status match {
         case Status.Ok    => StatusData.Ok
         case Status.Error => StatusData.Error(None)


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/trace/api/#span |
| Java implementation | [SpanData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/data/SpanData.java) |

The last `*Data` model.