### PR TITLE
Implement scalafix migration rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p testkit/metrics/jvm/target oteljava/metrics/target testkit/common/jvm/target core/trace/.js/target semconv/.jvm/target core/common/.jvm/target unidocs/target core/metrics/.native/target core/all/.native/target core/metrics/.jvm/target core/all/.js/target core/metrics/.js/target core/all/.jvm/target core/trace/.native/target semconv/.js/target oteljava/common/target core/trace/.jvm/target core/common/.native/target core/common/.js/target oteljava/trace/target semconv/.native/target testkit/all/jvm/target oteljava/all/target project/target
+        run: mkdir -p testkit/metrics/jvm/target oteljava/metrics/target testkit/common/jvm/target core/trace/.js/target semconv/.jvm/target core/common/.jvm/target unidocs/target core/metrics/.native/target core/all/.native/target core/metrics/.jvm/target core/all/.js/target core/metrics/.js/target core/all/.jvm/target core/trace/.native/target semconv/.js/target oteljava/common/target scalafix/rules/target core/trace/.jvm/target core/common/.native/target core/common/.js/target oteljava/trace/target semconv/.native/target testkit/all/jvm/target oteljava/all/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar testkit/metrics/jvm/target oteljava/metrics/target testkit/common/jvm/target core/trace/.js/target semconv/.jvm/target core/common/.jvm/target unidocs/target core/metrics/.native/target core/all/.native/target core/metrics/.jvm/target core/all/.js/target core/metrics/.js/target core/all/.jvm/target core/trace/.native/target semconv/.js/target oteljava/common/target core/trace/.jvm/target core/common/.native/target core/common/.js/target oteljava/trace/target semconv/.native/target testkit/all/jvm/target oteljava/all/target project/target
+        run: tar cf targets.tar testkit/metrics/jvm/target oteljava/metrics/target testkit/common/jvm/target core/trace/.js/target semconv/.jvm/target core/common/.jvm/target unidocs/target core/metrics/.native/target core/all/.native/target core/metrics/.jvm/target core/all/.js/target core/metrics/.js/target core/all/.jvm/target core/trace/.native/target semconv/.js/target oteljava/common/target scalafix/rules/target core/trace/.jvm/target core/common/.native/target core/common/.js/target oteljava/trace/target semconv/.native/target testkit/all/jvm/target oteljava/all/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -239,7 +239,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: otel4s-sdk-common_native0.4_2.13 otel4s-sdk-common_native0.4_3 otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s-sdk-common_sjs1_2.13 otel4s-sdk-common_sjs1_3 otel4s-sdk-trace_sjs1_2.13 otel4s-sdk-trace_sjs1_3 otel4s_2.13 otel4s_3 docs_2.13 docs_3 otel4s-sdk_native0.4_2.13 otel4s-sdk_native0.4_3 otel4s-sdk-common_2.13 otel4s-sdk-common_3 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 otel4s-sdk-trace_native0.4_2.13 otel4s-sdk-trace_native0.4_3 otel4s-sdk_sjs1_2.13 otel4s-sdk_sjs1_3 otel4s-sdk_2.13 otel4s-sdk_3 otel4s-sdk-trace_2.13 otel4s-sdk-trace_3
+          modules-ignore: otel4s-sdk-common_native0.4_2.13 otel4s-sdk-common_native0.4_3 otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s-sdk-common_sjs1_2.13 otel4s-sdk-common_sjs1_3 otel4s-sdk-trace_sjs1_2.13 otel4s-sdk-trace_sjs1_3 otel4s_2.13 otel4s_3 docs_2.13 docs_3 scalafix-output_2.13 scalafix-input_2.13 otel4s-sdk_native0.4_2.13 otel4s-sdk_native0.4_3 otel4s-sdk-common_2.13 otel4s-sdk-common_3 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 otel4s-sdk-trace_native0.4_2.13 otel4s-sdk-trace_native0.4_3 scalafix-tests_2.13 otel4s-sdk_sjs1_2.13 otel4s-sdk_sjs1_3 otel4s-sdk_2.13 otel4s-sdk_3 otel4s-sdk-trace_2.13 otel4s-sdk-trace_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,9 @@ lazy val root = tlCrossRootProject
     examples,
     unidocs
   )
+  .configureRoot(
+    _.aggregate(scalafix.componentProjectReferences: _*)
+  )
   .settings(name := "otel4s")
 
 lazy val `core-common` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -326,6 +329,28 @@ lazy val semconv = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+
