### PR TITLE
Use no-op `cats.effect.std.Console` in tests

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessor.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessor.scala
@@ -60,7 +60,7 @@ final class SimpleSpanProcessor[F[_]: MonadThrow: Console] private (
   private def doExport(span: SpanData): F[Unit] =
     exporter.exportSpans(List(span)).handleErrorWith { e =>
       Console[F].errorln(
-        s"SimpleSpanExporter: the export has failed: ${e.getMessage}\n${e.getStackTrace.mkString("\n")}\n"
+        s"SimpleSpanProcessor: the export has failed: ${e.getMessage}\n${e.getStackTrace.mkString("\n")}\n"
       )
     }
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/NoopConsole.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/NoopConsole.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.Show
+import cats.effect.Sync
+import cats.effect.std.Console
+
+import java.nio.charset.Charset
+
+class NoopConsole[F[_]: Sync] extends Console[F] {
+  def readLineWithCharset(charset: Charset): F[String] =
+    Sync[F].delay(sys.error("not implemented"))
+  def print[A](a: A)(implicit S: Show[A]): F[Unit] = Sync[F].unit
+  def println[A](a: A)(implicit S: Show[A]): F[Unit] = Sync[F].unit
+  def error[A](a: A)(implicit S: Show[A]): F[Unit] = Sync[F].unit
+  def errorln[A](a: A)(implicit S: Show[A]): F[Unit] = Sync[F].unit
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -19,6 +19,7 @@ package sdk
 package trace
 
 import cats.effect.IO
+import cats.effect.std.Console
 import cats.effect.std.Queue
 import cats.effect.testkit.TestControl
 import cats.syntax.monoid._
@@ -42,6 +43,8 @@ import org.typelevel.otel4s.trace.Status
 import scala.concurrent.duration._
 
 class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+
+  private implicit val noopConsole: Console[IO] = new NoopConsole[IO]
 
   // Span.Backend methods
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/BatchSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/BatchSpanProcessorSuite.scala
@@ -19,6 +19,7 @@ package processor
 
 import cats.Foldable
 import cats.effect.IO
+import cats.effect.std.Console
 import cats.syntax.foldable._
 import cats.syntax.traverse._
 import munit.CatsEffectSuite
@@ -33,6 +34,8 @@ import org.typelevel.otel4s.sdk.trace.scalacheck.Arbitraries._
 class BatchSpanProcessorSuite
     extends CatsEffectSuite
     with ScalaCheckEffectSuite {
+
+  private implicit val noopConsole: Console[IO] = new NoopConsole[IO]
 
   test("show details in the name") {
     val exporter = new FailingExporter(

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
@@ -19,6 +19,7 @@ package processor
 
 import cats.Foldable
 import cats.effect.IO
+import cats.effect.std.Console
 import cats.syntax.foldable._
 import cats.syntax.traverse._
 import munit.CatsEffectSuite
@@ -43,6 +44,8 @@ import scala.concurrent.duration.FiniteDuration
 class SimpleSpanProcessorSuite
     extends CatsEffectSuite
     with ScalaCheckEffectSuite {
+
+  private implicit val noopConsole: Console[IO] = new NoopConsole[IO]
 
   test("show details in the name") {
     val exporter = new FailingExporter(


### PR DESCRIPTION
Test logs are verbose and non-informative. We can silent them.