### PR TITLE
Redefine `Resource` as a sealed trait

### DIFF
--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/Resource.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/Resource.scala
@@ -20,109 +20,156 @@ import cats.Hash
 import cats.Show
 import cats.syntax.all._
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.sdk.Resource.ResourceInitiationError
+import org.typelevel.otel4s.sdk.Resource.ResourceInitializationError
 import org.typelevel.otel4s.semconv.resource.attributes.ResourceAttributes._
 
 /** [[Resource]] serves as a representation of a resource that captures
   * essential identifying information regarding the entities associated with
   * reported signals, such as statistics or traces.
-  * @param attributes
-  *   \- a collection of [[Attribute]]s
-  * @param schemaUrl
-  *   \- an optional schema URL
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/resource/sdk]]
   */
-final case class Resource(
-    attributes: Attributes,
-    schemaUrl: Option[String]
-) {
+sealed trait Resource {
 
-  /** Merges [[Resource]] into another [[Resource]]. If the same attribute
-    * exists in both resources, the attribute in the other [[Resource]] will be
-    * used.
+  /** An [[Attributes]] associated with the resource.
+    */
+  def attributes: Attributes
+
+  /** An optional schema URL associated with the resource.
+    */
+  def schemaUrl: Option[String]
+
+  /** Merges [[Resource]] into another [[Resource]].
+    *
+    * Schema URL merge outcomes:
+    *   - if `this` resource's schema URL is empty then the `other` resource's
+    *     schema URL will be selected
+    *
+    *   - if `other` resource's schema URL is empty then `this` resource's
+    *     schema URL will be selected
+    *
+    *   - if `this` and `other` resources have the same non-empty schema URL
+    *     then this schema URL will be selected
+    *
+    *   - if `this` and `other` resources have different non-empty schema URLs
+    *     then the result will be a merge error
+    *
+    * @note
+    *   if the same attribute exists in both resources, the attribute from the
+    *   `other` [[Resource]] will be retained.
+    *
     * @param other
-    *   \- the other [[Resource]] to merge into.
+    *   the other [[Resource]] to merge with
+    *
     * @return
-    *   a new [[Resource]] with the merged attributes.
+    *   a new [[Resource]] with the merged attributes
     */
-  def mergeInto(other: Resource): Either[ResourceInitiationError, Resource] = {
-    if (other == Resource.Empty) this.asRight
-    else {
-      val schemaUrlOptEither = (other.schemaUrl, schemaUrl) match {
-        case (Some(otherUrl), Some(url)) =>
-          if (otherUrl == url)
-            url.some.asRight
-          else
-            ResourceInitiationError.SchemaUrlConflict.asLeft
-        case (otherUrl, url) =>
-          otherUrl.orElse(url).asRight
-      }
+  def merge(other: Resource): Either[ResourceInitializationError, Resource]
 
-      schemaUrlOptEither.map(
-        Resource(
-          attributes |+| other.attributes,
-          _
-        )
-      )
+  /** Unsafe version of [[merge]] which throws an exception if the merge fails.
+    *
+    * @param other
+    *   the other [[Resource]] to merge with
+    */
+  def mergeUnsafe(other: Resource): Resource
+
+  override final def hashCode(): Int =
+    Hash[Resource].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: Resource => Hash[Resource].eqv(this, other)
+      case _               => false
     }
-  }
 
-  /** Unsafe version of [[Resource.mergeInto]] which throws an exception if the
-    * merge fails.
-    */
-  private def mergeIntoUnsafe(other: Resource): Resource =
-    mergeInto(other).fold(
-      throw _,
-      identity
-    )
-
-  override def toString: String =
+  override final def toString: String =
     Show[Resource].show(this)
+
 }
 
 object Resource {
-  sealed abstract class ResourceInitiationError extends Throwable
-  object ResourceInitiationError {
-    case object SchemaUrlConflict extends ResourceInitiationError
-  }
+  private val Empty: Resource =
+    Resource(Attributes.empty, None)
 
-  def apply(attributes: Attributes): Resource =
-    Resource(attributes, None)
-
-  /** Returns an empty [[Resource]]. It is strongly recommended to start with
-    * [[Resource.Default]] instead of this method to include SDK required
-    * attributes.
-    *
-    * @return
-    *   an empty [[Resource]].
-    */
-  val Empty: Resource = Resource(Attributes.empty)
-
-  private val TelemetrySdk: Resource = Resource(
-    Attributes(
+  private val Default: Resource = {
+    val telemetrySdk = Attributes(
       Attribute(TelemetrySdkName, "otel4s"),
       Attribute(TelemetrySdkLanguage, TelemetrySdkLanguageValue.Scala.value),
       Attribute(TelemetrySdkVersion, BuildInfo.version)
     )
-  )
 
-  private val Mandatory: Resource = Resource(
-    Attributes(
+    val mandatory = Attributes(
       Attribute(ServiceName, "unknown_service:scala")
     )
-  )
+
+    Resource(telemetrySdk |+| mandatory, None)
+  }
+
+  sealed abstract class ResourceInitializationError extends Throwable
+  object ResourceInitializationError {
+    case object SchemaUrlConflict extends ResourceInitializationError
+  }
+
+  /** Creates a [[Resource]] with the given `attributes`. The `schemaUrl` will
+    * be `None.`
+    *
+    * @param attributes
+    *   the attributes to associate with the resource
+    */
+  def apply(attributes: Attributes): Resource =
+    Impl(attributes, None)
+
+  /** Creates a [[Resource]] with the given `attributes` and `schemaUrl`.
+    *
+    * @param attributes
+    *   the attributes to associate with the resource
+    *
+    * @param schemaUrl
+    *   schema URL to associate with the result
+    */
+  def apply(attributes: Attributes, schemaUrl: Option[String]): Resource =
+    Impl(attributes, schemaUrl)
+
+  /** Returns an empty [[Resource]].
+    *
+    * It is strongly recommended to start with [[Resource.default]] instead of
+    * this method to include SDK required attributes.
+    */
+  def empty: Resource = Empty
 
   /** Returns the default [[Resource]]. This resource contains the default
     * attributes provided by the SDK.
-    *
-    * @return
-    *   a [[Resource]].
     */
-  val Default: Resource = TelemetrySdk.mergeIntoUnsafe(Mandatory)
+  def default: Resource = Default
 
   implicit val showResource: Show[Resource] =
     r => show"Resource{attributes=${r.attributes}, schemaUrl=${r.schemaUrl}}"
 
   implicit val hashResource: Hash[Resource] =
     Hash.by(r => (r.attributes, r.schemaUrl))
+
+  private final case class Impl(
+      attributes: Attributes,
+      schemaUrl: Option[String]
+  ) extends Resource {
+
+    def merge(other: Resource): Either[ResourceInitializationError, Resource] =
+      if (other == Resource.Empty) Right(this)
+      else if (this == Resource.Empty) Right(other)
+      else {
+        (other.schemaUrl, schemaUrl) match {
+          case (Some(otherUrl), Some(url)) if otherUrl != url =>
+            Left(ResourceInitializationError.SchemaUrlConflict)
+
+          case (otherUrl, url) =>
+            Right(Impl(attributes |+| other.attributes, otherUrl.orElse(url)))
+        }
+      }
+
+    def mergeUnsafe(other: Resource): Resource =
+      merge(other).fold(throw _, identity)
+
+  }
 
 }

--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/ResourceProps.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/ResourceProps.scala
@@ -24,9 +24,9 @@ import org.typelevel.otel4s.sdk.arbitrary.resource
 
 class ResourceProps extends ScalaCheckSuite {
 
-  property("Attributes#mergeInto merges attributes") {
+  property("Attributes#merge merges attributes") {
     forAll(resource.arbitrary, resource.arbitrary) { (resource1, resource2) =>
-      val mergedEither = resource1.mergeInto(resource2)
+      val mergedEither = resource1.merge(resource2)
       mergedEither match {
         case Right(merged) =>
           val mergedAttrs = merged.attributes

--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/ResourceSuite.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/ResourceSuite.scala
@@ -19,19 +19,19 @@ package sdk
 
 import cats.syntax.either._
 import munit.FunSuite
-import org.typelevel.otel4s.sdk.Resource.ResourceInitiationError
-import org.typelevel.otel4s.sdk.Resource.ResourceInitiationError.SchemaUrlConflict
+import org.typelevel.otel4s.sdk.Resource.ResourceInitializationError
+import org.typelevel.otel4s.sdk.Resource.ResourceInitializationError.SchemaUrlConflict
 
 class ResourceSuite extends FunSuite {
 
   def checkSchemaMerge(
       leftSchemaUrl: Option[String],
       rightSchemaUrl: Option[String],
-      expected: Either[ResourceInitiationError, Option[String]]
+      expected: Either[ResourceInitializationError, Option[String]]
   ): Unit =
     assertEquals(
       Resource(Attributes.empty, leftSchemaUrl)
-        .mergeInto(Resource(Attributes.empty, rightSchemaUrl))
+        .merge(Resource(Attributes.empty, rightSchemaUrl))
         .map(_.schemaUrl),
       expected
     )
@@ -86,7 +86,7 @@ class ResourceSuite extends FunSuite {
     val that = Resource(Attributes(Attribute("key", "that")))
     val other = Resource(Attributes(Attribute("key", "other")))
 
-    assertEquals(that.mergeInto(other), Right(other))
+    assertEquals(that.merge(other), Right(other))
   }
 
 }


### PR DESCRIPTION
The changes:
1) Redefine `Resource` as a sealed trait
2) Update documentation
3) Rename `mergeInto` to `merge`
4) Rename `ResourceInitiationError` to `ResourceInitializationError`
