### PR TITLE
sdk: add `AutoConfigure` and `Config`

### DIFF
--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/AutoConfigure.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/AutoConfigure.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+import cats.MonadThrow
+import cats.effect.Resource
+import cats.syntax.monadError._
+
+/** Creates and autoconfigures the component of type `A` using `config`.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  *
+  * @tparam A
+  *   the type of the component
+  */
+trait AutoConfigure[F[_], A] {
+  def configure(config: Config): Resource[F, A]
+}
+
+object AutoConfigure {
+
+  abstract class WithHint[F[_]: MonadThrow, A](
+      hint: String
+  ) extends AutoConfigure[F, A] {
+
+    final def configure(config: Config): Resource[F, A] =
+      fromConfig(config).adaptError {
+        case e: AutoConfigureError => e
+        case cause                 => new AutoConfigureError(hint, cause)
+      }
+
+    protected def fromConfig(config: Config): Resource[F, A]
+  }
+
+}

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/AutoConfigureError.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/AutoConfigureError.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+final class AutoConfigureError(
+    hint: String,
+    cause: Throwable
+) extends RuntimeException(s"Cannot auto configure [$hint]", cause)

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/Config.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/Config.scala
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+import cats.effect.Sync
+import cats.effect.std.Env
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+
+import scala.concurrent.duration._
+
+/** The config to use for auto-configuration of the SDK components.
+  */
+sealed trait Config {
+
+  /** Returns the decoded value for the given key.
+    *
+    * @param key
+    *   the key a value is associated with
+    *
+    * @tparam A
+    *   the type of a value
+    *
+    * @return
+    *   - `Left(ConfigurationError)` - when the key exists in the config but
+    *     cannot be decoded as `A`
+    *
+    *   - `Right(None)` - when the key does not exist in the config
+    *
+    *   - `Right(Some(a))` - when the key exists in the config and successfully
+    *     decoded as `A`
+    */
+  def get[A: Config.Reader](key: String): Either[ConfigurationError, Option[A]]
+
+  /** Returns the decoded value for the given key or the default one.
+    *
+    * @param key
+    *   the key a value is associated with
+    *
+    * @param default
+    *   the default value
+    *
+    * @tparam A
+    *   the type of a value
+    */
+  final def getOrElse[A: Config.Reader](
+      key: String,
+      default: => A
+  ): Either[ConfigurationError, A] =
+    get[A](key).map(_.getOrElse(default))
+
+  /** Returns the decoded value for the given key.
+    *
+    * @param key
+    *   the key a value is associated with
+    *
+    * @tparam A
+    *   the type of a value
+    *
+    * @return
+    *   - `Left(ConfigurationError)` - when the key exists in the config but
+    *     cannot be decoded as `A`
+    *
+    *   - `Right(None)` - when the key does not exist in the config
+    *
+    *   - `Right(Some(a))` - when the key exists in the config and successfully
+    *     decoded as `A`
+    */
+  final def get[A: Config.Reader](
+      key: Config.Key[A]
+  ): Either[ConfigurationError, Option[A]] =
+    get[A](key.name)
+
+  /** Returns the decoded value for the given key or the default one.
+    *
+    * @param key
+    *   the key a value is associated with
+    *
+    * @param default
+    *   the default value
+    *
+    * @tparam A
+    *   the type of a value
+    */
+  final def getOrElse[A: Config.Reader](
+      key: Config.Key[A],
+      default: => A
+  ): Either[ConfigurationError, A] =
+    get[A](key).map(_.getOrElse(default))
+
+  /** Returns a copy of the config with the overriden values.
+    *
+    * @param overrides
+    *   the values to override
+    */
+  def withOverrides(overrides: Map[String, String]): Config
+}
+
+object Config {
+
+  final class Key[A] private (val name: String)
+  object Key {
+    def apply[A](name: String): Key[A] = new Key[A](name)
+  }
+
+  /** Decodes a string value as `A`.
+    *
+    * @tparam A
+    *   the type of a value
+    */
+  trait Reader[A] {
+    def read(
+        key: String,
+        properties: Map[String, String]
+    ): Either[ConfigurationError, Option[A]]
+  }
+
+  object Reader {
+    def apply[A](implicit ev: Reader[A]): Reader[A] = ev
+
+    implicit val stringReader: Reader[String] =
+      (key, props) => Right(props.get(key).map(_.trim).filter(_.nonEmpty))
+
+    implicit val booleanReader: Reader[Boolean] =
+      decodeWithHint("Boolean")(v => Right(v.toBoolean))
+
+    implicit val doubleReader: Reader[Double] =
+      decodeWithHint("Double")(v => Right(v.toDouble))
+
+    implicit val intReader: Reader[Int] =
+      decodeWithHint("Int")(v => Right(v.toInt))
+
+    implicit val finiteDurationReader: Reader[FiniteDuration] =
+      decodeWithHint("FiniteDuration") { string =>
+        Duration(string) match {
+          case duration: FiniteDuration =>
+            Right(duration)
+          case _ =>
+            Left(ConfigurationError("The duration must be finite"))
+        }
+      }
+
+    implicit val stringListReader: Reader[List[String]] =
+      decodeWithHint("List[String]")(string => Right(asStringList(string)))
+
+    implicit val stringSetReader: Reader[Set[String]] =
+      decodeWithHint("Set[String]") { string =>
+        val list = asStringList(string)
+        val set = list.toSet
+
+        Either.cond(
+          test = set.size == list.size,
+          right = set,
+          left = {
+            val duplicates = list.diff(set.toSeq).toSet.mkString("[", ", ", "]")
+            ConfigurationError(
+              s"The string set contains duplicates: $duplicates"
+            )
+          }
+        )
+      }
+
+    implicit val stringMapReader: Reader[Map[String, String]] =
+      decodeWithHint("Map[String, String]") { string =>
+        val list = asStringList(string)
+
+        list
+          .traverse { entry =>
+            val parts = entry.split("=", 2).map(_.trim)
+            Either.cond(
+              test = parts.length == 2 && parts.head.nonEmpty,
+              right = parts.toList,
+              left = ConfigurationError(s"Invalid map property [$entry]")
+            )
+          }
+          .map { entries =>
+            entries
+              .collect { case key :: value :: Nil => (key, value) }
+              .groupMapReduce(_._1)(_._2)((_, last) => last)
+          }
+      }
+
+    private def asStringList(string: String): List[String] =
+      string.split(",").map(_.trim).filter(_.nonEmpty).toList
+
+    private def decodeWithHint[A](
+        hint: String
+    )(decode: String => Either[ConfigurationError, A]): Reader[A] =
+      (key, properties) =>
+        Reader[String].read(key, properties).flatMap {
+          case Some(value) =>
+            Either
+              .catchNonFatal(decode(value))
+              .leftMap { cause =>
+                ConfigurationError(
+                  s"Invalid value for property $key=$value. Must be [$hint]",
+                  cause
+                )
+              }
+              .flatten
+              .map(Some(_))
+
+          case None => Right(None)
+        }
+
+  }
+
+  /** Creates a [[Config]] with the given properties. The keys of the properties
+    * will be normalized.
+    *
+    * The priorities of the values: system properties > env variables > default.
+    *
+    * @param systemProperties
+    *   the system properties (e.g. `sys.props`)
+    *
+    * @param environmentVariables
+    *   the env variables (e.g. `sys.env`)
+    *
+    * @param defaultProperties
+    *   the default properties
+    */
+  def apply(
+      systemProperties: Map[String, String],
+      environmentVariables: Map[String, String],
+      defaultProperties: Map[String, String]
+  ): Config = {
+    val default = defaultProperties.map { case (key, value) =>
+      (normalizePropertyKey(key), value)
+    }
+
+    val env = environmentVariables.map { case (key, value) =>
+      (normalizeEnvVariableKey(key), value)
+    }
+
+    val props = systemProperties.map { case (key, value) =>
+      (normalizePropertyKey(key), value)
+    }
+
+    Impl(default ++ env ++ props)
+  }
+
+  /** Creates a [[Config]] by loading properties from the env variables and
+    * system props.
+    *
+    * @param default
+    *   the default properties
+    */
+  def load[F[_]: Sync](default: Map[String, String]): F[Config] =
+    for {
+      envVars <- Env.make[F].entries
+      systemProps <- Sync[F].delay(sys.props.toMap)
+    } yield apply(systemProps, envVars.toMap, default)
+
+  private final case class Impl[F[_]](
+      properties: Map[String, String]
+  ) extends Config {
+
+    def get[A: Reader](key: String): Either[ConfigurationError, Option[A]] =
+      Reader[A].read(normalizePropertyKey(key), properties)
+
+    def withOverrides(overrides: Map[String, String]): Config = {
+      val normalized = overrides.map { case (key, value) =>
+        (normalizePropertyKey(key), value)
+      }
+
+      copy(properties = this.properties ++ normalized)
+    }
+
+  }
+
+  /** Normalizes a property key by converting to lower case and replacing "-"
+    * with ".".
+    */
+  private def normalizePropertyKey(key: String): String =
+    key.toLowerCase.replace("-", ".");
+
+  /** Normalizes an env variable key by converting to lower case and replacing
+    * "_" with ".".
+    */
+  private def normalizeEnvVariableKey(key: String): String =
+    key.toLowerCase.replace("_", ".")
+
+}

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/ConfigurationError.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/ConfigurationError.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+final class ConfigurationError(
+    message: String,
+    cause: Option[Throwable]
+) extends RuntimeException(message, cause.orNull)
+
+object ConfigurationError {
+
+  def apply(message: String): ConfigurationError =
+    new ConfigurationError(message, None)
+
+  def apply(message: String, cause: Throwable): ConfigurationError =
+    new ConfigurationError(message, Some(cause))
+
+}

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk
+package autoconfigure
+
+import cats.MonadThrow
+import cats.effect.Resource
+import cats.syntax.either._
+import cats.syntax.traverse._
+import org.typelevel.otel4s.semconv.resource.attributes.ResourceAttributes
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/** Autoconfigures [[TelemetryResource]].
+  *
+  * The configuration options:
+  * {{{
+  * | System property                          | Environment variable                     | Description                                                                                                |
+  * |------------------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------|
+  * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
+  * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
+  * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
+  * }}}
+  *
+  * @see
+  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+  */
+private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
+    extends AutoConfigure.WithHint[F, TelemetryResource]("TelemetryResource") {
+
+  import TelemetryResourceAutoConfigure.ConfigKeys
+
+  def fromConfig(config: Config): Resource[F, TelemetryResource] = {
+    def parse(entries: List[(String, String)], disabledKeys: Set[String]) =
+      entries
+        .filter { case (key, _) => !disabledKeys.contains(key) }
+        .traverse { case (key, value) =>
+          Either
+            .catchNonFatal {
+              val decoded =
+                URLDecoder.decode(value, StandardCharsets.UTF_8.name)
+              Attribute(key, decoded)
+            }
+            .leftMap { e =>
+              ConfigurationError("Unable to decode resource attributes", e)
+            }
+        }
+
+    val attempt = for {
+      disabledKeys <-
+        config.getOrElse(ConfigKeys.DisabledKeys, Set.empty[String])
+
+      entries <-
+        config.getOrElse(ConfigKeys.Attributes, Map.empty[String, String])
+
+      attributes <- parse(entries.toList, disabledKeys)
+    } yield {
+      val serviceName = config
+        .get(ConfigKeys.ServiceName)
+        .toOption
+        .flatten
+        .map(value => ResourceAttributes.ServiceName(value))
+
+      TelemetryResource(
+        Attributes.fromSpecific(attributes ++ serviceName.toSeq)
+      )
+    }
+
+    Resource.eval(MonadThrow[F].fromEither(attempt))
+  }
+
+}
+
+private[sdk] object TelemetryResourceAutoConfigure {
+
+  private object ConfigKeys {
+    val DisabledKeys: Config.Key[Set[String]] =
+      Config.Key("otel.experimental.resource.disabled.keys")
+
+    val Attributes: Config.Key[Map[String, String]] =
+      Config.Key("otel.resource.attributes")
+
+    val ServiceName: Config.Key[String] =
+      Config.Key("otel.service.name")
+  }
+
+  /** Returns [[AutoConfigure]] that configures the [[TelemetryResource]].
+    *
+    * The configuration options:
+    * {{{
+    * | System property                          | Environment variable                     | Description                                                                                                |
+    * |------------------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------|
+    * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
+    * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
+    * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
+    * }}}
+    *
+    * @see
+    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+    */
+  def apply[F[_]: MonadThrow]: AutoConfigure[F, TelemetryResource] =
+    new TelemetryResourceAutoConfigure[F]
+
+}

