### PR TITLE
sdk-trace: add `SdkTracer`, `SdkTracerBuilder`, `SdkTracerProvider`

### DIFF
--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/context/package.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/context/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk
+
+import cats.mtl.Ask
+import cats.mtl.Local
+
+package object context {
+
+  type AskContext[F[_]] = Ask[F, Context]
+  type LocalContext[F[_]] = Local[F, Context]
+
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -66,7 +66,7 @@ import scala.concurrent.duration.FiniteDuration
   * @tparam F
   *   the higher-kinded type of a polymorphic effect
   */
-private[trace] final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
+private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
     spanProcessor: SpanProcessor[F],
     immutableState: SdkSpanBackend.ImmutableState,
     mutableState: Ref[F, SdkSpanBackend.MutableState]
@@ -214,7 +214,7 @@ private[trace] final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
 
 }
 
-private[trace] object SdkSpanBackend {
+private object SdkSpanBackend {
 
   /** Starts a new span.
     *

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -42,7 +42,7 @@ import scodec.bits.ByteVector
 
 import scala.concurrent.duration.FiniteDuration
 
-private[trace] final case class SdkSpanBuilder[F[_]: Temporal: Console](
+private final case class SdkSpanBuilder[F[_]: Temporal: Console](
     name: String,
     scopeInfo: InstrumentationScope,
     tracerSharedState: TracerSharedState[F],
@@ -227,7 +227,7 @@ private[trace] final case class SdkSpanBuilder[F[_]: Temporal: Console](
 
 }
 
-private[trace] object SdkSpanBuilder {
+private object SdkSpanBuilder {
 
   sealed trait Parent
   object Parent {

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraceScope.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraceScope.scala
@@ -37,7 +37,7 @@ import org.typelevel.otel4s.trace.SpanContext
   * @tparam F
   *   the higher-kinded type of a polymorphic effect
   */
-private[trace] trait SdkTraceScope[F[_]] {
+private trait SdkTraceScope[F[_]] {
 
   /** Returns a [[SpanContext]] if it's available in the current scope.
     */
@@ -271,7 +271,7 @@ private[trace] trait SdkTraceScope[F[_]] {
   def contextReader[A](f: Context => A): F[A]
 }
 
-private[trace] object SdkTraceScope {
+private object SdkTraceScope {
 
   def fromLocal[F[_]](implicit L: Local[F, Context]): SdkTraceScope[F] =
     new SdkTraceScope[F] {

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk
+package trace
+
+import cats.data.OptionT
+import cats.effect.Temporal
+import cats.effect.std.Console
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.context.propagation.ContextPropagators
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.context.propagation.TextMapUpdater
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.processor.SpanStorage
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.SpanBuilder
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.Tracer
+
+private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
+    scopeInfo: InstrumentationScope,
+    propagators: ContextPropagators[Context],
+    sharedState: TracerSharedState[F],
+    traceScope: SdkTraceScope[F],
+    storage: SpanStorage[F]
+) extends Tracer[F] {
+
+  val meta: Tracer.Meta[F] = Tracer.Meta.enabled[F]
+
+  def currentSpanContext: F[Option[SpanContext]] =
+    traceScope.current.map(current => current.filter(_.isValid))
+
+  def currentSpanOrNoop: F[Span[F]] =
+    OptionT(traceScope.current)
+      .semiflatMap { ctx =>
+        OptionT(storage.get(ctx)).getOrElse(Span.Backend.propagating(ctx))
+      }
+      .getOrElse(Span.Backend.noop)
+      .map(backend => Span.fromBackend(backend))
+
+  def spanBuilder(name: String): SpanBuilder[F] =
+    new SdkSpanBuilder[F](name, scopeInfo, sharedState, traceScope)
+
+  def childScope[A](parent: SpanContext)(fa: F[A]): F[A] =
+    traceScope.childScope(parent).flatMap(trace => trace(fa))
+
+  def rootScope[A](fa: F[A]): F[A] =
+    traceScope.rootScope.flatMap(trace => trace(fa))
+
+  def noopScope[A](fa: F[A]): F[A] =
+    traceScope.noopScope(fa)
+
+  def joinOrRoot[A, C: TextMapGetter](carrier: C)(fa: F[A]): F[A] = {
+    val context = propagators.textMapPropagator.extract(Context.root, carrier)
+    // use external context to bring extracted headers
+    traceScope.withContext(context)(fa)
+  }
+
+  def propagate[C: TextMapUpdater](carrier: C): F[C] =
+    traceScope.contextReader { ctx =>
+      propagators.textMapPropagator.inject(ctx, carrier)
+    }
+
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerBuilder.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk
+package trace
+
+import cats.effect.Temporal
+import cats.effect.std.Console
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.context.propagation.ContextPropagators
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.processor.SpanStorage
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerBuilder
+
+private final case class SdkTracerBuilder[F[_]: Temporal: Console](
+    propagators: ContextPropagators[Context],
+    traceScope: SdkTraceScope[F],
+    sharedState: TracerSharedState[F],
+    storage: SpanStorage[F],
+    name: String,
+    version: Option[String] = None,
+    schemaUrl: Option[String] = None
+) extends TracerBuilder[F] {
+
+  def withVersion(version: String): TracerBuilder[F] =
+    copy(version = Option(version))
+
+  def withSchemaUrl(schemaUrl: String): TracerBuilder[F] =
+    copy(schemaUrl = Option(schemaUrl))
+
+  def get: F[Tracer[F]] =
+    Temporal[F].pure(
+      new SdkTracer[F](
+        InstrumentationScope(name, version, schemaUrl, Attributes.empty),
+        propagators,
+        sharedState,
+        traceScope,
+        storage
+      )
+    )
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk
+package trace
+
+import cats.Parallel
+import cats.effect.Temporal
+import cats.effect.std.Console
+import cats.effect.std.Random
+import cats.syntax.functor._
+import org.typelevel.otel4s.context.propagation.ContextPropagators
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.context.LocalContext
+import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
+import org.typelevel.otel4s.sdk.trace.processor.SpanStorage
+import org.typelevel.otel4s.sdk.trace.samplers.Sampler
+import org.typelevel.otel4s.trace.TracerBuilder
+import org.typelevel.otel4s.trace.TracerProvider
+
+private class SdkTracerProvider[F[_]: Temporal: Parallel: Console](
+    idGenerator: IdGenerator[F],
+    resource: TelemetryResource,
+    sampler: Sampler,
+    propagators: ContextPropagators[Context],
+    spanProcessors: List[SpanProcessor[F]],
+    traceScope: SdkTraceScope[F],
+    storage: SpanStorage[F]
+) extends TracerProvider[F] {
+
+  private val sharedState: TracerSharedState[F] =
+    TracerSharedState(
+      idGenerator,
+      resource,
+      sampler,
+      SpanProcessor.of(spanProcessors: _*)
+    )
+
+  def tracer(name: String): TracerBuilder[F] =
+    new SdkTracerBuilder[F](propagators, traceScope, sharedState, storage, name)
+}
+
+object SdkTracerProvider {
+
+  /** Builder for [[org.typelevel.otel4s.trace.TracerProvider TraceProvider]].
+    */
+  sealed trait Builder[F[_]] {
+
+    /** Sets an [[IdGenerator]].
+      *
+      * [[IdGenerator]] will be used each time a
+      * [[org.typelevel.otel4s.trace.Span Span]] is started.
+      *
+      * @note
+      *   the id generator must be thread-safe and return immediately (no remote
+      *   calls, as contention free as possible).
+      *
+      * @param idGenerator
+      *   the [[IdGenerator]] to use
+      */
+    def withIdGenerator(idGenerator: IdGenerator[F]): Builder[F]
+
+    /** Sets a [[TelemetryResource]] to be attached to all spans created by
+      * [[org.typelevel.otel4s.trace.Tracer Tracer]].
+      *
+      * @note
+      *   on multiple subsequent calls, the resource from the last call will be
+      *   retained.
+      *
+      * @param resource
+      *   the [[TelemetryResource]] to use
+      */
+    def withResource(resource: TelemetryResource): Builder[F]
+
+    /** Merges the given [[TelemetryResource]] with the current one.
+      *
+      * @note
+      *   if both resources have different non-empty `schemaUrl`, the merge will
+      *   fail.
+      *
+      * @see
+      *   [[TelemetryResource.mergeUnsafe]]
+      *
+      * @param resource
+      *   the [[TelemetryResource]] to merge the current one with
+      */
+    def addResource(resource: TelemetryResource): Builder[F]
+
+    /** Sets a [[org.typelevel.otel4s.sdk.trace.samplers.Sampler Sampler]].
+      *
+      * The sampler will be called each time a
+      * [[org.typelevel.otel4s.trace.Span Span]] is started.
+      *
+      * @note
+      *   the sampler must be thread-safe and return immediately (no remote
+      *   calls, as contention free as possible).
+      *
+      * @param sampler
+      *   the [[org.typelevel.otel4s.sdk.trace.samplers.Sampler Sampler]] to use
+      */
+    def withSampler(sampler: Sampler): Builder[F]
+
+    /** Adds a
+      * [[org.typelevel.otel4s.context.propagation.TextMapPropagator TextMapPropagator]]s
+      * to use for the context propagation.
+      *
+      * @param propagators
+      *   the propagators to add
+      */
+    def addTextMapPropagators(
+        propagators: TextMapPropagator[Context]*
+    ): Builder[F]
+
+    /** Adds a
+      * [[org.typelevel.otel4s.sdk.trace.processor.SpanProcessor SpanProcessor]]
+      * to the span processing pipeline that will be built.
+      *
+      * The span processor will be called each time a
+      * [[org.typelevel.otel4s.trace.Span Span]] is started or ended.
+      *
+      * @note
+      *   the span processor must be thread-safe and return immediately (no
+      *   remote calls, as contention free as possible).
+      *
+      * @param processor
+      *   the span processor to add
+      */
+    def addSpanProcessor(processor: SpanProcessor[F]): Builder[F]
+
+    /** Creates a new
+      * [[org.typelevel.otel4s.trace.TracerProvider TraceProvider]] with the
+      * configuration of this builder.
+      */
+    def build: F[TracerProvider[F]]
+  }
+
+  /** Creates a new [[Builder]] with default configuration.
+    */
+  def builder[
+      F[_]: Temporal: Parallel: Random: LocalContext: Console
+  ]: Builder[F] =
+    BuilderImpl[F](
+      idGenerator = IdGenerator.random,
+      resource = TelemetryResource.default,
+      sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      propagators = Nil,
+      spanProcessors = Nil
+    )
+
+  private final case class BuilderImpl[
+      F[_]: Temporal: Parallel: LocalContext: Console
+  ](
+      idGenerator: IdGenerator[F],
+      resource: TelemetryResource,
+      sampler: Sampler,
+      propagators: List[TextMapPropagator[Context]],
+      spanProcessors: List[SpanProcessor[F]]
+  ) extends Builder[F] {
+
+    def withIdGenerator(generator: IdGenerator[F]): Builder[F] =
+      copy(idGenerator = generator)
+
+    def withResource(resource: TelemetryResource): Builder[F] =
+      copy(resource = resource)
+
+    def addResource(resource: TelemetryResource): Builder[F] =
+      copy(resource = this.resource.mergeUnsafe(resource))
+
+    def withSampler(sampler: Sampler): Builder[F] =
+      copy(sampler = sampler)
+
+    def addTextMapPropagators(
+        propagators: TextMapPropagator[Context]*
+    ): Builder[F] =
+      copy(propagators = this.propagators ++ propagators)
+
+    def addSpanProcessor(processor: SpanProcessor[F]): Builder[F] =
+      copy(spanProcessors = this.spanProcessors :+ processor)
+
+    def build: F[TracerProvider[F]] =
+      SpanStorage.create[F].map { storage =>
+        new SdkTracerProvider[F](
+          idGenerator,
+          resource,
+          sampler,
+          ContextPropagators.of(propagators: _*),
+          spanProcessors :+ storage,
+          SdkTraceScope.fromLocal[F],
+          storage
+        )
+      }
+  }
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanRef.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanRef.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration.FiniteDuration
   * @tparam F
   *   the higher-kinded type of a polymorphic effect
   */
-trait SpanRef[F[_]] { self: Span.Backend[F] =>
+trait SpanRef[F[_]] extends Span.Backend[F] {
 
   /** Returns the kind of the span. */
   def kind: SpanKind

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/SpanStorage.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/SpanStorage.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+package processor
+
+import cats.Applicative
+import cats.effect.Concurrent
+import cats.effect.Ref
+import cats.syntax.functor._
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.trace.SpanContext
+
+/** The span storage is used to keep the references of the active SpanRefs.
+  *
+  * @see
+  *   [[SdkTracer.currentSpanOrNoop]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+private[trace] class SpanStorage[F[_]: Applicative] private (
+    storage: Ref[F, Map[SpanContext, SpanRef[F]]]
+) extends SpanProcessor[F] {
+  val name: String = "SpanStorage"
+
+  def isStartRequired: Boolean = true
+  def isEndRequired: Boolean = true
+
+  def onStart(parentContext: Option[SpanContext], span: SpanRef[F]): F[Unit] =
+    storage.update(_.updated(span.context, span))
+
+  def onEnd(span: SpanData): F[Unit] =
+    storage.update(_.removed(span.spanContext))
+
+  def get(context: SpanContext): F[Option[SpanRef[F]]] =
+    storage.get.map(_.get(context))
+
+  def forceFlush: F[Unit] =
+    Applicative[F].unit
+}
+
+private[trace] object SpanStorage {
+  def create[F[_]: Concurrent]: F[SpanStorage[F]] =
+    for {
+      storage <- Ref[F].of(Map.empty[SpanContext, SpanRef[F]])
+    } yield new SpanStorage[F](storage)
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/samplers/ParentBasedSampler.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/samplers/ParentBasedSampler.scala
@@ -30,7 +30,7 @@ import scodec.bits.ByteVector
   * @see
   *   [[https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased]]
   */
-private[samplers] final class ParentBasedSampler private (
+private final class ParentBasedSampler private (
     root: Sampler,
     remoteParentSampled: Sampler,
     remoteParentNotSampled: Sampler,

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/samplers/TraceIdRatioBasedSampler.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/samplers/TraceIdRatioBasedSampler.scala
@@ -39,7 +39,7 @@ import scodec.bits.ByteVector
   * @see
   *   [[https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased]]
   */
-private[samplers] final class TraceIdRatioBasedSampler private (
+private final class TraceIdRatioBasedSampler private (
     ratio: Double,
     idUpperBound: Long
 ) extends Sampler {
@@ -64,7 +64,7 @@ private[samplers] final class TraceIdRatioBasedSampler private (
   val description: String = f"TraceIdRatioBased{$ratio%.6f}".replace(",", ".")
 }
 
-private[samplers] object TraceIdRatioBasedSampler {
+private object TraceIdRatioBasedSampler {
 
   /** Creates a new [[TraceIdRatioBasedSampler]] Sampler.
     *

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
@@ -1,0 +1,1002 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.effect.IO
+import cats.effect.IOLocal
+import cats.effect.MonadCancelThrow
+import cats.effect.Resource
+import cats.effect.std.Random
+import cats.effect.testkit.TestControl
+import cats.syntax.functor._
+import cats.~>
+import munit.CatsEffectSuite
+import munit.Location
+import munit.TestOptions
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.context.propagation.PassThroughPropagator
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.data.EventData
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.sdk.trace.data.StatusData
+import org.typelevel.otel4s.sdk.trace.exporter.InMemorySpanExporter
+import org.typelevel.otel4s.sdk.trace.processor.BatchSpanProcessor
+import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
+import org.typelevel.otel4s.sdk.trace.samplers.Sampler
+import org.typelevel.otel4s.trace.Span
+import org.typelevel.otel4s.trace.Status
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+class SdkTracerSuite extends CatsEffectSuite {
+
+  sdkTest("propagate instrumentation info") { sdk =>
+    val expected = InstrumentationScope(
+      name = "tracer",
+      version = Some("1.0"),
+      schemaUrl = Some("https://localhost:8080"),
+      attributes = Attributes.empty
+    )
+
+    for {
+      tracer <- sdk.provider
+        .tracer("tracer")
+        .withVersion("1.0")
+        .withSchemaUrl("https://localhost:8080")
+        .get
+
+      _ <- tracer.span("span").use_
+
+      spans <- sdk.finishedSpans
+    } yield assertEquals(
+      spans.map(_.instrumentationScope),
+      List(expected)
+    )
+  }
+
+  sdkTest("update span name") { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.span("span").use(span => span.updateName("span-use"))
+      spans <- sdk.finishedSpans
+    } yield assertEquals(spans.map(_.name), List("span-use"))
+  }
+
+  sdkTest("set attributes only once") { sdk =>
+    val key = "string-attribute"
+    val value = "value"
+    val attribute = Attribute(key, value)
+
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.span("span", attribute).use_
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(spans.flatMap(_.attributes.toList), List(attribute))
+    }
+  }
+
+  sdkTest("propagate traceId and spanId") { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.currentSpanContext.assertEquals(None)
+      result <- tracer.span("span").use { span =>
+        for {
+          _ <- tracer.currentSpanContext.assertEquals(Some(span.context))
+          span2 <- tracer.span("span-2").use { span2 =>
+            for {
+              _ <- tracer.currentSpanContext.assertEquals(Some(span2.context))
+            } yield span2
+          }
+        } yield (span, span2)
+      }
+      spans <- sdk.finishedSpans
+    } yield {
+      val (span, span2) = result
+      assertEquals(span.context.traceIdHex, span2.context.traceIdHex)
+      assertEquals(
+        spans.map(_.spanContext),
+        List(span2.context, span.context)
+      )
+      assertEquals(
+        spans.map(_.spanContext),
+        List(span2.context, span.context)
+      )
+    }
+  }
+
+  sdkTest("propagate attributes") { sdk =>
+    val attribute = Attribute("string-attribute", "value")
+
+    for {
+      tracer <- sdk.provider.get("tracer")
+      span <- tracer.span("span", attribute).use(IO.pure)
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(
+        spans.map(_.spanContext.traceIdHex),
+        List(span.context.traceIdHex)
+      )
+      assertEquals(
+        spans.map(_.spanContext.spanIdHex),
+        List(span.context.spanIdHex)
+      )
+      assertEquals(spans.flatMap(_.attributes.toList), List(attribute))
+    }
+  }
+
+  // todo: enable when W3C propagator is ready
+  /*sdkTest("propagate to an arbitrary carrier") { sdk =>
+    TestControl.executeEmbed {
+      for {
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.span("span").use { span =>
+          for {
+            carrier <- tracer.propagate(Map("key" -> "value"))
+          } yield {
+            assertEquals(carrier.get("key"), Some("value"))
+            val expected =
+              s"00-${span.context.traceIdHex}-${span.context.spanIdHex}-01"
+            assertEquals(carrier.get("traceparent"), Some(expected))
+          }
+        }
+      } yield ()
+    }
+  }*/
+
+  sdkTest("automatically start and stop span") { sdk =>
+    val sleepDuration = 500.millis
+
+    TestControl.executeEmbed {
+      for {
+        tracer <- sdk.provider.get("tracer")
+        now <- IO.monotonic.delayBy(1.millis) // otherwise returns 0
+        _ <- tracer.span("span").surround(IO.sleep(sleepDuration))
+        spans <- sdk.finishedSpans
+      } yield {
+        assertEquals(spans.map(_.startTimestamp), List(now))
+        assertEquals(
+          spans.map(_.endTimestamp),
+          List(Some(now.plus(sleepDuration)))
+        )
+      }
+    }
+  }
+
+  sdkTest("set error status on abnormal termination (canceled)") { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      fiber <- tracer.span("span").surround(IO.canceled).start
+      _ <- fiber.joinWith(IO.unit)
+      spans <- sdk.finishedSpans
+    } yield {
+      assertEquals(
+        spans.map(_.status),
+        List(StatusData(Status.Error, "canceled"))
+      )
+      assertEquals(spans.map(_.events.isEmpty), List(true))
+    }
+  }
+
+  sdkTest("set error status on abnormal termination (exception)") { sdk =>
+    final case class Err(reason: String)
+        extends RuntimeException(reason)
+        with NoStackTrace
+
+    val exception = Err("error")
+
+    def expected(timestamp: FiniteDuration) =
+      EventData.fromException(
+        // SpanLimits.Default,
+        timestamp,
+        exception,
+        Attributes.empty,
+        false
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.span("span").surround(IO.raiseError(exception)).attempt
+        spans <- sdk.finishedSpans
+      } yield {
+        assertEquals(spans.map(_.status), List(StatusData.Error(None)))
+        assertEquals(
+          spans.map(_.events),
+          List(Vector(expected(now)))
+        )
+      }
+
+    }
+  }
+
+  sdkTest("create root span explicitly") { sdk =>
+    def expected(now: FiniteDuration) =
+      List(
+        SpanNode("span-2", now, now, Nil),
+        SpanNode("span-1", now, now, Nil)
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.span("span-1").use { span1 =>
+          tracer.rootSpan("span-2").use { span2 =>
+            for {
+              _ <- tracer.currentSpanContext.assertEquals(Some(span2.context))
+              _ <- IO(assertIdsNotEqual(span1, span2))
+            } yield ()
+          }
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        //  _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, expected(now))
+    }
+  }
+
+  sdkTest("create a new root scope") { sdk =>
+    def expected(now: FiniteDuration) =
+      List(
+        SpanNode("span-2", now, now, Nil),
+        SpanNode("span-1", now, now, Nil)
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        _ <- tracer.span("span-1").use { span1 =>
+          for {
+            _ <- tracer.currentSpanContext.assertEquals(Some(span1.context))
+            _ <- tracer.rootScope {
+              for {
+                _ <- tracer.currentSpanContext.assertEquals(None)
+                // a new root span should be created
+                _ <- tracer.span("span-2").use { span2 =>
+                  for {
+                    _ <- IO(assertIdsNotEqual(span1, span2))
+                    _ <- tracer.currentSpanContext
+                      .assertEquals(Some(span2.context))
+                  } yield ()
+                }
+              } yield ()
+            }
+          } yield ()
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        //  _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, expected(now))
+    }
+  }
+
+  sdkTest("create a no-op scope") { sdk =>
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        _ <- tracer.span("span-1").use { span =>
+          for {
+            _ <- tracer.currentSpanContext.assertEquals(Some(span.context))
+            _ <- tracer.noopScope {
+              for {
+                _ <- tracer.currentSpanContext.assertEquals(None)
+                // a new root span should not be created
+                _ <- tracer
+                  .span("span-2")
+                  .use(_ => tracer.currentSpanContext.assertEquals(None))
+                _ <- tracer
+                  .rootSpan("span-3")
+                  .use(_ => tracer.currentSpanContext.assertEquals(None))
+                _ <- tracer.rootScope {
+                  tracer
+                    .span("span-4")
+                    .use(_ => tracer.currentSpanContext.assertEquals(None))
+                }
+              } yield ()
+            }
+          } yield ()
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(SpanNode("span-1", now, now, Nil)))
+    }
+  }
+
+  sdkTest("`currentSpanOrNoop` outside of a span (root scope)") { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      currentSpan <- tracer.currentSpanOrNoop
+      _ <- currentSpan.addAttribute(Attribute("string-attribute", "value"))
+      spans <- sdk.finishedSpans
+    } yield {
+      assert(!currentSpan.context.isValid)
+      assertEquals(spans.length, 0)
+    }
+  }
+
+  sdkTest("`currentSpanOrNoop` in noop scope") { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.noopScope {
+        for {
+          currentSpan <- tracer.currentSpanOrNoop
+          _ <- currentSpan.addAttribute(Attribute("string-attribute", "value"))
+        } yield assert(!currentSpan.context.isValid)
+      }
+      spans <- sdk.finishedSpans
+    } yield assertEquals(spans.length, 0)
+  }
+
+  sdkTest("`currentSpanOrNoop` inside a span") { sdk =>
+    def expected(now: FiniteDuration): List[SpanNode] =
+      List(SpanNode("span", now, now, Nil))
+
+    val attribute =
+      Attribute("string-attribute", "value")
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.span("span").surround {
+          for {
+            currentSpan <- tracer.currentSpanOrNoop
+            _ <- currentSpan.addAttribute(attribute)
+          } yield assert(currentSpan.context.isValid)
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield {
+        assertEquals(tree, expected(now))
+        assertEquals(spans.map(_.attributes), List(Attributes(attribute)))
+      }
+    }
+  }
+
+  sdkTest("create a new scope with a custom parent") { sdk =>
+    def expected(now: FiniteDuration) =
+      SpanNode(
+        "span",
+        now,
+        now,
+        List(
+          SpanNode("span-3", now, now, Nil),
+          SpanNode("span-2", now, now, Nil)
+        )
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        _ <- tracer.span("span").use { span =>
+          for {
+            _ <- tracer.currentSpanContext.assertEquals(Some(span.context))
+            _ <- tracer.span("span-2").use { span2 =>
+              for {
+                _ <- tracer.currentSpanContext
+                  .assertEquals(Some(span2.context))
+                _ <- tracer.childScope(span.context) {
+                  for {
+                    _ <- tracer.currentSpanContext
+                      .assertEquals(Some(span.context))
+                    _ <- tracer.span("span-3").use { span3 =>
+                      tracer.currentSpanContext
+                        .assertEquals(Some(span3.context))
+                    }
+                  } yield ()
+
+                }
+              } yield ()
+            }
+          } yield ()
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  sdkTest("create a span with a custom parent (via builder)") { sdk =>
+    def expected(now: FiniteDuration) =
+      SpanNode(
+        "span",
+        now,
+        now,
+        List(
+          SpanNode("span-3", now, now, Nil),
+          SpanNode("span-2", now, now, Nil)
+        )
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        _ <- tracer.span("span").use { span =>
+          for {
+            _ <- tracer.currentSpanContext.assertEquals(Some(span.context))
+            _ <- tracer.span("span-2").use { span2 =>
+              for {
+                _ <- tracer.currentSpanContext
+                  .assertEquals(Some(span2.context))
+                _ <- tracer
+                  .spanBuilder("span-3")
+                  .withParent(span.context)
+                  .build
+                  .use { span3 =>
+                    tracer.currentSpanContext
+                      .assertEquals(Some(span3.context))
+                  }
+              } yield ()
+            }
+          } yield ()
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  sdkTest("trace resource with use") { sdk =>
+    val attribute = Attribute("string-attribute", "value")
+
+    val acquireInnerDuration = 25.millis
+    val body1Duration = 100.millis
+    val body2Duration = 200.millis
+    val body3Duration = 50.millis
+    val releaseDuration = 300.millis
+
+    def mkRes(tracer: Tracer[IO]): Resource[IO, Unit] =
+      Resource
+        .make(
+          tracer.span("acquire-inner").surround(IO.sleep(acquireInnerDuration))
+        )(_ => IO.sleep(releaseDuration))
+
+    def expected(start: FiniteDuration) = {
+      val acquireEnd = start + acquireInnerDuration
+
+      val (body1Start, body1End) = (acquireEnd, acquireEnd + body1Duration)
+      val (body2Start, body2End) = (body1End, body1End + body2Duration)
+      val (body3Start, body3End) = (body2End, body2End + body3Duration)
+
+      val end = body3End + releaseDuration
+
+      SpanNode(
+        "resource-span",
+        start,
+        end,
+        List(
+          SpanNode(
+            "acquire",
+            start,
+            acquireEnd,
+            List(
+              SpanNode(
+                "acquire-inner",
+                start,
+                acquireEnd,
+                Nil
+              )
+            )
+          ),
+          SpanNode(
+            "use",
+            body1Start,
+            body3End,
+            List(
+              SpanNode("body-1", body1Start, body1End, Nil),
+              SpanNode("body-2", body2Start, body2End, Nil),
+              SpanNode("body-3", body3Start, body3End, Nil)
+            )
+          ),
+          SpanNode(
+            "release",
+            body3End,
+            end,
+            Nil
+          )
+        )
+      )
+    }
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- wrapResource(tracer, mkRes(tracer), attribute)
+          .use {
+            _ {
+              tracer.span("use").surround {
+                for {
+                  _ <- tracer.span("body-1").surround(IO.sleep(100.millis))
+                  _ <- tracer.span("body-2").surround(IO.sleep(200.millis))
+                  _ <- tracer.span("body-3").surround(IO.sleep(50.millis))
+                } yield ()
+              }
+            }
+          }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  sdkTest("trace resource with surround") { sdk =>
+    val acquireDuration = 25.millis
+    val bodyDuration = 100.millis
+    val releaseDuration = 300.millis
+
+    def mkRes: Resource[IO, Unit] =
+      Resource.make(IO.sleep(acquireDuration))(_ => IO.sleep(releaseDuration))
+
+    def expected(start: FiniteDuration) = {
+      val acquireEnd = start + acquireDuration
+      val (bodyStart, bodyEnd) = (acquireEnd, acquireEnd + bodyDuration)
+      val end = bodyEnd + releaseDuration
+
+      SpanNode(
+        "resource-span",
+        start,
+        end,
+        List(
+          SpanNode(
+            "acquire",
+            start,
+            acquireEnd,
+            Nil
+          ),
+          SpanNode(
+            "use",
+            bodyStart,
+            bodyEnd,
+            List(
+              SpanNode("body", bodyStart, bodyEnd, Nil)
+            )
+          ),
+          SpanNode(
+            "release",
+            bodyEnd,
+            end,
+            Nil
+          )
+        )
+      )
+    }
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.tracer("tracer").get
+        _ <- wrapResource(tracer, mkRes)
+          .use { trace =>
+            trace {
+              tracer.span("use").surround {
+                tracer.span("body").surround(IO.sleep(100.millis))
+              }
+            }
+          }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  sdkTest("trace resource with use_") { sdk =>
+    val acquireDuration = 25.millis
+    val releaseDuration = 300.millis
+
+    def mkRes: Resource[IO, Unit] =
+      Resource.make(IO.sleep(acquireDuration))(_ => IO.sleep(releaseDuration))
+
+    def expected(start: FiniteDuration) = {
+      val acquireEnd = start + acquireDuration
+      val end = acquireEnd + releaseDuration
+
+      SpanNode(
+        "resource-span",
+        start,
+        end,
+        List(
+          SpanNode(
+            "acquire",
+            start,
+            acquireEnd,
+            Nil
+          ),
+          SpanNode(
+            "use",
+            acquireEnd,
+            acquireEnd,
+            Nil
+          ),
+          SpanNode(
+            "release",
+            acquireEnd,
+            end,
+            Nil
+          )
+        )
+      )
+    }
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.tracer("tracer").get
+        _ <- wrapResource(tracer, mkRes)
+          .use {
+            _(tracer.span("use").use_)
+          }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  sdkTest("startUnmanaged: respect builder start time") { sdk =>
+    val expected = SpanNode(
+      name = "span",
+      start = 100.millis,
+      end = 200.millis,
+      children = Nil
+    )
+
+    TestControl.executeEmbed {
+      for {
+        tracer <- sdk.provider.get("tracer")
+        span <- tracer
+          .spanBuilder("span")
+          .withStartTimestamp(100.millis)
+          .build
+          .startUnmanaged
+
+        // the sleep time should be ignored since the end timestamp is specified explicitly
+        _ <- IO.sleep(100.millis)
+
+        _ <- span.end(200.millis)
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected))
+    }
+  }
+
+  sdkTest(
+    "startUnmanaged: use Clock[F].realTime to set start and end if builder's time is undefined"
+  ) { sdk =>
+    def expected(now: FiniteDuration) =
+      SpanNode(
+        name = "span",
+        start = now,
+        end = now.plus(100.millis),
+        children = Nil
+      )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        span <- tracer.spanBuilder("span").build.startUnmanaged
+
+        _ <- IO.sleep(100.millis)
+
+        _ <- span.end
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+  }
+
+  // external span does not appear in the recorded spans of the in-memory sdk
+  // todo: enable when W3C propagator is ready
+  /*sdkTest(
+    "joinOrRoot: join an external span when can be extracted",
+    additionalPropagators = List(PassThroughPropagator("foo", "bar"))
+  ) { sdk =>
+    val traceId = "84b54e9330faae5350f0dd8673c98146"
+    val spanId = "279fa73bc935cc05"
+
+    val headers = Map(
+      "traceparent" -> s"00-$traceId-$spanId-01",
+      "foo" -> "1",
+      "baz" -> "2"
+    )
+
+    TestControl.executeEmbed {
+      for {
+        tracer <- sdk.provider.get("tracer")
+        tuple <- tracer.span("local").surround {
+          tracer.joinOrRoot(headers) {
+            (
+              tracer.currentSpanContext,
+              tracer.span("inner").use(r => IO.pure(r.context)),
+              tracer.propagate(Map.empty[String, String]),
+            ).tupled
+          }
+        }
+        (external, inner, resultHeaders) = tuple
+      } yield {
+        assertEquals(external.map(_.traceIdHex), Some(traceId))
+        assertEquals(external.map(_.spanIdHex), Some(spanId))
+        assertEquals(inner.traceIdHex, traceId)
+        assertEquals(resultHeaders.size, 2)
+        assertEquals(
+          resultHeaders.get("traceparent"),
+          Some(s"00-$traceId-$spanId-01")
+        )
+        assertEquals(resultHeaders.get("foo"), Some("1"))
+      }
+    }
+  }*/
+
+  sdkTest(
+    "joinOrRoot: ignore an external span when cannot be extracted and start a root span"
+  ) { sdk =>
+    val traceId = "84b54e9330faae5350f0dd8673c98146"
+    val spanId = "279fa73bc935cc05"
+
+    val headers = Map(
+      "some_random_header" -> s"00-$traceId-$spanId-01"
+    )
+
+    // we must always start a root span
+    def expected(now: FiniteDuration) = List(
+      SpanNode(
+        name = "inner",
+        start = now.plus(500.millis),
+        end = now.plus(500.millis).plus(200.millis),
+        children = Nil
+      ),
+      SpanNode(
+        name = "local",
+        start = now,
+        end = now.plus(500.millis).plus(200.millis),
+        children = Nil
+      )
+    )
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.span("local").surround {
+          tracer
+            .joinOrRoot(headers) {
+              tracer.span("inner").surround(IO.sleep(200.millis))
+            }
+            .delayBy(500.millis)
+        }
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, expected(now))
+    }
+  }
+
+  /*
+  test("propagate trace info over stream scopes") {
+    def expected(now: FiniteDuration) =
+      SpanNode(
+        "span",
+        now,
+        now,
+        List(
+          SpanNode("span-3", now, now, Nil),
+          SpanNode("span-2", now, now, Nil)
+        )
+      )
+
+    def flow(tracer: Tracer[IO]): Stream[IO, Unit] =
+      for {
+        span <- Stream.resource(tracer.span("span"))
+        _ <- Stream.eval(
+          tracer.currentSpanContext.assertEquals(Some(span.context))
+        )
+        span2 <- Stream.resource(tracer.span("span-2"))
+        _ <- Stream.eval(
+          tracer.currentSpanContext.assertEquals(Some(span2.context))
+        )
+        span3 <- Stream.resource(
+          tracer.spanBuilder("span-3").withParent(span.context).start
+        )
+        _ <- Stream.eval(
+          tracer.currentSpanContext.assertEquals(Some(span3.context))
+        )
+      } yield ()
+
+    TestControl.executeEmbed {
+      for {
+        now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
+        sdk <- makeSdk()
+        tracer <- sdk.provider.get("tracer")
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        _ <- flow(tracer).compile.drain
+        _ <- tracer.currentSpanContext.assertEquals(None)
+        spans <- sdk.finishedSpans
+        tree <- IO.pure(SpanNode.fromSpans(spans))
+        // _ <- IO.println(tree.map(SpanNode.render).mkString("\n"))
+      } yield assertEquals(tree, List(expected(now)))
+    }
+   }
+   */
+
+  sdkTest(
+    "setting attributes using builder does not remove previous ones"
+  ) { sdk =>
+    val previousAttribute = Attribute("previous-attribute", "previous-value")
+    val newAttribute = Attribute("new-attribute", "new-value")
+
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer
+        .spanBuilder("span")
+        .addAttribute(previousAttribute)
+        .addAttributes(newAttribute)
+        .build
+        .use_
+      spans <- sdk.finishedSpans
+    } yield assertEquals(
+      spans.flatMap(_.attributes.toList),
+      List(previousAttribute, newAttribute)
+    )
+  }
+
+  // typelevel/otel4s#277
+  sdkTest(
+    "retain all of a provided context through propagation",
+    additionalPropagators = List(PassThroughPropagator("foo", "bar"))
+  ) { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.joinOrRoot(Map("foo" -> "1", "baz" -> "2")) {
+        for {
+          carrier <- tracer.propagate(Map.empty[String, String])
+        } yield {
+          assertEquals(carrier.size, 1)
+          assertEquals(carrier.get("foo"), Some("1"))
+        }
+      }
+    } yield ()
+  }
+
+  sdkTest(
+    "keep propagating non-recording spans, but don't record them",
+    sampler = Sampler.AlwaysOff
+  ) { sdk =>
+    for {
+      tracer <- sdk.provider.get("tracer")
+      _ <- tracer.span("local").use { span1 =>
+        for {
+          _ <- IO(assertEquals(span1.context.isValid, true))
+          _ <- IO(assertEquals(span1.context.isSampled, false))
+          _ <- tracer.span("local-2").use { span2 =>
+            for {
+              _ <- IO(assertEquals(span2.context.isValid, true))
+              _ <- IO(assertEquals(span2.context.isSampled, false))
+              _ <- IO(
+                assertEquals(span2.context.traceId, span1.context.traceId)
+              )
+            } yield ()
+          }
+        } yield ()
+      }
+      spans <- sdk.finishedSpans
+    } yield assertEquals(spans, Nil)
+  }
+
+  private def wrapResource[F[_]: MonadCancelThrow, A](
+      tracer: Tracer[F],
+      resource: Resource[F, A],
+      attributes: Attribute[_]*
+  ): Resource[F, F ~> F] = {
+    tracer
+      .span("resource-span", attributes: _*)
+      .resource
+      .flatMap { res =>
+        Resource[F, A] {
+          res.trace {
+            tracer
+              .span("acquire")
+              .surround {
+                resource.allocated.map { case (acquired, release) =>
+                  acquired -> res.trace(
+                    tracer.span("release").surround(release)
+                  )
+                }
+              }
+          }
+        }.as(res.trace)
+      }
+  }
+
+  private def assertIdsNotEqual(s1: Span[IO], s2: Span[IO]): Unit = {
+    assertNotEquals(s1.context.traceIdHex, s2.context.traceIdHex)
+    assertNotEquals(s1.context.spanIdHex, s2.context.spanIdHex)
+  }
+
+  private def sdkTest[A](
+      options: TestOptions,
+      sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      additionalPropagators: List[TextMapPropagator[Context]] = Nil
+  )(body: SdkTracerSuite.Sdk => IO[A])(implicit loc: Location): Unit =
+    test(options)(makeSdk(sampler, additionalPropagators).use(body))
+
+  private def makeSdk(
+      sampler: Sampler,
+      additionalPropagators: List[TextMapPropagator[Context]]
+  ): Resource[IO, SdkTracerSuite.Sdk] = {
+    import org.typelevel.otel4s.instances.local._
+
+    val textMapPropagators: List[TextMapPropagator[Context]] =
+      /*List(W3CTraceContextPropagator) ++*/ additionalPropagators
+
+    def createTracerProvider(
+        processor: SpanProcessor[IO]
+    )(implicit ioLocal: IOLocal[Context]): IO[TracerProvider[IO]] =
+      Random.scalaUtilRandom[IO].flatMap { implicit random =>
+        SdkTracerProvider
+          .builder[IO]
+          .addTextMapPropagators(textMapPropagators: _*)
+          .addSpanProcessor(processor)
+          .withSampler(sampler)
+          .build
+      }
+
+    for {
+      ioLocal <- Resource.eval(IOLocal(Context.root))
+      exporter <- Resource.eval(InMemorySpanExporter.create[IO](None))
+      processor <- BatchSpanProcessor.builder(exporter).build
+      tracerProvider <- Resource.eval(createTracerProvider(processor)(ioLocal))
+    } yield new SdkTracerSuite.Sdk(tracerProvider, processor, exporter)
+  }
+
+}
+
+object SdkTracerSuite {
+
+  class Sdk(
+      val provider: TracerProvider[IO],
+      processor: SpanProcessor[IO],
+      exporter: InMemorySpanExporter[IO]
+  ) {
+
+    def finishedSpans: IO[List[SpanData]] =
+      processor.forceFlush >> exporter.finishedSpans
+
+  }
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanNode.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanNode.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+
+import scala.concurrent.duration._
+
+// Tree-like representation of a span
+final case class SpanNode(
+    name: String,
+    start: FiniteDuration,
+    end: FiniteDuration,
+    children: List[SpanNode]
+)
+
+object SpanNode {
+
+  def fromSpans(spans: List[SpanData]): List[SpanNode] = {
+    val spansByParent = spans.groupBy { span =>
+      span.parentSpanContext.filter(_.isValid).map(_.spanIdHex)
+    }
+    val topNodes = spansByParent.getOrElse(None, Nil)
+    val bottomToTop = sortNodesByDepth(0, topNodes, spansByParent, Nil)
+    val maxDepth = bottomToTop.headOption.map(_.depth).getOrElse(0)
+    buildFromBottom(maxDepth, bottomToTop, spansByParent, Map.empty)
+  }
+
+  def render(tree: SpanNode): String = {
+    def loop(input: SpanNode, depth: Int): String = {
+      val prefix = " " * depth
+      val next =
+        if (input.children.isEmpty) ""
+        else " =>\n" + input.children.map(loop(_, depth + 2)).mkString("\n")
+
+      s"$prefix${input.name} ${input.start.toNanos} -> ${input.end.toNanos}$next"
+    }
+
+    loop(tree, 0)
+  }
+
+  private case class EntryWithDepth(data: SpanData, depth: Int)
+
+  @annotation.tailrec
+  private def sortNodesByDepth(
+      depth: Int,
+      nodesInDepth: List[SpanData],
+      nodesByParent: Map[Option[String], List[SpanData]],
+      acc: List[EntryWithDepth]
+  ): List[EntryWithDepth] = {
+    val withDepth = nodesInDepth.map(n => EntryWithDepth(n, depth))
+    val calculated = withDepth ++ acc
+
+    val children =
+      nodesInDepth.flatMap(n =>
+        nodesByParent.getOrElse(Some(n.spanContext.spanIdHex), Nil)
+      )
+
+    children match {
+      case Nil =>
+        calculated
+
+      case _ =>
+        sortNodesByDepth(depth + 1, children, nodesByParent, calculated)
+    }
+  }
+
+  @annotation.tailrec
+  private def buildFromBottom(
+      depth: Int,
+      remaining: List[EntryWithDepth],
+      nodesByParent: Map[Option[String], List[SpanData]],
+      processedNodesById: Map[String, SpanNode]
+  ): List[SpanNode] = {
+    val (nodesOnCurrentDepth, rest) = remaining.span(_.depth == depth)
+    val newProcessedNodes = nodesOnCurrentDepth.map { n =>
+      val nodeId = n.data.spanContext.spanIdHex
+      val children = nodesByParent
+        .getOrElse(Some(nodeId), Nil)
+        .flatMap(c => processedNodesById.get(c.spanContext.spanIdHex))
+      val node = SpanNode(
+        n.data.name,
+        n.data.startTimestamp,
+        n.data.endTimestamp.getOrElse(Duration.Zero),
+        children
+      )
+      nodeId -> node
+    }.toMap
+
+    if (depth > 0) {
+      buildFromBottom(
+        depth - 1,
+        rest,
+        nodesByParent,
+        processedNodesById ++ newProcessedNodes
+      )
+    } else {
+      // top nodes
+      newProcessedNodes.values.toList
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Java implementation | [SdkTracer.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracer.java) <br> [SdkTracerBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerBuilder.java) <br> [SdkTracerProvider.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java) <br> [SdkTracerProviderBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProviderBuilder.java) |

It's hard to add each of them individually, so we have a big PR 🙁  
