### PR TITLE
sdk-exporter-trace: add `OtlpHttpClientAutoConfigure`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,19 @@ lazy val scalafixSettings = Seq(
   )
 )
 
+lazy val scalaJSLinkerSettings = Def.settings(
+  scalaJSLinkerConfig ~= (_.withESFeatures(
+    _.withESVersion(org.scalajs.linker.interface.ESVersion.ES2018)
+  )),
+  Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+)
+
+lazy val scalaNativeSettings = Def.settings(
+  libraryDependencies += "com.armanbilge" %%% "epollcat" % EpollcatVersion % Test,
+  Test / nativeBrewFormulas ++= Set("s2n", "utf8proc"),
+  Test / envVars ++= Map("S2N_DONT_MLOCK" -> "1")
+)
+
 val Scala213 = "2.13.12"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")
 ThisBuild / scalaVersion := Scala213 // the default Scala
@@ -266,6 +279,9 @@ lazy val `sdk-exporter-common` =
         "io.circe" %%% "circe-generic" % CirceVersion % Test
       )
     )
+    .jsSettings(scalaJSLinkerSettings)
+    .nativeEnablePlugins(ScalaNativeBrewedConfigPlugin)
+    .nativeSettings(scalaNativeSettings)
     .settings(munitDependencies)
     .settings(scalafixSettings)
 
@@ -283,20 +299,9 @@ lazy val `sdk-exporter-trace` =
       startYear := Some(2023),
       dockerComposeEnvFile := crossProjectBaseDirectory.value / "docker" / "docker-compose.yml"
     )
-    .jsSettings(
-      scalaJSLinkerConfig ~= (_.withESFeatures(
-        _.withESVersion(org.scalajs.linker.interface.ESVersion.ES2018)
-      )),
-      Test / scalaJSLinkerConfig ~= (_.withModuleKind(
-        ModuleKind.CommonJSModule
-      ))
-    )
+    .jsSettings(scalaJSLinkerSettings)
     .nativeEnablePlugins(ScalaNativeBrewedConfigPlugin)
-    .nativeSettings(
-      libraryDependencies += "com.armanbilge" %%% "epollcat" % EpollcatVersion % Test,
-      Test / nativeBrewFormulas ++= Set("s2n", "utf8proc"),
-      Test / envVars ++= Map("S2N_DONT_MLOCK" -> "1")
-    )
+    .nativeSettings(scalaNativeSettings)
     .settings(munitDependencies)
     .settings(scalafixSettings)
 

--- a/sdk-exporter/common/.js/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
+++ b/sdk-exporter/common/.js/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+
+import cats.effect.IO
+import fs2.compression.Compression
+import munit.CatsEffectSuite
+
+trait SuiteRuntimePlatform { self: CatsEffectSuite =>
+
+  implicit val fs2Compression: Compression[IO] =
+    fs2.io.compression.fs2ioCompressionForIO
+
+}

--- a/sdk-exporter/common/.jvm/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
+++ b/sdk-exporter/common/.jvm/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+
+import munit.CatsEffectSuite
+
+trait SuiteRuntimePlatform { self: CatsEffectSuite => }

--- a/sdk-exporter/common/.native/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
+++ b/sdk-exporter/common/.native/src/test/scala/org/typelevel/otel4s/sdk/exporter/SuiteRuntimePlatform.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+
+import cats.effect.unsafe.IORuntime
+import epollcat.unsafe.EpollRuntime
+import munit.CatsEffectSuite
+
+// can be removed once CE 3.6.x is released
+trait SuiteRuntimePlatform { self: CatsEffectSuite =>
+  override def munitIORuntime: IORuntime = EpollRuntime.global
+}

--- a/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/OtlpHttpClient.scala
+++ b/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/OtlpHttpClient.scala
@@ -36,6 +36,7 @@ import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.HttpVersion
 import org.http4s.Method
+import org.http4s.ProductId
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
@@ -45,7 +46,9 @@ import org.http4s.client.middleware.{RetryPolicy => HttpRetryPolicy}
 import org.http4s.client.middleware.GZip
 import org.http4s.client.middleware.Retry
 import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers.`User-Agent`
 import org.typelevel.ci._
+import org.typelevel.otel4s.sdk.BuildInfo
 import org.typelevel.otel4s.sdk.exporter.RetryPolicy
 import scalapb_circe.Printer
 