--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/ConfigSuite.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/ConfigSuite.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+import cats.syntax.either._
+import munit.FunSuite
+
+import scala.concurrent.duration._
+
+class ConfigSuite extends FunSuite {
+
+  private val properties = Map(
+    "test.string" -> "str",
+    "test.int" -> "10",
+    "test.double" -> "5.4",
+    "test.boolean" -> "true",
+    "test.list" -> "a,b,c",
+    "test.map" -> "a=1,b=2,c=3,d=",
+    "test.duration" -> "1s",
+  )
+
+  test("get - using dots") {
+    val config = makeConfig(properties)
+
+    assertEquals(config.get[String]("test.string"), Right(Some("str")))
+    assertEquals(config.get[Int]("test.int"), Right(Some(10)))
+    assertEquals(config.get[Double]("test.double"), Right(Some(5.4)))
+    assertEquals(config.get[Boolean]("test.boolean"), Right(Some(true)))
+    assertEquals(
+      config.get[List[String]]("test.list"),
+      Right(Some(List("a", "b", "c")))
+    )
+    assertEquals(
+      config.get[Set[String]]("test.list"),
+      Right(Some(Set("a", "b", "c")))
+    )
+    assertEquals(
+      config.get[Map[String, String]]("test.map"),
+      Right(Some(Map("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "")))
+    )
+    assertEquals(
+      config.get[FiniteDuration]("test.duration"),
+      Right(Some(1.second))
+    )
+  }
+
+  test("get - using hyphens") {
+    val config = makeConfig(properties)
+
+    assertEquals(config.get[String]("test-string"), Right(Some("str")))
+    assertEquals(config.get[Int]("test-int"), Right(Some(10)))
+    assertEquals(config.get[Double]("test-double"), Right(Some(5.4)))
+    assertEquals(config.get[Boolean]("test-boolean"), Right(Some(true)))
+    assertEquals(
+      config.get[List[String]]("test-list"),
+      Right(Some(List("a", "b", "c")))
+    )
+    assertEquals(
+      config.get[Set[String]]("test-list"),
+      Right(Some(Set("a", "b", "c")))
+    )
+    assertEquals(
+      config.get[Map[String, String]]("test-map"),
+      Right(Some(Map("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "")))
+    )
+    assertEquals(
+      config.get[FiniteDuration]("test-duration"),
+      Right(Some(1.second))
+    )
+  }
+
+  test("get - missing entries") {
+    val config = makeConfig(Map.empty)
+
+    assertEquals(config.get[String]("test.string"), Right(None))
+    assertEquals(config.get[Int]("test.int"), Right(None))
+    assertEquals(config.get[Double]("test.double"), Right(None))
+    assertEquals(config.get[Boolean]("test.boolean"), Right(None))
+    assertEquals(config.get[List[String]]("test.list"), Right(None))
+    assertEquals(config.get[Map[String, String]]("test.map"), Right(None))
+    assertEquals(config.get[FiniteDuration]("test.duration"), Right(None))
+  }
+
+  test("get - empty values") {
+    val config = makeConfig(properties.map { case (k, _) => (k, "") })
+
+    assertEquals(config.get[String]("test.string"), Right(None))
+    assertEquals(config.get[Int]("test.int"), Right(None))
+    assertEquals(config.get[Double]("test.double"), Right(None))
+    assertEquals(config.get[Boolean]("test.boolean"), Right(None))
+    assertEquals(config.get[List[String]]("test.list"), Right(None))
+    assertEquals(config.get[Map[String, String]]("test.map"), Right(None))
+    assertEquals(config.get[FiniteDuration]("test.duration"), Right(None))
+  }
+
+  test("get - non-trivial string list") {
+    val config = makeConfig(Map("key" -> "   a,  b,c   ,d,, e,, d ,  ,"))
+
+    assertEquals(
+      config.get[List[String]]("key"),
+      Right(Some(List("a", "b", "c", "d", "e", "d")))
+    )
+  }
+
+  test("get - non-trivial string set") {
+    val config = makeConfig(Map("key" -> "   a,  b,c   ,d,, e,, f ,  ,"))
+
+    assertEquals(
+      config.get[Set[String]]("key"),
+      Right(Some(Set("a", "b", "c", "d", "e", "f")))
+    )
+  }
+
+  test("get - non-trivial string map") {
+    val config = makeConfig(Map("key" -> "   a=1,  b=2,c =  3   ,   d= 4,, ,"))
+
+    assertEquals(
+      config.get[Map[String, String]]("key"),
+      Right(Some(Map("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4")))
+    )
+  }
+
+  test("get - invalid int") {
+    assertEquals(
+      makeConfig(Map("key" -> "value")).get[Int]("key").leftMap(_.getMessage),
+      Left("Invalid value for property key=value. Must be [Int]")
+    )
+
+    assertEquals(
+      makeConfig(Map("key" -> Long.MaxValue.toString))
+        .get[Int]("key")
+        .leftMap(_.getMessage),
+      Left("Invalid value for property key=9223372036854775807. Must be [Int]")
+    )
+  }
+
+  test("get - invalid double") {
+    val config = makeConfig(Map("key" -> "value"))
+
+    assertEquals(
+      config.get[Double]("key").leftMap(_.getMessage),
+      Left("Invalid value for property key=value. Must be [Double]")
+    )
+  }
+
+  test("get - invalid boolean") {
+    val config = makeConfig(Map("key" -> "value"))
+
+    assertEquals(
+      config.get[Boolean]("key").leftMap(_.getMessage),
+      Left("Invalid value for property key=value. Must be [Boolean]")
+    )
+  }
+
+  test("get - invalid string map") {
+    val config = makeConfig(Map("key" -> "a=1,b"))
+
+    assertEquals(
+      config.get[Map[String, String]]("key").leftMap(_.getMessage),
+      Left("Invalid map property [b]")
+    )
+  }
+
+  test("get - invalid string set (duplicates)") {
+    val config = makeConfig(Map("key" -> "   a,  b,c   ,d,, b,, e ,  c,"))
+
+    assertEquals(
+      config.get[Set[String]]("key").leftMap(_.getMessage),
+      Left("The string set contains duplicates: [b, c]")
+    )
+  }
+
+  test("get - invalid duration (non parsable)") {
+    val config = makeConfig(Map("key" -> "12secz"))
+
+    assertEquals(
+      config.get[FiniteDuration]("key").leftMap(_.getMessage),
+      Left("Invalid value for property key=12secz. Must be [FiniteDuration]")
+    )
+  }
+
+  test("get - invalid duration (infinite)") {
+    val config = makeConfig(Map("key" -> "Inf"))
+
+    assertEquals(
+      config.get[FiniteDuration]("key").leftMap(_.getMessage),
+      Left("The duration must be finite")
+    )
+  }
+
+  private def makeConfig(props: Map[String, String]): Config =
+    Config(props, Map.empty, Map.empty)
+
+}

--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk
+package autoconfigure
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
+
+  test("load from an empty config") {
+    val config = Config(Map.empty, Map.empty, Map.empty)
+    TelemetryResourceAutoConfigure[IO].configure(config).use { resource =>
+      IO(assertEquals(resource, TelemetryResource.empty))
+    }
+  }
+
+  test("load from the config") {
+    val props = Map(
+      "otel.service.name" -> "some-service",
+      "otel.resource.attributes" -> "key1=val1,key2=val2,key3=val3",
+      "otel.experimental.resource.disabled-keys" -> "key1,val3,test,key3"
+    )
+
+    val config = Config(props, Map.empty, Map.empty)
+
+    val expectedAttributes = Attributes(
+      Attribute("key2", "val2"),
+      Attribute("service.name", "some-service")
+    )
+
+    TelemetryResourceAutoConfigure[IO].configure(config).use { resource =>
+      IO(assertEquals(resource, TelemetryResource(expectedAttributes)))
+    }
+  }
+}


### PR DESCRIPTION
That's the first step towards an auto-configuration of the SDK module. 

OpenTelemetry Java also relies on the [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html), which is available only on the JVM (IIRC). https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#resource-provider-spi.


How the `AutoConfigure` can be used in the SDK module:

https://github.com/typelevel/otel4s/blob/34a509247f8c6eb02b3a2f8745aa6d63946ac52e/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala#L194-L205