### PR TITLE
sdk-trace: add `SpanProcessor`

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanProcessor.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanProcessor.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk.trace
+
+import cats.Applicative
+import cats.Monoid
+import cats.Parallel
+import cats.data.NonEmptyList
+import cats.syntax.foldable._
+import cats.syntax.parallel._
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.trace.SpanContext
+
+/** The interface that tracer uses to invoke hooks when a span is started or
+  * ended.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+trait SpanProcessor[F[_]] {
+
+  /** Called when a span is started, if the `span.isRecording` returns true.
+    *
+    * This method is called synchronously on the execution thread, should not
+    * throw or block the execution thread.
+    *
+    * @param parentContext
+    *   the optional parent [[trace.SpanContext SpanContext]]
+    *
+    * @param span
+    *   the started span
+    */
+  def onStart(parentContext: Option[SpanContext], span: SpanRef[F]): F[Unit]
+
+  /** Whether the [[SpanProcessor]] requires start events.
+    *
+    * If true, the [[onStart]] will be called upon the start of a span.
+    */
+  def isStartRequired: Boolean
+
+  /** Called when a span is ended, if the `span.isRecording` returns true.
+    *
+    * This method is called synchronously on the execution thread, should not
+    * throw or block the execution thread.
+    *
+    * @param span
+    *   the ended span
+    */
+  def onEnd(span: SpanData): F[Unit]
+
+  /** Whether the [[SpanProcessor]] requires end events.
+    *
+    * If true, the [[onEnd]] will be called upon the end of a span.
+    */
+  def isEndRequired: Boolean
+
+  /** Processes all pending spans (if any).
+    */
+  def forceFlush: F[Unit]
+}
+
+object SpanProcessor {
+
+  /** Creates a [[SpanProcessor]] which delegates all processing to the
+    * processors in order.
+    */
+  def of[F[_]: Applicative: Parallel](
+      processors: SpanProcessor[F]*
+  ): SpanProcessor[F] =
+    if (processors.sizeIs == 1) processors.head
+    else processors.combineAll
+
+  /** Creates a no-op implementation of the [[SpanProcessor]].
+    *
+    * All export operations are no-op.
+    */
+  def noop[F[_]: Applicative]: SpanProcessor[F] =
+    new Noop
+
+  implicit def spanProcessorMonoid[F[_]: Applicative: Parallel]
+      : Monoid[SpanProcessor[F]] =
+    new Monoid[SpanProcessor[F]] {
+      val empty: SpanProcessor[F] =
+        noop[F]
+
+      def combine(x: SpanProcessor[F], y: SpanProcessor[F]): SpanProcessor[F] =
+        (x, y) match {
+          case (that, _: Noop[F]) =>
+            that
+          case (_: Noop[F], other) =>
+            other
+          case (that: Multi[F], other: Multi[F]) =>
+            Multi(that.processors.concatNel(other.processors))
+          case (that: Multi[F], other) =>
+            Multi(that.processors :+ other)
+          case (that, other: Multi[F]) =>
+            Multi(that :: other.processors)
+          case (that, other) =>
+            Multi(NonEmptyList.of(that, other))
+        }
+    }
+
+  private final class Noop[F[_]: Applicative] extends SpanProcessor[F] {
+    def isStartRequired: Boolean = false
+    def isEndRequired: Boolean = false
+
+    def onStart(parentCtx: Option[SpanContext], span: SpanRef[F]): F[Unit] =
+      Applicative[F].unit
+
+    def onEnd(span: SpanData): F[Unit] =
+      Applicative[F].unit
+
+    def forceFlush: F[Unit] =
+      Applicative[F].unit
+
+    override def toString: String = "SpanProcessor.Noop"
+  }
+
+  private final case class Multi[F[_]: Parallel](
+      processors: NonEmptyList[SpanProcessor[F]]
+  ) extends SpanProcessor[F] {
+    private val startOnly: List[SpanProcessor[F]] =
+      processors.filter(_.isStartRequired)
+
+    private val endOnly: List[SpanProcessor[F]] =
+      processors.filter(_.isEndRequired)
+
+    def isStartRequired: Boolean = startOnly.nonEmpty
+    def isEndRequired: Boolean = endOnly.nonEmpty
+
+    def onStart(parentCtx: Option[SpanContext], span: SpanRef[F]): F[Unit] =
+      startOnly.parTraverse_(_.onStart(parentCtx, span))
+
+    def onEnd(span: SpanData): F[Unit] =
+      endOnly.parTraverse_(_.onEnd(span))
+
+    def forceFlush: F[Unit] =
+      processors.parTraverse_(_.forceFlush)
+
+    override def toString: String =
+      s"SpanProcessor.Multi(${processors.map(_.toString).mkString_(", ")})"
+  }
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanRef.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanRef.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk
+package trace
+
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.SpanKind
+
+import scala.concurrent.duration.FiniteDuration
+
+/** An extended Span interface that provides access to internal state.
+  *
+  * Since the span's internal state can be mutated during the lifetime, some
+  * operations are effectful.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+trait SpanRef[F[_]] { self: Span.Backend[F] =>
+
+  /** Returns the kind of the span. */
+  def kind: SpanKind
+
+  /** Returns the instrumentation scope specified when creating the tracer which
+    * produced this span.
+    */
+  def scopeInfo: InstrumentationScope
+
+  /** Returns the parent's span context of the span. */
+  def parentSpanContext: Option[SpanContext]
+
+  /** Returns the name of the span.
+    *
+    * '''Note''': the name of the span can be changed during the lifetime of the
+    * span by using
+    * [[org.typelevel.otel4s.trace.Span.updateName Span.updateName]], so this
+    * value cannot be cached.
+    */
+  def name: F[String]
+
+  /** Returns an immutable instance of the [[data.SpanData SpanData]], for use
+    * in export.
+    */
+  def toSpanData: F[SpanData]
+
+  /** Indicates whether the span has already been ended. */
+  def hasEnded: F[Boolean]
+
+  /** Returns the duration of the span.
+    *
+    * If still active then returns `Clock[F].realTime - start` time.
+    */
+  def duration: F[FiniteDuration]
+
+  /** Returns the attribute value for the given `key`. Returns `None` if the key
+    * is absent in the storage.
+    *
+    * '''Note''': the attribute values can be changed during the lifetime of the
+    * span by using
+    * [[org.typelevel.otel4s.trace.Span.addAttribute Span.addAttribute]], so
+    * this value cannot be cached.
+    */
+  def getAttribute[A](key: AttributeKey[A]): F[Option[A]]
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanProcessorSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.effect.IO
+import munit.FunSuite
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.trace.SpanContext
+
+class SpanProcessorSuite extends FunSuite {
+
+  test("create a no-op instance") {
+    val processor = SpanProcessor.noop[IO]
+
+    assertEquals(processor.toString, "SpanProcessor.Noop")
+  }
+
+  test("of (empty input) - use noop") {
+    val composite = SpanProcessor.of[IO]()
+
+    assertEquals(composite.toString, "SpanProcessor.Noop")
+  }
+
+  test("of (single input) - use this input") {
+    val processor = SpanProcessor.of(testProcessor("test"))
+
+    assertEquals(processor.toString, "test")
+  }
+
+  test("of (multiple) - create a multi instance") {
+    val processorA = SpanProcessor.of(testProcessor("testA"))
+    val processorB = SpanProcessor.of(testProcessor("testB"))
+
+    val composite = SpanProcessor.of(processorA, processorB)
+
+    assertEquals(composite.toString, "SpanProcessor.Multi(testA, testB)")
+  }
+
+  test("of (multiple) - flatten out nested multi instances") {
+    val processorA = SpanProcessor.of(testProcessor("testA"))
+    val processorB = SpanProcessor.of(testProcessor("testB"))
+
+    val composite1 = SpanProcessor.of(processorA, processorB)
+    val composite2 = SpanProcessor.of(processorA, processorB)
+
+    val composite = SpanProcessor.of(composite1, composite2)
+
+    assertEquals(
+      composite.toString,
+      "SpanProcessor.Multi(testA, testB, testA, testB)"
+    )
+  }
+
+  private def testProcessor(name: String): SpanProcessor[IO] =
+    new SpanProcessor[IO] {
+      def onStart(
+          parentContext: Option[SpanContext],
+          span: SpanRef[IO]
+      ): IO[Unit] =
+        IO.unit
+
+      def isStartRequired: Boolean =
+        false
+
+      def onEnd(span: SpanData): IO[Unit] =
+        IO.unit
+
+      def isEndRequired: Boolean =
+        false
+
+      def forceFlush: IO[Unit] =
+        IO.unit
+
+      override def toString: String = name
+    }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor |
| Java implementation | [SpanProcessor.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java) <br>  [ReadWriteSpan.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/ReadWriteSpan.java) <br> [ReadableSpan.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/ReadableSpan.java) |


### Why do we need a `SpanRef`?

Some `SpanProcessor`s may require access to the **internal** state of a span (e.g. actual name, SpanData, etc). The changes made to the span must be accessible by the processor. For example, we can implement a span leak detector that determines whether the span is leaked based on the state.

P.S. Java SDK calls the interface `ReadableSpan` rather than `SpanRef`. So, I'm open to better name suggestions :) 
