### PR TITLE
sdk-trace: add `JaegerPropagator`

### DIFF
--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/scalacheck/Gens.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/scalacheck/Gens.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.trace.scalacheck
 
 import org.scalacheck.Gen
+import org.typelevel.otel4s.baggage.Baggage
 import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Status
@@ -49,6 +50,16 @@ trait Gens extends org.typelevel.otel4s.scalacheck.Gens {
       k3 <- nonEmptyString
       v3 <- nonEmptyString
     } yield TraceState.empty.updated(k1, v1).updated(k2, v2).updated(k3, v3)
+
+  val baggage: Gen[Baggage] =
+    for {
+      k1 <- nonEmptyString
+      v1 <- nonEmptyString
+      k2 <- nonEmptyString
+      v2 <- nonEmptyString
+      k3 <- nonEmptyString
+      v3 <- nonEmptyString
+    } yield Baggage.empty.updated(k1, v1).updated(k2, v2).updated(k3, v3)
 
   val spanContext: Gen[SpanContext] =
     for {

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagator.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagator.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.context.propagation
+
+import org.typelevel.otel4s.baggage.Baggage
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.context.propagation.TextMapUpdater
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.SdkContextKeys
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.TraceFlags
+import org.typelevel.otel4s.trace.TraceState
+import scodec.bits.ByteVector
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import scala.util.control.NonFatal
+
+/** A Jaeger propagator.
+  *
+  * The trace id header format: {trace-id}:{span-id}:{parent-span-id}:{flags}.
+  *
+  * @see
+  *   [[https://www.jaegertracing.io/docs/client-libraries/#propagation-format]]
+  */
+private final class JaegerPropagator extends TextMapPropagator[Context] {
+  import JaegerPropagator.Const
+  import JaegerPropagator.Headers
+
+  val fields: List[String] = List(Headers.TraceId)
+
+  def extract[A: TextMapGetter](ctx: Context, carrier: A): Context = {
+    val withSpanCtx =
+      TextMapGetter[A].get(carrier, Headers.TraceId) match {
+        case Some(traceIdHeader) =>
+          prepareHeader(traceIdHeader).flatMap(decode) match {
+            case Some(spanContext) if spanContext.isValid =>
+              ctx.updated(SdkContextKeys.SpanContextKey, spanContext)
+
+            case _ =>
+              ctx
+          }
+
+        case None =>
+          ctx
+      }
+
+    val baggage = decodeBaggage(carrier)
+    if (baggage.isEmpty) withSpanCtx
+    else withSpanCtx.updated(SdkContextKeys.BaggageKey, baggage)
+  }
+
+  def inject[A: TextMapUpdater](ctx: Context, carrier: A): A = {
+    val withSpanContext =
+      ctx.get(SdkContextKeys.SpanContextKey).filter(_.isValid) match {
+        case Some(spanContext) =>
+          val sampled =
+            if (spanContext.isSampled) Const.Sampled else Const.NotSampled
+
+          val header =
+            spanContext.traceIdHex + Const.Delimiter +
+              spanContext.spanIdHex + Const.Delimiter +
+              Const.DeprecatedParent + Const.Delimiter +
+              sampled
+
+          TextMapUpdater[A].updated(carrier, Headers.TraceId, header)
+
+        case None =>
+          carrier
+      }
+
+    ctx.get(SdkContextKeys.BaggageKey) match {
+      case Some(baggage) =>
+        baggage.asMap.foldLeft(withSpanContext) {
+          case (carrier, (key, entry)) =>
+            val k = Const.BaggagePrefix + key
+            TextMapUpdater[A].updated(carrier, k, urlEncode(entry.value))
+        }
+
+      case None =>
+        withSpanContext
+    }
+  }
+
+  private def decode(traceIdHeader: String): Option[SpanContext] = {
+    val parts = traceIdHeader.split(Const.Delimiter)
+
+    if (parts.size == 4) {
+      val traceIdHex = parts(0)
+      val spanIdHex = parts(1)
+      val traceFlagsHex = parts(3)
+
+      for {
+        traceId <- ByteVector.fromHex(traceIdHex)
+        spanId <- ByteVector.fromHex(spanIdHex)
+        flag <- traceFlagsHex.toByteOption
+      } yield SpanContext(
+        traceId = padLeft(traceId, SpanContext.TraceId.Bytes.toLong),
+        spanId = padLeft(spanId, SpanContext.SpanId.Bytes.toLong),
+        traceFlags = TraceFlags.fromByte(flag),
+        traceState = TraceState.empty,
+        remote = true
+      )
+    } else {
+      None
+    }
+  }
+
+  private def padLeft(input: ByteVector, expectedSize: Long): ByteVector =
+    if (input.size <= expectedSize) input.padLeft(expectedSize) else input
+
+  // a header can be URL encoded, so we try to decode it
+  private def prepareHeader(traceIdHeader: String): Option[String] =
+    if (traceIdHeader.contains(Const.Delimiter)) {
+      Some(traceIdHeader)
+    } else {
+      try {
+        Some(URLDecoder.decode(traceIdHeader, Const.Charset))
+      } catch {
+        case NonFatal(_) =>
+          None
+      }
+    }
+
+  private def decodeBaggage[A: TextMapGetter](carrier: A): Baggage = {
+    val keys = TextMapGetter[A].keys(carrier)
+    val prefixLength = Const.BaggagePrefix.length
+
+    def isPrefix(key: String): Boolean =
+      key.startsWith(Const.BaggagePrefix) && key.length != prefixLength
+
+    keys.foldLeft(Baggage.empty) {
+      case (baggage, key) if isPrefix(key) =>
+        TextMapGetter[A]
+          .get(carrier, key)
+          .map(safeUrlDecode)
+          .fold(baggage)(v => baggage.updated(key.drop(prefixLength), v))
+
+      case (baggage, key) if key == Headers.Baggage =>
+        TextMapGetter[A]
+          .get(carrier, key)
+          .fold(baggage)(v => parseBaggageHeader(v, baggage))
+
+      case (baggage, _) =>
+        baggage
+    }
+  }
+
+  private def parseBaggageHeader(header: String, to: Baggage): Baggage =
+    header
+      .split(Const.BaggageHeaderDelimiter)
+      .foldLeft(to) { (baggage, part) =>
+        val parts = part.split(Const.BaggageHeaderEntryDelimiter)
+        if (parts.size == 2) baggage.updated(parts(0), safeUrlDecode(parts(1)))
+        else baggage
+      }
+
+  private def urlEncode(input: String): String =
+    URLEncoder.encode(input, Const.Charset)
+
+  private def safeUrlDecode(input: String): String =
+    try {
+      URLDecoder.decode(input, Const.Charset)
+    } catch {
+      case e if NonFatal(e) => input
+    }
+
+  override def toString: String = "JaegerPropagator"
+}
+
+object JaegerPropagator {
+
+  private val Default = new JaegerPropagator
+
+  private object Headers {
+    val TraceId = "uber-trace-id"
+    val Baggage = "jaeger-baggage"
+  }
+
+  private object Const {
+    val Delimiter = ":"
+    val DeprecatedParent = "0"
+    val Sampled = "1"
+    val NotSampled = "0"
+    val BaggagePrefix = "uberctx-"
+    val Charset = StandardCharsets.UTF_8.name()
+    val BaggageHeaderDelimiter = "\\s*,\\s*"
+    val BaggageHeaderEntryDelimiter = "\\s*=\\s*"
+  }
+
+  /** Returns an instance of the W3CTraceContextPropagator.
+    */
+  def default: TextMapPropagator[Context] = Default
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagatorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagatorSuite.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.context.propagation
+
+import munit._
+import org.scalacheck.Prop
+import org.typelevel.otel4s.baggage.Baggage
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.SdkContextKeys
+import org.typelevel.otel4s.sdk.trace.scalacheck.Gens
+import org.typelevel.otel4s.trace.SpanContext
+import scodec.bits.ByteVector
+
+import java.net.URLEncoder
+
+class JaegerPropagatorSuite extends ScalaCheckSuite {
+
+  private val propagator = JaegerPropagator.default
+
+  //
+  // Common
+  //
+
+  test("fields") {
+    assertEquals(propagator.fields, List("uber-trace-id"))
+  }
+
+  test("toString") {
+    assertEquals(propagator.toString, "JaegerPropagator")
+  }
+
+  //
+  // Inject
+  //
+
+  test("inject nothing when context is empty") {
+    val result = propagator.inject(Context.root, Map.empty[String, String])
+    assertEquals(result.size, 0)
+  }
+
+  test("inject - invalid context - do nothing") {
+    val ctx = SpanContext.invalid
+    val context = Context.root.updated(SdkContextKeys.SpanContextKey, ctx)
+
+    assertEquals(
+      propagator.inject(context, Map.empty[String, String]),
+      Map.empty[String, String]
+    )
+  }
+
+  test("inject - valid context") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val context = Context.root.updated(SdkContextKeys.SpanContextKey, ctx)
+      val expected = toTraceId(ctx)
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      assertEquals(result.get("uber-trace-id"), Some(expected))
+    }
+  }
+
+  test("inject - valid context with baggage") {
+    Prop.forAll(Gens.spanContext, Gens.baggage) { (c, baggage) =>
+      val ctx = asRemote(c)
+      val context = Context.root
+        .updated(SdkContextKeys.SpanContextKey, ctx)
+        .updated(SdkContextKeys.BaggageKey, baggage)
+
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      assertEquals(result.get("uber-trace-id"), Some(toTraceId(ctx)))
+      baggage.asMap.foreach { case (key, entry) =>
+        assertEquals(result.get(s"uberctx-$key"), Some(entry.value))
+      }
+    }
+  }
+
+  test("inject - only baggage") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val context = Context.root.updated(SdkContextKeys.BaggageKey, baggage)
+
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      baggage.asMap.foreach { case (key, entry) =>
+        assertEquals(result.get(s"uberctx-$key"), Some(entry.value))
+      }
+    }
+  }
+
+  test("inject - baggage - URL encode headers") {
+    val baggage = Baggage.empty.updated("key", "value 1 / blah")
+    val context = Context.root.updated(SdkContextKeys.BaggageKey, baggage)
+
+    val result = propagator.inject(context, Map.empty[String, String])
+
+    assertEquals(result, Map("uberctx-key" -> "value+1+%2F+blah"))
+  }
+
+  //
+  // Extract
+  //
+
+  test("extract - empty context") {
+    val ctx = propagator.extract(Context.root, Map.empty[String, String])
+    assertEquals(getSpanContext(ctx), None)
+  }
+
+  test("extract - 'uber-trace-id' header is missing") {
+    val ctx = propagator.extract(Context.root, Map("key" -> "value"))
+    assertEquals(getSpanContext(ctx), None)
+  }
+
+  test("extract - valid 'uber-trace-id' header") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val carrier = Map("uber-trace-id" -> toTraceId(ctx))
+      val result = propagator.extract(Context.root, carrier)
+      assertEquals(getSpanContext(result), Some(asRemote(ctx)))
+    }
+  }
+
+  test("extract - 'uber-trace-id' and 'uberctx-X' headers are valid") {
+    Prop.forAll(Gens.spanContext, Gens.baggage) { (ctx, baggage) =>
+      val baggageHeaders = toBaggageHeaders(baggage)
+      val carrier = Map("uber-trace-id" -> toTraceId(ctx)) ++ baggageHeaders
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(result), Some(asRemote(ctx)))
+      assertEquals(getBaggage(result), Some(baggage))
+    }
+  }
+
+  test("extract - 'uber-trace-id' header has invalid format") {
+    val carrier = Map("uber-trace-id" -> "00-11-22-33")
+    val result = propagator.extract(Context.root, carrier)
+    assertEquals(getSpanContext(result), None)
+  }
+
+  test("extract - invalid header - not enough parts") {
+    val carrier = Map("uber-trace-id" -> "00:11:22")
+    val result = propagator.extract(Context.root, carrier)
+    assertEquals(getSpanContext(result), None)
+  }
+
+  test("extract - invalid header - too many parts") {
+    val carrier = Map("uber-trace-id" -> "00:11:22:33:44")
+    val result = propagator.extract(Context.root, carrier)
+    assertEquals(getSpanContext(result), None)
+  }
+
+  test("extract - invalid trace id (too long)") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val suffix = if (ctx.isSampled) "1" else "0"
+      val traceId = s"${ctx.traceIdHex}00:${ctx.spanIdHex}:0:$suffix"
+      val carrier = Map("uber-trace-id" -> traceId)
+      val result = propagator.extract(Context.root, carrier)
+      assertEquals(getSpanContext(result), None)
+    }
+  }
+
+  test("extract - invalid span id (too long)") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val suffix = if (ctx.isSampled) "1" else "0"
+      val traceId = s"${ctx.traceIdHex}:${ctx.spanIdHex}00:0:$suffix"
+      val carrier = Map("uber-trace-id" -> traceId)
+      val result = propagator.extract(Context.root, carrier)
+      assertEquals(getSpanContext(result), None)
+    }
+  }
+
+  test("extract - invalid flags (too long)") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val traceId = s"${ctx.traceIdHex}:${ctx.spanIdHex}:0:10220"
+      val carrier = Map("uber-trace-id" -> traceId)
+      val result = propagator.extract(Context.root, carrier)
+      assertEquals(getSpanContext(result), None)
+    }
+  }
+
+  test("extract - invalid flags (non numeric)") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val traceId = s"${ctx.traceIdHex}:${ctx.spanIdHex}:0:abc"
+      val carrier = Map("uber-trace-id" -> traceId)
+      val result = propagator.extract(Context.root, carrier)
+      assertEquals(getSpanContext(result), None)
+    }
+  }
+
+  test("extract - short trace id (pad left zeroes)") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val shortTraceId = ctx.traceIdHex.take(16)
+
+      val suffix = if (ctx.isSampled) "1" else "0"
+      val traceId = s"$shortTraceId:${ctx.spanIdHex}:0:$suffix"
+      val carrier = Map("uber-trace-id" -> traceId)
+      val result = propagator.extract(Context.root, carrier)
+
+      val expected = SpanContext(
+        traceId = ByteVector.fromValidHex(shortTraceId).padLeft(16),
+        spanId = ctx.spanId,
+        traceFlags = ctx.traceFlags,
+        traceState = ctx.traceState,
+        remote = true
+      )
+
+      assertEquals(getSpanContext(result), Some(expected))
+    }
+  }
+
+  test("extract - decode url encoded header") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val traceId = toTraceId(ctx)
+      val carrier = Map("uber-trace-id" -> URLEncoder.encode(traceId, "UTF-8"))
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(result), Some(asRemote(ctx)))
+    }
+  }
+
+  test("extract - context and baggage") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val carrier = toBaggageHeaders(baggage)
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+    }
+  }
+
+  test("extract - only baggage") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val carrier = toBaggageHeaders(baggage)
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+    }
+  }
+
+  test("extract - only baggage - prefix without key") {
+    val carrier = Map("uberctx-" -> "value")
+    val result = propagator.extract(Context.root, carrier)
+
+    assertEquals(getBaggage(result), None)
+  }
+
+  test("extract - only baggage - single header") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val header = baggage.asMap
+        .map { case (key, entry) => key + "=" + entry.value }
+        .mkString(",")
+
+      val carrier = Map("jaeger-baggage" -> header)
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+    }
+  }
+
+  test("extract - only baggage - single header with spaces") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val header = baggage.asMap
+        .map { case (key, entry) => key + " = " + entry.value }
+        .mkString("  ,  ")
+
+      val carrier = Map("jaeger-baggage" -> header)
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+    }
+  }
+
+  test("extract - only baggage - invalid single header") {
+    val carrier = Map("jaeger-baggage" -> "foo+bar")
+    val result = propagator.extract(Context.root, carrier)
+
+    assertEquals(getBaggage(result), None)
+  }
+
+  test("extract - only baggage - single header and multiple headers") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val headers = toBaggageHeaders(baggage)
+      val carrier =
+        Map("jaeger-baggage" -> "key=value,key2 = value2") ++ headers
+      val result = propagator.extract(Context.root, carrier)
+      val expected = baggage.updated("key", "value").updated("key2", "value2")
+
+      assertEquals(getBaggage(result), Some(expected))
+    }
+  }
+
+  private def toTraceId(ctx: SpanContext): String = {
+    val suffix = if (ctx.isSampled) "1" else "0"
+    s"${ctx.traceIdHex}:${ctx.spanIdHex}:0:$suffix"
+  }
+
+  private def toBaggageHeaders(baggage: Baggage): Map[String, String] =
+    baggage.asMap.map { case (key, entry) => ("uberctx-" + key, entry.value) }
+
+  private def getSpanContext(ctx: Context): Option[SpanContext] =
+    ctx.get(SdkContextKeys.SpanContextKey)
+
+  private def getBaggage(ctx: Context): Option[Baggage] =
+    ctx.get(SdkContextKeys.BaggageKey)
+
+  private def asRemote(ctx: SpanContext): SpanContext =
+    SpanContext(
+      traceId = ctx.traceId,
+      spanId = ctx.spanId,
+      traceFlags = ctx.traceFlags,
+      traceState = ctx.traceState,
+      remote = true
+    )
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/W3CTraceContextPropagatorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/W3CTraceContextPropagatorSuite.scala
@@ -94,7 +94,7 @@ class W3CTraceContextPropagatorSuite extends ScalaCheckSuite {
   // Extract
   //
 
-  test("extract - empty empty") {
+  test("extract - empty context") {
     val ctx = propagator.extract(Context.root, Map.empty[String, String])
     assertEquals(getSpanContext(ctx), None)
   }


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://www.jaegertracing.io/docs/client-libraries/#propagation-format |
| Java implementation | [JaegerPropagator.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/JaegerPropagator.java) |


