### PR TITLE
metrics: redefine `Measurement` as a sealed trait

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
@@ -17,11 +17,58 @@
 package org.typelevel.otel4s.metrics
 
 import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
 
-/** @param value
-  *   the value to record
+/** The measurement to use with asynchronous instruments.
   *
-  * @param attributes
-  *   the set of attributes to associate with the value
+  * @tparam A
+  *   the type of the values to record
   */
-final case class Measurement[A](value: A, attributes: List[Attribute[_]])
+sealed trait Measurement[A] {
+
+  /** The value to record
+    */
+  def value: A
+
+  /** The set of attributes to associate with the value
+    */
+  def attributes: Attributes
+}
+
+object Measurement {
+
+  /** Creates a [[Measurement]] with the given `value`.
+    *
+    * @param value
+    *   the value to record
+    */
+  def apply[A](value: A): Measurement[A] =
+    Impl(value, Attributes.empty)
+
+  /** Creates a [[Measurement]] with the given `value` and `attributes`.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the attributes to associate with the value
+    */
+  def apply[A](value: A, attributes: Attribute[_]*): Measurement[A] =
+    Impl(value, Attributes.fromSpecific(attributes))
+
+  /** Creates a [[Measurement]] with the given `value` and `attributes`.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the attributes to associate with the value
+    */
+  def apply[A](value: A, attributes: Attributes): Measurement[A] =
+    Impl(value, attributes)
+
+  private final case class Impl[A](
+      value: A,
+      attributes: Attributes
+  ) extends Measurement[A]
+}

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.metrics
 
 import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
 
 trait ObservableMeasurement[F[_], A] {
 
@@ -28,5 +29,16 @@ trait ObservableMeasurement[F[_], A] {
     * @param attributes
     *   the set of attributes to associate with the value
     */
-  def record(value: A, attributes: Attribute[_]*): F[Unit]
+  final def record(value: A, attributes: Attribute[_]*): F[Unit] =
+    record(value, Attributes.fromSpecific(attributes))
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def record(value: A, attributes: Attributes): F[Unit]
 }

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
@@ -57,8 +57,8 @@ class ObservableSuite extends CatsEffectSuite {
             .getAndUpdate(_ + 1)
             .map(x =>
               List(
-                Measurement(x, List(Attribute("thing", "a"))),
-                Measurement(x, List(Attribute("thing", "b")))
+                Measurement(x, Attribute("thing", "a")),
+                Measurement(x, Attribute("thing", "b"))
               )
             )
         )
@@ -93,8 +93,8 @@ object ObservableSuite {
   ) {
     def run: IO[Unit] =
       callback(new ObservableMeasurement[IO, A] {
-        def record(value: A, attributes: Attribute[_]*): IO[Unit] =
-          observations.update(Record(value, attributes) :: _)
+        def record(value: A, attributes: Attributes): IO[Unit] =
+          observations.update(Record(value, attributes.toSeq) :: _)
       })
   }
 
@@ -117,7 +117,7 @@ object ObservableSuite {
           InMemoryObservable[A](
             recorder =>
               measurements.flatMap(
-                _.traverse_(x => recorder.record(x.value, x.attributes: _*))
+                _.traverse_(x => recorder.record(x.value, x.attributes))
               ),
             obs
           )

--- a/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/Conversions.scala
+++ b/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/Conversions.scala
@@ -21,7 +21,7 @@ import io.opentelemetry.api.common.{Attributes => JAttributes}
 
 private[oteljava] object Conversions {
 
-  def toJAttributes(attributes: Seq[Attribute[_]]): JAttributes = {
+  def toJAttributes(attributes: Iterable[Attribute[_]]): JAttributes = {
     val builder = JAttributes.builder
 
     attributes.foreach { case Attribute(key, value) =>

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableDoubleImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableDoubleImpl.scala
@@ -27,7 +27,7 @@ private[oteljava] class ObservableDoubleImpl[F[_]](
 )(implicit F: Sync[F])
     extends ObservableMeasurement[F, Double] {
 
-  def record(value: Double, attributes: Attribute[_]*): F[Unit] =
+  def record(value: Double, attributes: Attributes): F[Unit] =
     F.delay(odm.record(value, Conversions.toJAttributes(attributes)))
 
 }

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableLongImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableLongImpl.scala
@@ -27,7 +27,7 @@ private[oteljava] class ObservableLongImpl[F[_]](
 )(implicit F: Sync[F])
     extends ObservableMeasurement[F, Long] {
 
-  def record(value: Long, attributes: Attribute[_]*): F[Unit] =
+  def record(value: Long, attributes: Attributes): F[Unit] =
     F.delay(olm.record(value, Conversions.toJAttributes(attributes)))
 
 }

--- a/oteljava/metrics/src/test/scala/org/typelevel/otel4s/oteljava/metrics/ObservableSuite.scala
+++ b/oteljava/metrics/src/test/scala/org/typelevel/otel4s/oteljava/metrics/ObservableSuite.scala
@@ -54,8 +54,8 @@ class ObservableSuite extends CatsEffectSuite {
         .create(
           IO.pure(
             List(
-              Measurement(1336.0, List(Attribute("1", "2"))),
-              Measurement(1337.0, List(Attribute("a", "b")))
+              Measurement(1336.0, Attribute("1", "2")),
+              Measurement(1337.0, Attribute("a", "b"))
             )
           )
         )
@@ -106,8 +106,8 @@ class ObservableSuite extends CatsEffectSuite {
         .create(
           IO.pure(
             List(
-              Measurement(1336, List(Attribute("1", "2"))),
-              Measurement(1337, List(Attribute("a", "b")))
+              Measurement(1336, Attribute("1", "2")),
+              Measurement(1337, Attribute("a", "b"))
             )
           )
         )
@@ -158,8 +158,8 @@ class ObservableSuite extends CatsEffectSuite {
         .create(
           IO.pure(
             List(
-              Measurement(1336, List(Attribute("1", "2"))),
-              Measurement(1336, List(Attribute("a", "b")))
+              Measurement(1336, Attribute("1", "2")),
+              Measurement(1336, Attribute("a", "b"))
             )
           )
         )


### PR DESCRIPTION
`Measurement` could be extended in the future. Dealing with a sealed trait rather than a case class would be easier.