+lazy val scalafix = tlScalafixProject
+  .rulesSettings(
+    name := "otel4s-scalafix",
+    crossScalaVersions := Seq(Scala213),
+    startYear := Some(2024)
+  )
+  .inputSettings(
+    crossScalaVersions := Seq(Scala213),
+    libraryDependencies += "org.typelevel" %% "otel4s-java" % "0.4.0",
+    headerSources / excludeFilter := AllPassFilter
+  )
+  .inputConfigure(_.disablePlugins(ScalafixPlugin))
+  .outputSettings(
+    crossScalaVersions := Seq(Scala213),
+    headerSources / excludeFilter := AllPassFilter
+  )
+  .outputConfigure(_.dependsOn(oteljava).disablePlugins(ScalafixPlugin))
+  .testsSettings(
+    crossScalaVersions := Seq(Scala213),
+    startYear := Some(2024)
+  )
 
 lazy val benchmarks = project
   .enablePlugins(NoPublishPlugin)

--- a/scalafix/input/src/main/scala/example/V0_5_0Rewrites.scala
+++ b/scalafix/input/src/main/scala/example/V0_5_0Rewrites.scala
@@ -1,0 +1,41 @@
+/* rule=V0_5_0Rewrites */
+
+package example
+
+// format: off
+import cats.effect.Async
+import cats.effect.LiftIO
+import cats.effect.IOLocal
+import org.typelevel.otel4s.java._
+import org.typelevel.otel4s.java.OtelJava
+import org.typelevel.otel4s.java.trace._
+import org.typelevel.otel4s.java.trace.Traces
+import org.typelevel.otel4s.java.metrics._
+import org.typelevel.otel4s.java.metrics.Metrics
+import org.typelevel.otel4s.java.context._
+import org.typelevel.otel4s.java.context.AskContext
+import org.typelevel.otel4s.java.context.LocalContext
+import org.typelevel.otel4s.java.context.Context
+import org.typelevel.otel4s.java.instances._
+import org.typelevel.otel4s.java.instances.localForIoLocal
+import org.typelevel.otel4s.java.instances.{localForIoLocal => liftLocal}
+// format: on
+
+object Test {
+
+  def makeLocal[F[_]: Async: LiftIO](implicit local: IOLocal[Context]): Unit = {
+    val b = localForIoLocal
+    val c = localForIoLocal(Async[F], LiftIO[F], local)
+  }
+
+  def program[F[_]](implicit otelJava: OtelJava[F]): Unit = ???
+
+  def traces[F[_]](implicit traces: Traces[F]): Unit = ???
+
+  def metrics[F[_]](implicit metrics: Metrics[F]): Unit = ???
+
+  def askCtx[F[_]: AskContext]: Unit = ???
+
+  def localCtx[F[_]: LocalContext]: Unit = ???
+
+}

--- a/scalafix/input/src/main/scala/example/V0_5_0Rewrites.scala
+++ b/scalafix/input/src/main/scala/example/V0_5_0Rewrites.scala
@@ -6,6 +6,7 @@ package example
 import cats.effect.Async
 import cats.effect.LiftIO
 import cats.effect.IOLocal
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.java._
 import org.typelevel.otel4s.java.OtelJava
 import org.typelevel.otel4s.java.trace._
@@ -37,5 +38,14 @@ object Test {
   def askCtx[F[_]: AskContext]: Unit = ???
 
   def localCtx[F[_]: LocalContext]: Unit = ???
+
+  def meterOps[F[_]: Async](implicit meter: Meter[F]): Unit = {
+    meter.counter("counter").create
+    meter.histogram("histogram").withUnit("unit").create
+    meter.upDownCounter("upDownCounter").create
+    meter.observableGauge("observableGauge").create(Async[F].pure(Nil))
+    meter.observableCounter("observableCounter").create(Async[F].pure(Nil))
+    meter.observableUpDownCounter("observableUpDownCounter").create(Async[F].pure(Nil))
+  }
 
 }