@@ -60,10 +63,16 @@ import scala.concurrent.duration.FiniteDuration
   * @see
   *   [[https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/]]
   */
-private final class OtlpHttpClient[F[_]: Temporal: Console, A] private (
+private[otlp] final class OtlpHttpClient[F[_]: Temporal: Console, A] private (
     client: Client[F],
     config: OtlpHttpClient.Config,
 )(implicit encoder: ProtoEncoder.Message[List[A]], printer: Printer) {
+
+  import OtlpHttpClient.Defaults
+
+  private val userAgent = `User-Agent`(
+    ProductId(Defaults.UserAgentName, version = Some(BuildInfo.version))
+  )
 
   private implicit val entityEncoder: EntityEncoder[F, List[A]] =
     config.encoding match {
@@ -85,6 +94,7 @@ private final class OtlpHttpClient[F[_]: Temporal: Console, A] private (
     val request =
       Request[F](Method.POST, config.endpoint, HttpVersion.`HTTP/1.1`)
         .withEntity(records.toList)
+        .putHeaders(userAgent)
         .putHeaders(config.headers)
 
     client
@@ -140,6 +150,10 @@ private[otlp] object OtlpHttpClient {
       headers: Headers,
       gzipCompression: Boolean
   )
+
+  private object Defaults {
+    val UserAgentName: String = "OTel-OTLP-Exporter-Scala-Otel4s"
+  }
 
   def create[F[_]: Async: Network: Compression: Console, A](
       encoding: HttpPayloadEncoding,

--- a/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigure.scala
+++ b/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigure.scala
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+package otlp
+package autoconfigure
+
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.syntax.either._
+import cats.syntax.functor._
+import fs2.compression.Compression
+import fs2.io.net.Network
+import org.http4s.Header
+import org.http4s.Headers
+import org.http4s.Uri
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.autoconfigure.ConfigurationError
+import scalapb_circe.Printer
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Autoconfigures [[OtlpHttpClient]].
+  *
+  * Target-specific properties are prioritized. E.g.
+  * `otel.exporter.otlp.traces.endpoint` is prioritized over
+  * `otel.exporter.otlp.endpoint`.
+  *
+  * The general configuration options:
+  * {{{
+  * | System property                       | Environment variable                  | Description                                                                                                                                                                      |
+  * |---------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  * | otel.exporter.otlp.endpoint           | OTEL_EXPORTER_OTLP_ENDPOINT           | The OTLP traces, metrics, and logs endpoint to connect to. Must be a URL with a scheme of either `http` or `https` based on the use of TLS. Default is `http://localhost:4318/`. |
+  * | otel.exporter.otlp.headers            | OTEL_EXPORTER_OTLP_HEADERS            | Key-value pairs separated by commas to pass as request headers on OTLP trace, metric, and log requests.                                                                          |
+  * | otel.exporter.otlp.compression        | OTEL_EXPORTER_OTLP_COMPRESSION        | The compression type to use on OTLP trace, metric, and log requests. Options include `gzip`. By default no compression will be used.                                             |
+  * | otel.exporter.otlp.timeout            | OTEL_EXPORTER_OTLP_TIMEOUT            | The maximum waiting time to send each OTLP trace, metric, and log batch. Default is `10 seconds`.                                                                                |
+  * }}}
+  *
+  * The traces-specific configuration options:
+  * {{{
+  * | System property                       | Environment variable                  | Description                                                                                                         |
+  * |---------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+  * | otel.exporter.otlp.traces.headers     | OTEL_EXPORTER_OTLP_TRACES_HEADERS     | Key-value pairs separated by commas to pass as request headers on OTLP trace requests.                              |
+  * | otel.exporter.otlp.traces.endpoint    | OTEL_EXPORTER_OTLP_TRACES_ENDPOINT    | The OTLP traces endpoint to connect to. Default is `http://localhost:4318/v1/traces`.                               |
+  * | otel.exporter.otlp.traces.compression | OTEL_EXPORTER_OTLP_TRACES_COMPRESSION | The compression type to use on OTLP trace requests. Options include `gzip`. By default no compression will be used. |
+  * | otel.exporter.otlp.traces.timeout     | OTEL_EXPORTER_OTLP_TRACES_TIMEOUT     | The maximum waiting time to send each OTLP trace batch. Default is `10 seconds`.                                    |
+  * }}}
+  *
+  * @see
+  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-span-metric-and-log-exporters]]
+  */
+private final class OtlpHttpClientAutoConfigure[
+    F[_]: Async: Network: Compression: Console,
+    A
+](
+    specific: OtlpHttpClientAutoConfigure.ConfigKeys.Keys,
+    defaults: OtlpHttpClientAutoConfigure.Defaults,
+    configKeys: Set[Config.Key[_]]
+)(implicit encoder: ProtoEncoder.Message[List[A]], printer: Printer)
+    extends AutoConfigure.WithHint[F, OtlpHttpClient[F, A]](
+      "OtlpHttpClient",
+      configKeys
+    ) {
+
+  import OtlpHttpClientAutoConfigure.{ConfigKeys, Defaults, PayloadCompression}
+
+  protected def fromConfig(
+      config: Config
+  ): Resource[F, OtlpHttpClient[F, A]] = {
+
+    def get[V: Config.Reader](
+        select: ConfigKeys.Keys => Config.Key[V]
+    ): Either[ConfigurationError, Option[V]] =
+      config.get(select(specific)).flatMap {
+        case Some(value) =>
+          Right(Some(value))
+
+        case None =>
+          config.get(select(ConfigKeys.General))
+      }
+
+    def getOrElse[V: Config.Reader](
+        select: ConfigKeys.Keys => Config.Key[V],
+        default: Defaults => V
+    ): Either[ConfigurationError, V] =
+      get(select).map(_.getOrElse(default(defaults)))
+
+    def getEndpoint =
+      config.get(specific.Endpoint).flatMap {
+        case Some(value) =>
+          Right(value)
+
+        case None =>
+          config
+            .get(ConfigKeys.General.Endpoint)
+            .map(_.fold(defaults.endpoint)(_.addPath(defaults.apiPath)))
+      }
+
+    def tryLoad =
+      for {
+        endpoint <- getEndpoint
+        timeout <- getOrElse(_.Timeout, _.timeout)
+        headers <- getOrElse(_.Headers, _.headers)
+        compression <- get(_.Compression)
+      } yield OtlpHttpClient.create(
+        defaults.encoding,
+        endpoint,
+        timeout,
+        headers,
+        compression.isDefined,
+        RetryPolicy.default,
+        None
+      )
+
+    tryLoad match {
+      case Right(resource) => resource
+      case Left(error)     => Resource.raiseError(error: Throwable)
+    }
+  }
+
+  private implicit val uriReader: Config.Reader[Uri] =
+    Config.Reader.decodeWithHint("Uri") { s =>
+      Uri.fromString(s).leftMap(e => ConfigurationError(e.message))
+    }
+
+  private implicit val compressionReader: Config.Reader[PayloadCompression] =
+    Config.Reader.decodeWithHint("Compression") { s =>
+      s.trim.toLowerCase match {
+        case "gzip" =>
+          Right(PayloadCompression.Gzip)
+
+        case _ =>
+          Left(
+            ConfigurationError(
+              "Unrecognized compression. Supported options [gzip]"
+            )
+          )
+      }
+    }
+
+  private implicit val headersReader: Config.Reader[Headers] =
+    Config.Reader[Map[String, String]].map { value =>
+      val headers = value.map { case (key, value) =>
+        Header.Raw(CIString(key), value)
+      }
+      new Headers(headers.toList)
+    }
+}
+
+private[exporter] object OtlpHttpClientAutoConfigure {
+
+  private sealed trait PayloadCompression
+  private object PayloadCompression {
+    case object Gzip extends PayloadCompression
+  }
+
+  final case class Defaults(
+      endpoint: Uri,
+      apiPath: String,
+      headers: Headers,
+      timeout: FiniteDuration,
+      encoding: HttpPayloadEncoding
+  )
+
+  private object ConfigKeys {
+
+    object General extends Keys("otel.exporter.otlp")
+    object Traces extends Keys("otel.exporter.otlp.traces")
+
+    abstract class Keys(namespace: String) {
+      val Endpoint: Config.Key[Uri] =
+        Config.Key(s"$namespace.endpoint")
+      val Headers: Config.Key[Headers] =
+        Config.Key(s"$namespace.headers")
+      val Compression: Config.Key[PayloadCompression] =
+        Config.Key(s"$namespace.compression")
+      val Timeout: Config.Key[FiniteDuration] =
+        Config.Key(s"$namespace.timeout")
+
+      val All: Set[Config.Key[_]] = Set(Endpoint, Headers, Compression, Timeout)
+    }
+  }
+
+  /** Autoconfigures [[OtlpHttpClient]] using `otel.exporter.otlp.traces.{x}`
+    * and `otel.exporter.otlp.{x}` properties.
+    *
+    * @param defaults
+    *   the default values to use as a fallback when property is missing in the
+    *   config
+    */
+  def traces[F[_]: Async: Network: Compression: Console, A](
+      defaults: Defaults
+  )(implicit
+      encoder: ProtoEncoder.Message[List[A]],
+      printer: Printer
+  ): AutoConfigure[F, OtlpHttpClient[F, A]] =
+    new OtlpHttpClientAutoConfigure[F, A](
+      ConfigKeys.Traces,
+      defaults,
+      ConfigKeys.General.All ++ ConfigKeys.Traces.All
+    )
+
+}

--- a/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigureSuite.scala
+++ b/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigureSuite.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+package otlp.autoconfigure
+
+import cats.effect.IO
+import cats.syntax.either._
+import cats.syntax.traverse._
+import munit.CatsEffectSuite
+import org.http4s.Headers
+import org.http4s.Uri
+import org.http4s.syntax.literals._
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.exporter.otlp.HttpPayloadEncoding
+import org.typelevel.otel4s.sdk.exporter.otlp.ProtoEncoder
+import scalapb_circe.Printer
+
+import scala.concurrent.duration._
+
+class OtlpHttpClientAutoConfigureSuite
+    extends CatsEffectSuite
+    with SuiteRuntimePlatform {
+
+  import OtlpHttpClientAutoConfigure.Defaults
+
+  private sealed trait Payload
+
+  private implicit val protoEncoder: ProtoEncoder.Message[List[Payload]] =
+    _ => ???
+
+  private implicit val jsonPrinter: Printer = new Printer()
+
+  private val tracesDefaults = Defaults(
+    uri"http://localhost:4318/v1/traces",
+    "v1/traces",
+    Headers.empty,
+    10.seconds,
+    HttpPayloadEncoding.Protobuf
+  )
+
+  test("traces - empty config - load default") {
+    val config = Config.ofProps(Map.empty)
+
+    val expected =
+      "OtlpHttpClient{" +
+        "encoding=Protobuf, " +
+        "endpoint=http://localhost:4318/v1/traces, " +
+        "timeout=10 seconds, " +
+        "gzipCompression=false, " +
+        "headers={}}"
+
+    OtlpHttpClientAutoConfigure
+      .traces[IO, Payload](tracesDefaults)
+      .configure(config)
+      .use(client => IO(assertEquals(client.toString, expected)))
+  }
+
+  test("traces - empty string - load default") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.compression" -> "",
+        "otel.exporter.otlp.endpoint" -> "",
+        "otel.exporter.otlp.headers" -> "",
+        "otel.exporter.otlp.timeout" -> "",
+        "otel.exporter.otlp.traces.compression" -> "",
+        "otel.exporter.otlp.traces.endpoint" -> "",
+        "otel.exporter.otlp.traces.headers" -> "",
+        "otel.exporter.otlp.traces.timeout" -> ""
+      )
+    )
+
+    val expected =
+      "OtlpHttpClient{" +
+        "encoding=Protobuf, " +
+        "endpoint=http://localhost:4318/v1/traces, " +
+        "timeout=10 seconds, " +
+        "gzipCompression=false, " +
+        "headers={}}"
+
+    OtlpHttpClientAutoConfigure
+      .traces[IO, Payload](tracesDefaults)
+      .configure(config)
+      .use(client => IO(assertEquals(client.toString, expected)))
+  }
+
+  test("traces - use global properties") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.compression" -> "gzip",
+        "otel.exporter.otlp.endpoint" -> "http://localhost:1234/",
+        "otel.exporter.otlp.headers" -> "header1=value1",
+        "otel.exporter.otlp.timeout" -> "5 seconds"
+      )
+    )
+
+    val expected =
+      "OtlpHttpClient{" +
+        "encoding=Protobuf, " +
+        "endpoint=http://localhost:1234/v1/traces, " +
+        "timeout=5 seconds, " +
+        "gzipCompression=true, " +
+        "headers={header1: value1}}"
+
+    OtlpHttpClientAutoConfigure
+      .traces[IO, Payload](tracesDefaults)
+      .configure(config)
+      .use(client => IO(assertEquals(client.toString, expected)))
+  }
+
+  test("traces - prioritize 'traces' properties") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.compression" -> "",
+        "otel.exporter.otlp.endpoint" -> "",
+        "otel.exporter.otlp.headers" -> "header1=value1",
+        "otel.exporter.otlp.timeout" -> "5 seconds",
+        "otel.exporter.otlp.traces.compression" -> "gzip",
+        "otel.exporter.otlp.traces.endpoint" -> "http://localhost:1234/v2/traces",
+        "otel.exporter.otlp.traces.headers" -> "header2=value2",
+        "otel.exporter.otlp.traces.timeout" -> "15 seconds"
+      )
+    )
+
+    val expected =
+      "OtlpHttpClient{" +
+        "encoding=Protobuf, " +
+        "endpoint=http://localhost:1234/v2/traces, " +
+        "timeout=15 seconds, " +
+        "gzipCompression=true, " +
+        "headers={header2: value2}}"
+
+    OtlpHttpClientAutoConfigure
+      .traces[IO, Payload](tracesDefaults)
+      .configure(config)
+      .use(client => IO(assertEquals(client.toString, expected)))
+  }
+
+  test("traces - invalid property - fail") {
+    val input = List(
+      "otel.exporter.otlp.compression" -> "unknown",
+      "otel.exporter.otlp.endpoint" -> "not\\//-a-url",
+      "otel.exporter.otlp.headers" -> "header1",
+      "otel.exporter.otlp.timeout" -> "5 hertz",
+      "otel.exporter.otlp.traces.compression" -> "gzipped",
+      "otel.exporter.otlp.traces.endpoint" -> "aa aa",
+      "otel.exporter.otlp.traces.headers" -> "not a header",
+      "otel.exporter.otlp.traces.timeout" -> "invalid"
+    )
+
+    val empty = Map(
+      "otel.exporter.otlp.compression" -> "",
+      "otel.exporter.otlp.endpoint" -> "",
+      "otel.exporter.otlp.headers" -> "",
+      "otel.exporter.otlp.timeout" -> "",
+      "otel.exporter.otlp.traces.compression" -> "",
+      "otel.exporter.otlp.traces.endpoint" -> "",
+      "otel.exporter.otlp.traces.headers" -> "",
+      "otel.exporter.otlp.traces.timeout" -> ""
+    )
+
+    val errors = Map(
+      "otel.exporter.otlp.compression" -> "Unrecognized compression. Supported options [gzip]",
+      "otel.exporter.otlp.endpoint" -> Uri
+        .fromString("not\\//-a-url")
+        .fold(_.message, _ => ""),
+      "otel.exporter.otlp.headers" -> "Invalid map property [header1]",
+      "otel.exporter.otlp.timeout" -> "Invalid value for property otel.exporter.otlp.timeout=5 hertz. Must be [FiniteDuration]",
+      "otel.exporter.otlp.traces.compression" -> "Unrecognized compression. Supported options [gzip]",
+      "otel.exporter.otlp.traces.endpoint" -> Uri
+        .fromString("aa aa")
+        .fold(_.message, _ => ""),
+      "otel.exporter.otlp.traces.headers" -> "Invalid map property [not a header]",
+      "otel.exporter.otlp.traces.timeout" -> "Invalid value for property otel.exporter.otlp.traces.timeout=invalid. Must be [FiniteDuration]"
+    )
+
+    input.traverse { case (key, value) =>
+      val properties = empty.updated(key, value)
+      val config = Config.ofProps(properties)
+      val cause = errors(key)
+
+      val prettyConfig = properties.toSeq.sorted.zipWithIndex
+        .map { case ((k, v), i) =>
+          val idx = i + 1
+          val value = if (v.isEmpty) "N/A" else v
+          s"$idx) `$k` - $value"
+        }
+        .mkString("\n")
+
+      val expected =
+        s"Cannot autoconfigure [OtlpHttpClient].\nCause: $cause.\nConfig:\n$prettyConfig"
+
+      OtlpHttpClientAutoConfigure
+        .traces[IO, Payload](tracesDefaults)
+        .configure(config)
+        .use_
+        .attempt
+        .map(_.leftMap(_.getMessage))
+        .assertEquals(Left(expected))
+    }
+  }
+
+  test("traces - unknown protocol - fail") {
+    val config =
+      Config.ofProps(Map("otel.exporter.otlp.headers" -> "non-header"))
+
+    OtlpHttpClientAutoConfigure
+      .traces[IO, Payload](tracesDefaults)
+      .configure(config)
+      .use_
+      .attempt
+      .map(_.leftMap(_.getMessage))
+      .assertEquals(
+        Left("""Cannot autoconfigure [OtlpHttpClient].
+               |Cause: Invalid map property [non-header].
+               |Config:
+               |1) `otel.exporter.otlp.compression` - N/A
+               |2) `otel.exporter.otlp.endpoint` - N/A
+               |3) `otel.exporter.otlp.headers` - non-header
+               |4) `otel.exporter.otlp.timeout` - N/A
+               |5) `otel.exporter.otlp.traces.compression` - N/A
+               |6) `otel.exporter.otlp.traces.endpoint` - N/A
+               |7) `otel.exporter.otlp.traces.headers` - N/A
+               |8) `otel.exporter.otlp.traces.timeout` - N/A""".stripMargin)
+      )
+  }
+
+}

