### PR TITLE
IdGeneratorSuite: reduce the number of attempts

### DIFF
--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/IdGeneratorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/IdGeneratorSuite.scala
@@ -22,7 +22,7 @@ import munit.CatsEffectSuite
 import org.typelevel.otel4s.trace.SpanContext
 
 class IdGeneratorSuite extends CatsEffectSuite {
-  private val Attempts = 1_000_000
+  private val Attempts = 100_000
 
   generatorTest("generate a valid trace id") { generator =>
     generator.generateTraceId


### PR DESCRIPTION
The tests are timing out on JS and Native platforms occasionally.