### PR TITLE
metrics: add `Meter[F].batchCallback`

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/BatchCallback.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/BatchCallback.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.metrics
+
+import cats.Apply
+import cats.effect.Resource
+import cats.syntax.apply._
+
+trait BatchCallback[F[_]] {
+
+  /** Constructs a batch callback.
+    *
+    * Batch callbacks allow a single callback to observe measurements for
+    * multiple asynchronous instruments.
+    *
+    * The callback will be called when the instruments are being observed.
+    *
+    * Callbacks are expected to abide by the following restrictions:
+    *   - Short-living and (ideally) non-blocking
+    *   - Run in a finite amount of time
+    *   - Safe to call repeatedly, across multiple threads
+    *
+    * @example
+    *   {{{
+    * val meter: Meter[F] = ???
+    * val server: F[Unit] = ??? // runs the server
+    *
+    * val background: Resource[F, Unit] =
+    *   for {
+    *     counter <- Resource.eval(meter.observableCounter[Long]("counter").createObserver)
+    *     upDownCounter <- Resource.eval(meter.observableUpDownCounter[Double]("up-down-counter").createObserver)
+    *     gauge <- Resource.eval(meter.observableGauge[Double]("gauge").createObserver)
+    *     callback = counter.record(1L) *> upDownCounter.record(2.0) *> gauge.record(3.0)
+    *     _ <- meter.batchCallback(callback, counter, upDownCounter, gauge)
+    *   } yield ()
+    *
+    * background.surround(server) // register batch callback and run the server
+    *   }}}
+    *
+    * @param callback
+    *   the callback to to observe values on-demand
+    *
+    * @param observable
+    *   the instrument for which the callback may observe values
+    *
+    * @param rest
+    *   the instruments for which the callback may observe values
+    */
+  def apply(
+      callback: F[Unit],
+      observable: ObservableMeasurement[F, _],
+      rest: ObservableMeasurement[F, _]*
+  ): Resource[F, Unit]
+
+  /** Constructs a batch callback.
+    *
+    * Batch callbacks allow a single callback to observe measurements for
+    * multiple asynchronous instruments.
+    *
+    * The callback will be called when the instruments are being observed.
+    *
+    * Callbacks are expected to abide by the following restrictions:
+    *   - Short-living and (ideally) non-blocking
+    *   - Run in a finite amount of time
+    *   - Safe to call repeatedly, across multiple threads
+    *
+    * @example
+    *   {{{
+    * val meter: Meter[F] = ???
+    * val server: F[Unit] = ??? // runs the server
+    *
+    * val background: Resource[F, Unit] =
+    *   meter.batchCallback.of(
+    *     meter.observableCounter[Long]("counter").createObserver,
+    *     meter.observableUpDownCounter[Double]("up-down-counter").createObserver,
+    *     meter.observableGauge[Double]("gauge").createObserver
+    *   ) { (counter, upDownCounter, gauge) =>
+    *     counter.record(1L) *> upDownCounter.record(2.0) *> gauge.record(3.0)
+    *   }
+    *
+    * background.surround(server) // register batch callback and run the server
+    *   }}}
+    */
+  final def of[A1, A2](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2).tupled)
+      .flatMap { case (a1, a2) => apply(cb(a1, a2), a1, a2) }
+
+  final def of[A1, A2, A3](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3).tupled)
+      .flatMap { case (a1, a2, a3) => apply(cb(a1, a2, a3), a1, a2, a3) }
+
+  final def of[A1, A2, A3, A4](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4).tupled)
+      .flatMap { case (a1, a2, a3, a4) =>
+        apply(cb(a1, a2, a3, a4), a1, a2, a3, a4)
+      }
+
+  final def of[A1, A2, A3, A4, A5](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]],
+      a5: F[ObservableMeasurement[F, A5]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4],
+          ObservableMeasurement[F, A5]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4, a5).tupled)
+      .flatMap { case (a1, a2, a3, a4, a5) =>
+        apply(cb(a1, a2, a3, a4, a5), a1, a2, a3, a4, a5)
+      }
+
+  final def of[A1, A2, A3, A4, A5, A6](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]],
+      a5: F[ObservableMeasurement[F, A5]],
+      a6: F[ObservableMeasurement[F, A6]],
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4],
+          ObservableMeasurement[F, A5],
+          ObservableMeasurement[F, A6]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4, a5, a6).tupled)
+      .flatMap { case (a1, a2, a3, a4, a5, a6) =>
+        apply(cb(a1, a2, a3, a4, a5, a6), a1, a2, a3, a4, a5, a6)
+      }
+
+  final def of[A1, A2, A3, A4, A5, A6, A7](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]],
+      a5: F[ObservableMeasurement[F, A5]],
+      a6: F[ObservableMeasurement[F, A6]],
+      a7: F[ObservableMeasurement[F, A7]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4],
+          ObservableMeasurement[F, A5],
+          ObservableMeasurement[F, A6],
+          ObservableMeasurement[F, A7]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4, a5, a6, a7).tupled)
+      .flatMap { case (a1, a2, a3, a4, a5, a6, a7) =>
+        apply(cb(a1, a2, a3, a4, a5, a6, a7), a1, a2, a3, a4, a5, a6, a7)
+      }
+
+  final def of[A1, A2, A3, A4, A5, A6, A7, A8](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]],
+      a5: F[ObservableMeasurement[F, A5]],
+      a6: F[ObservableMeasurement[F, A6]],
+      a7: F[ObservableMeasurement[F, A7]],
+      a8: F[ObservableMeasurement[F, A8]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4],
+          ObservableMeasurement[F, A5],
+          ObservableMeasurement[F, A6],
+          ObservableMeasurement[F, A7],
+          ObservableMeasurement[F, A8]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4, a5, a6, a7, a8).tupled)
+      .flatMap { case (a1, a2, a3, a4, a5, a6, a7, a8) =>
+        apply(
+          cb(a1, a2, a3, a4, a5, a6, a7, a8),
+          a1,
+          a2,
+          a3,
+          a4,
+          a5,
+          a6,
+          a7,
+          a8
+        )
+      }
+
+  final def of[A1, A2, A3, A4, A5, A6, A7, A8, A9](
+      a1: F[ObservableMeasurement[F, A1]],
+      a2: F[ObservableMeasurement[F, A2]],
+      a3: F[ObservableMeasurement[F, A3]],
+      a4: F[ObservableMeasurement[F, A4]],
+      a5: F[ObservableMeasurement[F, A5]],
+      a6: F[ObservableMeasurement[F, A6]],
+      a7: F[ObservableMeasurement[F, A7]],
+      a8: F[ObservableMeasurement[F, A8]],
+      a9: F[ObservableMeasurement[F, A9]]
+  )(
+      cb: (
+          ObservableMeasurement[F, A1],
+          ObservableMeasurement[F, A2],
+          ObservableMeasurement[F, A3],
+          ObservableMeasurement[F, A4],
+          ObservableMeasurement[F, A5],
+          ObservableMeasurement[F, A6],
+          ObservableMeasurement[F, A7],
+          ObservableMeasurement[F, A8],
+          ObservableMeasurement[F, A9]
+      ) => F[Unit]
+  )(implicit F: Apply[F]): Resource[F, Unit] =
+    Resource
+      .eval((a1, a2, a3, a4, a5, a6, a7, a8, a9).tupled)
+      .flatMap { case (a1, a2, a3, a4, a5, a6, a7, a8, a9) =>
+        apply(
+          cb(a1, a2, a3, a4, a5, a6, a7, a8, a9),
+          a1,
+          a2,
+          a3,
+          a4,
+          a5,
+          a6,
+          a7,
+          a8,
+          a9
+        )
+      }
+
+}
+
+object BatchCallback {
+
+  def noop[F[_]]: BatchCallback[F] =
+    new BatchCallback[F] {
+      def apply(
+          callback: F[Unit],
+          observable: ObservableMeasurement[F, _],
+          rest: ObservableMeasurement[F, _]*
+      ): Resource[F, Unit] =
+        Resource.unit
+    }
+
+}

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableCounter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableCounter.scala
@@ -89,6 +89,15 @@ object ObservableCounter {
     def create(
         measurements: F[Iterable[Measurement[A]]]
     ): Resource[F, ObservableCounter]
+
+    /** Creates an observer for this instrument to observe values from a
+      * [[BatchCallback]].
+      *
+      * @note
+      *   The observer '''must''' be registered via [[Meter.batchCallback]].
+      *   Values observed outside registered callbacks are ignored.
+      */
+    def createObserver: F[ObservableMeasurement[F, A]]
   }
 
 }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableGauge.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableGauge.scala