--- a/sdk-exporter/trace/shared/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporter.scala
+++ b/sdk-exporter/trace/shared/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporter.scala
@@ -27,17 +27,14 @@ import fs2.compression.Compression
 import fs2.io.net.Network
 import fs2.io.net.tls.TLSContext
 import org.http4s.Headers
-import org.http4s.ProductId
 import org.http4s.Uri
-import org.http4s.headers.`User-Agent`
 import org.http4s.syntax.literals._
-import org.typelevel.otel4s.sdk.BuildInfo
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
 
 import scala.concurrent.duration._
 
-/** Exports spans via HTTP. Support `json` and `protobuf` encoding.
+/** Exports spans via HTTP. Supports `json` and `protobuf` encodings.
   *
   * @see
   *   [[https://opentelemetry.io/docs/specs/otel/protocol/exporter/]]
@@ -62,7 +59,6 @@ object OtlpHttpSpanExporter {
     val Endpoint: Uri = uri"http://localhost:4318/v1/traces"
     val Timeout: FiniteDuration = 10.seconds
     val GzipCompression: Boolean = false
-    val UserAgentName: String = "OTel-OTLP-Exporter-Scala-Otel4s"
   }
 
   /** A builder of [[OtlpHttpSpanExporter]] */
@@ -132,11 +128,7 @@ object OtlpHttpSpanExporter {
       endpoint = Defaults.Endpoint,
       gzipCompression = Defaults.GzipCompression,
       timeout = Defaults.Timeout,
-      headers = Headers(
-        `User-Agent`(
-          ProductId(Defaults.UserAgentName, version = Some(BuildInfo.version))
-        )
-      ),
+      headers = Headers.empty,
       retryPolicy = RetryPolicy.default,
       tlsContext = None
     )

