### PR TITLE
Histogram builder: add `withExplicitBucketBoundaries`

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/BucketBoundaries.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/BucketBoundaries.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.metrics
+
+/** Represents bucket boundaries of a [[Histogram]] instrument.
+  */
+sealed trait BucketBoundaries {
+  def boundaries: Vector[Double]
+}
+
+object BucketBoundaries {
+
+  /** Creates [[BucketBoundaries]] using the given `boundaries`.
+    *
+    * Throws an exception if any of the following rules is violated:
+    *   - the boundary cannot be `Double.NaN`
+    *   - the boundaries must be in increasing order
+    *   - first boundary cannot be `Double.NegativeInfinity`
+    *   - last boundary cannot be `Double.PositiveInfinity`
+    *
+    * @param boundaries
+    *   the vector of bucket boundaries
+    */
+  def apply(boundaries: Vector[Double]): BucketBoundaries = {
+    require(
+      boundaries.forall(b => !b.isNaN),
+      "bucket boundary cannot be NaN"
+    )
+
+    require(
+      boundaries.sizeIs < 2 || boundaries.sliding(2).forall(p => p(0) < p(1)),
+      "bucket boundaries must be in increasing oder"
+    )
+
+    require(
+      boundaries.isEmpty || !boundaries.head.isNegInfinity,
+      "first boundary cannot be -Inf"
+    )
+    require(
+      boundaries.isEmpty || !boundaries.last.isPosInfinity,
+      "last boundary cannot be +Inf"
+    )
+
+    Impl(boundaries)
+  }
+
+  private final case class Impl(
+      boundaries: Vector[Double]
+  ) extends BucketBoundaries
+}

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
@@ -45,6 +45,55 @@ trait Histogram[F[_], A] extends HistogramMacro[F, A]
 
 object Histogram {
 
+  /** A builder of [[Histogram]].
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record. OpenTelemetry specification expects
+    *   `A` to be either [[scala.Long]] or [[scala.Double]].
+    */
+  trait Builder[F[_], A] {
+
+    /** Sets the unit of measure for this histogram.
+      *
+      * @see
+      *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-unit Instrument Unit]]
+      *
+      * @param unit
+      *   the measurement unit. Must be 63 or fewer ASCII characters.
+      */
+    def withUnit(unit: String): Builder[F, A]
+
+    /** Sets the description for this histogram.
+      *
+      * @see
+      *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-description Instrument Description]]
+      *
+      * @param description
+      *   the description to use
+      */
+    def withDescription(description: String): Builder[F, A]
+
+    /** Sets the explicit bucket boundaries for this histogram.
+      *
+      * @see
+      *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-advisory-parameter-explicitbucketboundaries Explicit bucket boundaries]]
+      *
+      * @param boundaries
+      *   the boundaries to use
+      */
+    def withExplicitBucketBoundaries(
+        boundaries: BucketBoundaries
+    ): Builder[F, A]
+
+    /** Creates a [[Histogram]] with the given `unit`, `description`, and
+      * `bucket boundaries` (if any).
+      */
+    def create: F[Histogram[F, A]]
+  }
+
   trait Meta[F[_]] extends InstrumentMeta[F] {
     def resourceUnit: Resource[F, Unit]
   }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
@@ -60,7 +60,7 @@ trait Meter[F[_]] {
     * @param name
     *   the name of the instrument
     */
-  def histogram(name: String): SyncInstrumentBuilder[F, Histogram[F, Double]]
+  def histogram(name: String): Histogram.Builder[F, Double]
 
   /** Creates a builder of [[UpDownCounter]] instrument that records
     * [[scala.Long]] values.
@@ -146,11 +146,16 @@ object Meter {
 
       def histogram(
           name: String
-      ): SyncInstrumentBuilder[F, Histogram[F, Double]] =
-        new SyncInstrumentBuilder[F, Histogram[F, Double]] {
-          type Self = this.type
-          def withUnit(unit: String): Self = this
-          def withDescription(description: String): Self = this
+      ): Histogram.Builder[F, Double] =
+        new Histogram.Builder[F, Double] {
+          def withUnit(unit: String): Histogram.Builder[F, Double] = this
+          def withDescription(
+              description: String
+          ): Histogram.Builder[F, Double] = this
+          def withExplicitBucketBoundaries(
+              boundaries: BucketBoundaries
+          ): Histogram.Builder[F, Double] =
+            this
           def create: F[Histogram[F, Double]] = F.pure(Histogram.noop)
         }
 

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/BucketBoundariesSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/BucketBoundariesSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.metrics
+
+import munit._
+
+class BucketBoundariesSuite extends FunSuite {
+
+  test("fail when a boundary is Double.NaN") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: bucket boundary cannot be NaN"
+    )(
+      BucketBoundaries(Vector(1.0, 2.0, Double.NaN, 3.0))
+    )
+  }
+
+  test("fail when boundaries are not increasing") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: bucket boundaries must be in increasing oder"
+    )(
+      BucketBoundaries(Vector(1.0, 1.2, 0.5, 3.0))
+    )
+  }
+
+  test("fail when first boundary is -Inf") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: first boundary cannot be -Inf"
+    )(
+      BucketBoundaries(Vector(Double.NegativeInfinity))
+    )
+  }
+
+  test("fail when last boundary is +Inf") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: last boundary cannot be +Inf"
+    )(
+      BucketBoundaries(Vector(Double.PositiveInfinity))
+    )
+  }
+
+  test("create successfully when input is valid") {
+    val input = Vector(
+      Vector.empty[Double],
+      Vector(1.0),
+      Vector(Double.MinValue),
+      Vector(Double.MinValue, Double.MaxValue),
+      Vector(Double.MaxValue),
+      Vector(-0.5, 0, 0.5, 1.5, 3.5)
+    )
+
+    input.foreach { boundaries =>
+      assertEquals(BucketBoundaries(boundaries).boundaries, boundaries)
+    }
+  }
+
+}

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
@@ -27,9 +27,7 @@ private[oteljava] class MeterImpl[F[_]: Async](jMeter: JMeter)
   def counter(name: String): SyncInstrumentBuilder[F, Counter[F, Long]] =
     new CounterBuilderImpl(jMeter, name)
 
-  def histogram(
-      name: String
-  ): SyncInstrumentBuilder[F, Histogram[F, Double]] =
+  def histogram(name: String): Histogram.Builder[F, Double] =
     new HistogramBuilderImpl(jMeter, name)
 
   def upDownCounter(


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | [Explicit bucket boundaries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-advisory-parameter-explicitbucketboundaries)  |
| Java implementation | [LongHistogramBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/metrics/LongHistogramBuilder.java) <br> [DoubleHistogramBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/metrics/DoubleHistogramBuilder.java) | 