@@ -89,6 +89,15 @@ object ObservableGauge {
     def create(
         measurements: F[Iterable[Measurement[A]]]
     ): Resource[F, ObservableGauge]
+
+    /** Creates an observer for this instrument to observe values from a
+      * [[BatchCallback]].
+      *
+      * @note
+      *   The observer '''must''' be registered via [[Meter.batchCallback]].
+      *   Values observed outside registered callbacks are ignored.
+      */
+    def createObserver: F[ObservableMeasurement[F, A]]
   }
 
 }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.metrics
 
+import cats.Applicative
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.Attributes
 
@@ -41,4 +42,14 @@ trait ObservableMeasurement[F[_], A] {
     *   the set of attributes to associate with the value
     */
   def record(value: A, attributes: Attributes): F[Unit]
+}
+
+object ObservableMeasurement {
+
+  def noop[F[_]: Applicative, A]: ObservableMeasurement[F, A] =
+    new ObservableMeasurement[F, A] {
+      def record(value: A, attributes: Attributes): F[Unit] =
+        Applicative[F].unit
+    }
+
 }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableUpDownCounter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableUpDownCounter.scala
@@ -89,6 +89,15 @@ object ObservableUpDownCounter {
     def create(
         measurements: F[Iterable[Measurement[A]]]
     ): Resource[F, ObservableUpDownCounter]
+
+    /** Creates an observer for this instrument to observe values from a
+      * [[BatchCallback]].
+      *
+      * @note
+      *   The observer '''must''' be registered via [[Meter.batchCallback]].
+      *   Values observed outside registered callbacks are ignored.
+      */
+    def createObserver: F[ObservableMeasurement[F, A]]
   }
 
 }

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/ObservableSuite.scala
@@ -138,6 +138,9 @@ object ObservableSuite {
         measurements: IO[Iterable[Measurement[A]]]
     ): Resource[IO, ObservableGauge] =
       createObservable(measurements).as(new ObservableGauge {})