--- a/sdk-exporter/trace/shared/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporterSuite.scala
+++ b/sdk-exporter/trace/shared/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporterSuite.scala
@@ -65,7 +65,7 @@ class OtlpHttpSpanExporterSuite
           "endpoint=https://localhost:4318/api/v1/traces, " +
           "timeout=5 seconds, " +
           "gzipCompression=true, " +
-          s"headers={User-Agent: OTel-OTLP-Exporter-Scala-Otel4s/${BuildInfo.version},X-Forwarded-For: 127.0.0.1}}}"
+          "headers={X-Forwarded-For: 127.0.0.1}}}"
 
       OtlpHttpSpanExporter
         .builder[IO]

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/Config.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/Config.scala
@@ -208,7 +208,7 @@ object Config {
     private def asStringList(string: String): List[String] =
       string.split(",").map(_.trim).filter(_.nonEmpty).toList
 
-    private def decodeWithHint[A](
+    private[otel4s] def decodeWithHint[A](
         hint: String
     )(decode: String => Either[ConfigurationError, A]): Reader[A] =
       (key, properties) =>


### PR DESCRIPTION
The usage (from the upcoming PR):

https://github.com/typelevel/otel4s/blob/af028a07e6c0c6243f944182554282be3f1a2a4f/sdk-exporter/trace/shared/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigure.scala#L95-L98

The preview version of the autoconfigure feature is available here https://github.com/typelevel/otel4s/pull/325.