### PR TITLE
Improve `Attribute` creation ergonomics

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
@@ -29,6 +29,11 @@ import cats.syntax.show._
 sealed trait AttributeKey[A] {
   def name: String
   def `type`: AttributeType[A]
+
+  /** @return
+    *   an [[`Attribute`]] associating this key with the given value
+    */
+  final def apply(value: A): Attribute[A] = Attribute(this, value)
 }
 
 object AttributeKey {


### PR DESCRIPTION
Add `AttributeKey#apply` method that creates an `Attribute`.

Motivated by a desire to improve the ergonomics of semconv.