+
+    def createObserver: IO[ObservableMeasurement[IO, A]] =
+      IO.pure(ObservableMeasurement.noop)
   }
 
 }

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/BatchCallbackImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/BatchCallbackImpl.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.oteljava.metrics
+
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Dispatcher
+import cats.syntax.functor._
+import io.opentelemetry.api.metrics.{Meter => JMeter}
+import org.typelevel.otel4s.metrics.BatchCallback
+import org.typelevel.otel4s.metrics.ObservableMeasurement
+
+private final class BatchCallbackImpl[F[_]: Async](
+    jMeter: JMeter
+) extends BatchCallback[F] {
+
+  def apply(
+      callback: F[Unit],
+      observable: ObservableMeasurement[F, _],
+      rest: ObservableMeasurement[F, _]*
+  ): Resource[F, Unit] = {
+    val all = (observable +: rest.view).collect {
+      case o: ObservableMeasurementImpl[F, _] => o.jObservableMeasurement
+    }.toList
+
+    all match {
+      case head :: tail =>
+        Dispatcher
+          .sequential[F]
+          .flatMap { dispatcher =>
+            Resource.fromAutoCloseable(
+              Async[F].delay {
+                jMeter.batchCallback(
+                  () => dispatcher.unsafeRunSync(callback),
+                  head,
+                  tail: _*
+                )
+              }
+            )
+          }
+          .void
+
+      case Nil =>
+        Resource.unit
+    }
+  }
+
+}

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
@@ -50,4 +50,8 @@ private[oteljava] class MeterImpl[F[_]: Async](jMeter: JMeter)
       name: String
   ): ObservableUpDownCounter.Builder[F, A] =
     ObservableUpDownCounterBuilderImpl(jMeter, name)