--- a/scalafix/output/src/main/scala/example/V0_5_0Rewrites.scala
+++ b/scalafix/output/src/main/scala/example/V0_5_0Rewrites.scala
@@ -1,0 +1,39 @@
+package example
+
+// format: off
+import cats.effect.Async
+import cats.effect.LiftIO
+import cats.effect.IOLocal
+import org.typelevel.otel4s.oteljava._
+import org.typelevel.otel4s.oteljava.OtelJava
+import org.typelevel.otel4s.oteljava.trace._
+import org.typelevel.otel4s.oteljava.trace.Traces
+import org.typelevel.otel4s.oteljava.metrics._
+import org.typelevel.otel4s.oteljava.metrics.Metrics
+import org.typelevel.otel4s.oteljava.context._
+import org.typelevel.otel4s.oteljava.context.AskContext
+import org.typelevel.otel4s.oteljava.context.LocalContext
+import org.typelevel.otel4s.oteljava.context.Context
+import org.typelevel.otel4s.instances.local._
+import org.typelevel.otel4s.instances.local.localForIOLocal
+import org.typelevel.otel4s.instances.local.{localForIOLocal => liftLocal}
+// format: on
+
+object Test {
+
+  def makeLocal[F[_]: Async: LiftIO](implicit local: IOLocal[Context]): Unit = {
+    val b = localForIOLocal
+    val c = localForIOLocal(Async[F], LiftIO[F], local)
+  }
+
+  def program[F[_]](implicit otelJava: OtelJava[F]): Unit = ???
+
+  def traces[F[_]](implicit traces: Traces[F]): Unit = ???
+
+  def metrics[F[_]](implicit metrics: Metrics[F]): Unit = ???
+
+  def askCtx[F[_]: AskContext]: Unit = ???
+
+  def localCtx[F[_]: LocalContext]: Unit = ???
+
+}

--- a/scalafix/output/src/main/scala/example/V0_5_0Rewrites.scala
+++ b/scalafix/output/src/main/scala/example/V0_5_0Rewrites.scala
@@ -4,6 +4,7 @@ package example
 import cats.effect.Async
 import cats.effect.LiftIO
 import cats.effect.IOLocal
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.oteljava._
 import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.oteljava.trace._
@@ -35,5 +36,14 @@ object Test {
   def askCtx[F[_]: AskContext]: Unit = ???
 
   def localCtx[F[_]: LocalContext]: Unit = ???
+
+  def meterOps[F[_]: Async](implicit meter: Meter[F]): Unit = {
+    meter.counter[Long]("counter").create
+    meter.histogram[Double]("histogram").withUnit("unit").create
+    meter.upDownCounter[Long]("upDownCounter").create
+    meter.observableGauge[Double]("observableGauge").create(Async[F].pure(Nil))
+    meter.observableCounter[Long]("observableCounter").create(Async[F].pure(Nil))
+    meter.observableUpDownCounter[Long]("observableUpDownCounter").create(Async[F].pure(Nil))
+  }
 
 }

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+org.typelevel.otel4s.scalafix.V0_5_0Rewrites

--- a/scalafix/rules/src/main/scala/org/typelevel/otel4s/scalafix/V0_5_0Rewrites.scala
+++ b/scalafix/rules/src/main/scala/org/typelevel/otel4s/scalafix/V0_5_0Rewrites.scala
@@ -81,7 +81,58 @@ class V0_5_0Rewrites extends SemanticRule("V0_5_0Rewrites") {
 
       case t @ LocalForIoLocal_M(_: Term.Name) =>
         Patch.replaceTree(t, "localForIOLocal")
+
+      // meter ops
+      case MeterOps.Counter(patch) =>
+        patch
+
+      case MeterOps.Histogram(patch) =>
+        patch
+
+      case MeterOps.UpDownCounter(patch) =>
+        patch
+
+      case MeterOps.ObservableGauge(patch) =>
+        patch
+
+      case MeterOps.ObservableCounter(patch) =>
+        patch
+
+      case MeterOps.ObservableUpDownCounter(patch) =>
+        patch
+
     }.asPatch
+  }
+
+  private object MeterOps {
+    abstract class MeterOpMatcher(termName: String, tpe: String) {
+      private val matcher = SymbolMatcher.exact(
+        s"org/typelevel/otel4s/metrics/Meter#$termName()."
+      )
+
+      def unapply(term: Term)(implicit doc: SemanticDocument): Option[Patch] = {
+        term match {
+          case a @ Term.Apply.After_4_6_0(select, arg) if matcher.matches(a) =>
+            val rewrite = Term.Apply(
+              Term.ApplyType(select, Type.ArgClause(List(Type.Name(tpe)))),
+              arg
+            )
+
+            Some(Patch.replaceTree(a, rewrite.toString()))
+
+          case _ =>
+            None
+        }
+      }
+    }
+
+    object Counter extends MeterOpMatcher("counter", "Long")
+    object Histogram extends MeterOpMatcher("histogram", "Double")
+    object UpDownCounter extends MeterOpMatcher("upDownCounter", "Long")
+    object ObservableGauge extends MeterOpMatcher("observableGauge", "Double")
+    object ObservableCounter extends MeterOpMatcher("observableCounter", "Long")
+    object ObservableUpDownCounter
+        extends MeterOpMatcher("observableUpDownCounter", "Long")
   }
 
 }

--- a/scalafix/rules/src/main/scala/org/typelevel/otel4s/scalafix/V0_5_0Rewrites.scala
+++ b/scalafix/rules/src/main/scala/org/typelevel/otel4s/scalafix/V0_5_0Rewrites.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.scalafix
+
+import scalafix.v1._
+import scala.meta._
+
+class V0_5_0Rewrites extends SemanticRule("V0_5_0Rewrites") {
+
+  private object selectors {
+    def oteljava(packages: String*): Term.Ref =
+      otel4s("oteljava" :: packages.toList: _*)
+
+    def otel4s(packages: String*): Term.Ref =
+      make("org" :: "typelevel" :: "otel4s" :: packages.toList: _*)
+
+    def make(packages: String*): Term.Ref =
+      packages.tail.foldLeft(Term.Name(packages.head): Term.Ref) {
+        case (selector, pkg) =>
+          Term.Select(selector, Term.Name(pkg))
+      }
+  }
+
+  private object imports {
+    val java = SymbolMatcher.exact("org/typelevel/otel4s/java/")
+    val metrics = SymbolMatcher.exact("org/typelevel/otel4s/java/metrics/")
+    val context = SymbolMatcher.exact("org/typelevel/otel4s/java/context/")
+    val trace = SymbolMatcher.exact("org/typelevel/otel4s/java/trace/")
+    val instances = SymbolMatcher.exact("org/typelevel/otel4s/java/instances.")
+  }
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    val LocalForIoLocal_M = SymbolMatcher.exact(
+      "org/typelevel/otel4s/java/instances.localForIoLocal()."
+    )
+
+    doc.tree.collect {
+      case importer @ Importer(ref, _) if imports.java.matches(ref) =>
+        val next = importer.copy(ref = selectors.oteljava())
+        Patch.replaceTree(importer, next.toString())
+
+      case importer @ Importer(ref, _) if imports.metrics.matches(ref) =>
+        val next = importer.copy(ref = selectors.oteljava("metrics"))
+        Patch.replaceTree(importer, next.toString())
+
+      case importer @ Importer(ref, _) if imports.context.matches(ref) =>
+        val next = importer.copy(ref = selectors.oteljava("context"))
+        Patch.replaceTree(importer, next.toString())
+
+      case importer @ Importer(ref, _) if imports.trace.matches(ref) =>
+        val next = importer.copy(ref = selectors.oteljava("trace"))
+        Patch.replaceTree(importer, next.toString())
+
+      case importer @ Importer(ref, imp) if imports.instances.matches(ref) =>
+        val importees = imp.map {
+          case Importee.Name(Name("localForIoLocal")) =>
+            Importee.Name(Name("localForIOLocal"))
+
+          case Importee.Rename(Name("localForIoLocal"), rename) =>
+            Importee.Rename(Name("localForIOLocal"), rename)
+
+          case other => other
+        }
+
+        val next = Importer(selectors.otel4s("instances", "local"), importees)
+        Patch.replaceTree(importer, next.toString())
+
+      case t @ LocalForIoLocal_M(_: Term.Name) =>
+        Patch.replaceTree(t, "localForIOLocal")
+    }.asPatch
+  }
+
+}

--- a/scalafix/tests/src/test/scala/org/typelevel/otel4s/scalafix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/org/typelevel/otel4s/scalafix/RuleSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.scalafix
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scalafix.testkit._
+
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
+  runAllTests()
+}


### PR DESCRIPTION
Closes #413.

Do we need to publish the rule as a separate jar? From what I see, Scala Steward should work with a reference to git too?

```hocon
migrations = [
  {
    groupId: "org.typelevel",
    artifactIds: ["otel4s-.*"],
    newVersion: "0.5.0",
    rewriteRules: ["github:typelevel/otel4s/V0_5_0Rewrites?sha=v0.5.0"]
  }
]
```