+
+  val batchCallback: BatchCallback[F] =
+    new BatchCallbackImpl(jMeter)
+
 }

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableCounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableCounterBuilderImpl.scala
@@ -55,6 +55,9 @@ private[oteljava] case class ObservableCounterBuilderImpl[F[_], A](
       measurements: F[Iterable[Measurement[A]]]
   ): Resource[F, ObservableCounter] =
     factory.create(name, unit, description, measurements)
+
+  def createObserver: F[ObservableMeasurement[F, A]] =
+    factory.createObserver(name, unit, description)
 }
 
 private[oteljava] object ObservableCounterBuilderImpl {
@@ -90,6 +93,18 @@ private[oteljava] object ObservableCounterBuilderImpl {
         }
       }
 
+    final def createObserver(
+        name: String,
+        unit: Option[String],
+        description: Option[String]
+    ): F[ObservableMeasurement[F, A]] =
+      Async[F].delay {
+        val b = jMeter.counterBuilder(name)
+        unit.foreach(b.setUnit)
+        description.foreach(b.setDescription)
+        buildObserver(b)
+      }
+
     final def createWithCallback(
         name: String,
         unit: Option[String],
@@ -112,6 +127,10 @@ private[oteljava] object ObservableCounterBuilderImpl {
         dispatcher: Dispatcher[F],
         cb: JMeasurement => F[Unit]
     ): AutoCloseable
+
+    protected def buildObserver(
+        builder: LongCounterBuilder
+    ): ObservableMeasurementImpl[F, A]
 
     protected def doRecord(
         measurement: JMeasurement,
@@ -151,6 +170,14 @@ private[oteljava] object ObservableCounterBuilderImpl {
       ): AutoCloseable =
         builder.buildWithCallback(om => dispatcher.unsafeRunSync(cb(om)))
 
+      protected def buildObserver(
+          builder: LongCounterBuilder
+      ): ObservableMeasurementImpl[F, A] =
+        new ObservableMeasurementImpl.LongObservableMeasurement[F, A](
+          cast,
+          builder.buildObserver()
+        )
+
       protected def doRecord(
           om: ObservableLongMeasurement,
           value: A,
@@ -174,6 +201,14 @@ private[oteljava] object ObservableCounterBuilderImpl {
         builder
           .ofDoubles()
           .buildWithCallback(om => dispatcher.unsafeRunSync(cb(om)))
+
+      protected def buildObserver(
+          builder: LongCounterBuilder
+      ): ObservableMeasurementImpl[F, A] =
+        new ObservableMeasurementImpl.DoubleObservableMeasurement[F, A](
+          cast,
+          builder.ofDoubles().buildObserver()
+        )
 
       protected def doRecord(
           om: ObservableDoubleMeasurement,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableGaugeBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableGaugeBuilderImpl.scala
@@ -53,6 +53,9 @@ private[oteljava] case class ObservableGaugeBuilderImpl[F[_], A](
       measurements: F[Iterable[Measurement[A]]]
   ): Resource[F, ObservableGauge] =
     factory.create(name, unit, description, measurements)
+
+  def createObserver: F[ObservableMeasurement[F, A]] =
+    factory.createObserver(name, unit, description)
 }
 
 private[oteljava] object ObservableGaugeBuilderImpl {
@@ -105,11 +108,27 @@ private[oteljava] object ObservableGaugeBuilderImpl {
         )
       }
 
+    final def createObserver(
+        name: String,
+        unit: Option[String],
+        description: Option[String]
+    ): F[ObservableMeasurement[F, A]] =
+      Async[F].delay {
+        val b = jMeter.gaugeBuilder(name)
+        unit.foreach(b.setUnit)
+        description.foreach(b.setDescription)
+        buildObserver(b)
+      }
+
     protected def create(
         builder: DoubleGaugeBuilder,
         dispatcher: Dispatcher[F],
         cb: JMeasurement => F[Unit]
     ): AutoCloseable
+
+    protected def buildObserver(
+        builder: DoubleGaugeBuilder
+    ): ObservableMeasurementImpl[F, A]
 
     protected def doRecord(
         measurement: JMeasurement,
@@ -151,6 +170,14 @@ private[oteljava] object ObservableGaugeBuilderImpl {
           .ofLongs()
           .buildWithCallback(om => dispatcher.unsafeRunSync(cb(om)))
 
+      protected def buildObserver(
+          builder: DoubleGaugeBuilder
+      ): ObservableMeasurementImpl[F, A] =
+        new ObservableMeasurementImpl.LongObservableMeasurement[F, A](
+          cast,
+          builder.ofLongs().buildObserver()
+        )
+
       protected def doRecord(
           om: ObservableLongMeasurement,
           value: A,
@@ -172,6 +199,14 @@ private[oteljava] object ObservableGaugeBuilderImpl {
           cb: ObservableDoubleMeasurement => F[Unit]
       ): AutoCloseable =
         builder.buildWithCallback(om => dispatcher.unsafeRunSync(cb(om)))
+
+      protected def buildObserver(
+          builder: DoubleGaugeBuilder
+      ): ObservableMeasurementImpl[F, A] =
+        new ObservableMeasurementImpl.DoubleObservableMeasurement[F, A](
+          cast,
+          builder.buildObserver()
+        )
 
       protected def doRecord(
           om: ObservableDoubleMeasurement,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableMeasurementImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/ObservableMeasurementImpl.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.oteljava.metrics
+
+import cats.effect.kernel.Sync
+import io.opentelemetry.api.metrics.{
+  ObservableMeasurement => JObservableMeasurement
+}
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement
+import io.opentelemetry.api.metrics.ObservableLongMeasurement
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.ObservableMeasurement
+import org.typelevel.otel4s.oteljava.Conversions
+
+private[metrics] sealed abstract class ObservableMeasurementImpl[F[_], A](
+    val jObservableMeasurement: JObservableMeasurement
+) extends ObservableMeasurement[F, A] {}
+
+private object ObservableMeasurementImpl {
+
+  final class LongObservableMeasurement[F[_]: Sync, A](
+      cast: A => Long,
+      jObservableMeasurement: ObservableLongMeasurement
+  ) extends ObservableMeasurementImpl[F, A](jObservableMeasurement) {
+
+    def record(value: A, attributes: Attributes): F[Unit] =
+      Sync[F].delay(
+        jObservableMeasurement.record(
+          cast(value),
+          Conversions.toJAttributes(attributes)
+        )
+      )
+  }
+
+  final class DoubleObservableMeasurement[F[_]: Sync, A](
+      cast: A => Double,
+      jObservableMeasurement: ObservableDoubleMeasurement
+  ) extends ObservableMeasurementImpl[F, A](jObservableMeasurement) {
+
+    def record(value: A, attributes: Attributes): F[Unit] =
+      Sync[F].delay(
+        jObservableMeasurement.record(
+          cast(value),
+          Conversions.toJAttributes(attributes)
+        )
+      )
+  }
+
+}

--- a/oteljava/metrics/src/test/scala/org/typelevel/otel4s/oteljava/metrics/BatchCallbackSuite.scala
+++ b/oteljava/metrics/src/test/scala/org/typelevel/otel4s/oteljava/metrics/BatchCallbackSuite.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.oteljava.metrics
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.testkit.metrics.MetricsSdk
+
+class BatchCallbackSuite extends CatsEffectSuite {
+
+  test("update multiple observers") {
+    for {
+      sdk <- IO.delay(MetricsSdk.create[IO]())
+      meter <- Metrics
+        .forAsync[IO](sdk.sdk)
+        .meterProvider
+        .meter("java.otel.suite")
+        .withVersion("1.0")
+        .withSchemaUrl("https://localhost:8080")
+        .get
+
+      metrics <- meter.batchCallback
+        .of(
+          meter.observableCounter[Long]("long-counter").createObserver,
+          meter.observableCounter[Double]("double-counter").createObserver,
+          meter
+            .observableUpDownCounter[Long]("long-up-down-counter")
+            .createObserver,
+          meter
+            .observableUpDownCounter[Double]("double-up-down-counter")
+            .createObserver,
+          meter.observableGauge[Long]("long-gauge").createObserver,
+          meter.observableGauge[Double]("double-gauge").createObserver
+        ) {
+          (
+              counter1,
+              counter2,
+              upDownCounter1,
+              upDownCounter2,
+              gauge1,
+              gauge2
+          ) =>
+            for {
+              _ <- counter1.record(1, Attribute("key", "value1"))
+              _ <- counter2.record(1.1, Attribute("key", "value2"))
+              _ <- upDownCounter1.record(2, Attribute("key", "value3"))
+              _ <- upDownCounter2.record(2.1, Attribute("key", "value4"))
+              _ <- gauge1.record(3, Attribute("key", "value5"))
+              _ <- gauge2.record(3.1, Attribute("key", "value6"))
+            } yield ()
+        }
+        .surround(sdk.metrics)
+    } yield {
+      assertEquals(
+        metrics.view
+          .map(r => (r.name, r.data.points.map(v => (v.value, v.attributes))))
+          .toMap,
+        Map(
+          "double-counter" -> List(1.1 -> List(Attribute("key", "value2"))),
+          "double-gauge" -> List(3.1 -> List(Attribute("key", "value6"))),
+          "double-up-down-counter" -> List(
+            2.1 -> List(Attribute("key", "value4"))
+          ),
+          "long-counter" -> List(1 -> List(Attribute("key", "value1"))),
+          "long-gauge" -> List(3 -> List(Attribute("key", "value5"))),
+          "long-up-down-counter" -> List(2 -> List(Attribute("key", "value3")))
+        )
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #201.

###  `meter.batchCallback.apply`

Nearly identical to what OpenTelemetry Java offers.

```scala
val meter: Meter[F] = ???

val background: Resource[F, Unit] = 
  for {
    counter <- Resource.eval(meter.observableCounter[Long]("counter").createObserver)
    upDownCounter <- Resource.eval(meter.observableUpDownCounter[Double]("up-down-counter").createObserver)
    gauge <- Resource.eval(meter.observableGauge[Double]("gauge").createObserver)
    _ <- meter.batchCallback(
      callback = counter.record(1L) *> upDownCounter.record(2.0) *> gauge.record(3.0),
      counter,
      upDownCounter,
      gauge
    )
  } yield ()
```

###  `meter.batchCallback.of`

A typesafe alternative with arity up to 9 arguments. It's much harder to miss an instrument that way. 


```scala
val meter: Meter[F] = ???

val background: Resource[F, Unit] = meter.batchCallback.of(
  meter.observableCounter[Long]("counter").createObserver,
  meter.observableUpDownCounter[Double]("up-down-counter").createObserver,
  meter.observableGauge[Double]("gauge").createObserver
) { (counter, upDownCounter, gauge) =>
  counter.record(1L) *> upDownCounter.record(2.0) *> gauge.record(3.0)
}
```

____

Both examples are equivalent. 