### PR TITLE
Enhance core APIs to support `Attributes`

### DIFF
--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -17,6 +17,8 @@
 package org.typelevel.otel4s
 package metrics
 
+import scala.collection.immutable
+
 private[otel4s] trait UpDownCounterMacro[F[_], A] {
   def backend: UpDownCounter.Backend[F, A]
 
@@ -31,6 +33,17 @@ private[otel4s] trait UpDownCounterMacro[F[_], A] {
   def add(value: A, attributes: Attribute[_]*): F[Unit] =
     macro UpDownCounterMacro.add[A]
 
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to add to the counter
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+    macro UpDownCounterMacro.addColl[A]
+
   /** Increments a counter by one.
     *
     * @param attributes
@@ -39,6 +52,14 @@ private[otel4s] trait UpDownCounterMacro[F[_], A] {
   def inc(attributes: Attribute[_]*): F[Unit] =
     macro UpDownCounterMacro.inc
 
+  /** Increments a counter by one.
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+    macro UpDownCounterMacro.incColl
+
   /** Decrements a counter by one.
     *
     * @param attributes
@@ -46,6 +67,14 @@ private[otel4s] trait UpDownCounterMacro[F[_], A] {
     */
   def dec(attributes: Attribute[_]*): F[Unit] =
     macro UpDownCounterMacro.dec
+
+  /** Decrements a counter by one.
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+    macro UpDownCounterMacro.decColl
 
 }
 
@@ -57,30 +86,52 @@ object UpDownCounterMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
+    addColl(c)(value, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def addColl[A](c: blackbox.Context)(
+      value: c.Expr[A],
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.add($value, ..$attributes) else $meta.unit"
+    q"if ($meta.isEnabled) $backend.add($value, $attributes) else $meta.unit"
   }
 
   def inc(c: blackbox.Context)(
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
+    incColl(c)(c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def incColl(c: blackbox.Context)(
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.inc(..$attributes) else $meta.unit"
+    q"if ($meta.isEnabled) $backend.inc($attributes) else $meta.unit"
   }
 
   def dec(c: blackbox.Context)(
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
+    decColl(c)(c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def decColl(c: blackbox.Context)(
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.dec(..$attributes) else $meta.unit"
+    q"if ($meta.isEnabled) $backend.dec($attributes) else $meta.unit"
   }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -19,6 +19,7 @@ package metrics
 
 import cats.effect.kernel.Resource
 
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.quoted.*
 
@@ -36,6 +37,20 @@ private[otel4s] trait HistogramMacro[F[_], A] {
   inline def record(
       inline value: A,
       inline attributes: Attribute[_]*
+  ): F[Unit] =
+    ${ HistogramMacro.record('backend, 'value, 'attributes) }
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def record(
+      inline value: A,
+      inline attributes: immutable.Iterable[Attribute[_]]
   ): F[Unit] =
     ${ HistogramMacro.record('backend, 'value, 'attributes) }
 
@@ -64,6 +79,31 @@ private[otel4s] trait HistogramMacro[F[_], A] {
   ): Resource[F, Unit] =
     ${ HistogramMacro.recordDuration('backend, 'timeUnit, 'attributes) }
 
+  /** Records duration of the given effect.
+    *
+    * @example
+    *   {{{
+    * val histogram: Histogram[F] = ???
+    * val attributeKey = AttributeKey.string("query_name")
+    *
+    * def findUser(name: String) =
+    *   histogram.recordDuration(TimeUnit.MILLISECONDS, Attributes(Attribute(attributeKey, "find_user"))).use { _ =>
+    *     db.findUser(name)
+    *   }
+    *   }}}
+    *
+    * @param timeUnit
+    *   the time unit of the duration measurement
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def recordDuration(
+      inline timeUnit: TimeUnit,
+      inline attributes: immutable.Iterable[Attribute[_]]
+  ): Resource[F, Unit] =
+    ${ HistogramMacro.recordDuration('backend, 'timeUnit, 'attributes) }
+
 }
 
 object HistogramMacro {
@@ -71,21 +111,21 @@ object HistogramMacro {
   def record[F[_], A](
       backend: Expr[Histogram.Backend[F, A]],
       value: Expr[A],
-      attributes: Expr[Seq[Attribute[_]]]
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
     '{
-      if ($backend.meta.isEnabled) $backend.record($value, $attributes*)
+      if ($backend.meta.isEnabled) $backend.record($value, $attributes)
       else $backend.meta.unit
     }
 
   def recordDuration[F[_], A](
       backend: Expr[Histogram.Backend[F, A]],
       timeUnit: Expr[TimeUnit],
-      attributes: Expr[Seq[Attribute[_]]]
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
     '{
       if ($backend.meta.isEnabled)
-        $backend.recordDuration($timeUnit, $attributes*)
+        $backend.recordDuration($timeUnit, $attributes)
       else $backend.meta.resourceUnit
     }
 

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s
 package metrics
 
+import scala.collection.immutable
 import scala.quoted.*
 
 private[otel4s] trait UpDownCounterMacro[F[_], A] {
@@ -33,12 +34,34 @@ private[otel4s] trait UpDownCounterMacro[F[_], A] {
   inline def add(inline value: A, inline attributes: Attribute[_]*): F[Unit] =
     ${ UpDownCounterMacro.add('backend, 'value, 'attributes) }
 
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to add to the counter
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def add(
+      inline value: A,
+      inline attributes: immutable.Iterable[Attribute[_]]
+  ): F[Unit] =
+    ${ UpDownCounterMacro.add('backend, 'value, 'attributes) }
+
   /** Increments a counter by one.
     *
     * @param attributes
     *   the set of attributes to associate with the value
     */
   inline def inc(inline attributes: Attribute[_]*): F[Unit] =
+    ${ UpDownCounterMacro.inc('backend, 'attributes) }
+
+  /** Increments a counter by one.
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def inc(inline attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
     ${ UpDownCounterMacro.inc('backend, 'attributes) }
 
   /** Decrements a counter by one.
@@ -49,6 +72,14 @@ private[otel4s] trait UpDownCounterMacro[F[_], A] {
   inline def dec(inline attributes: Attribute[_]*): F[Unit] =
     ${ UpDownCounterMacro.dec('backend, 'attributes) }
 
+  /** Decrements a counter by one.
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def dec(inline attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+    ${ UpDownCounterMacro.dec('backend, 'attributes) }
+
 }
 
 object UpDownCounterMacro {
@@ -56,28 +87,28 @@ object UpDownCounterMacro {
   def add[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
       value: Expr[A],
-      attributes: Expr[Seq[Attribute[_]]]
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
     '{
-      if ($backend.meta.isEnabled) $backend.add($value, $attributes*)
+      if ($backend.meta.isEnabled) $backend.add($value, $attributes)
       else $backend.meta.unit
     }
 
   def inc[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
-      attributes: Expr[Seq[Attribute[_]]]
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
     '{
-      if ($backend.meta.isEnabled) $backend.inc($attributes*)
+      if ($backend.meta.isEnabled) $backend.inc($attributes)
       else $backend.meta.unit
     }
 
   def dec[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
-      attributes: Expr[Seq[Attribute[_]]]
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
     '{
-      if ($backend.meta.isEnabled) $backend.dec($attributes*)
+      if ($backend.meta.isEnabled) $backend.dec($attributes)
       else $backend.meta.unit
     }
 

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
@@ -20,6 +20,8 @@ package metrics
 import cats.Applicative
 import org.typelevel.otel4s.meta.InstrumentMeta
 
+import scala.collection.immutable
+
 /** A `Counter` instrument that records values of type `A`.
   *
   * The [[Counter]] is monotonic. This means the aggregated value is nominally
@@ -88,24 +90,24 @@ object Counter {
       * @param attributes
       *   the set of attributes to associate with the value
       */
-    def add(value: A, attributes: Attribute[_]*): F[Unit]
+    def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit]
 
     /** Increments a counter by one.
       *
       * @param attributes
       *   the set of attributes to associate with the value
       */
-    def inc(attributes: Attribute[_]*): F[Unit]
+    def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
   }
 
   trait LongBackend[F[_]] extends Backend[F, Long] {
-    final def inc(attributes: Attribute[_]*): F[Unit] =
-      add(1L, attributes: _*)
+    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(1L, attributes)
   }
 
   trait DoubleBackend[F[_]] extends Backend[F, Double] {
-    final def inc(attributes: Attribute[_]*): F[Unit] =
-      add(1.0, attributes: _*)
+    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(1.0, attributes)
   }
 
   def noop[F[_], A](implicit F: Applicative[F]): Counter[F, A] =
@@ -113,8 +115,12 @@ object Counter {
       val backend: Backend[F, A] =
         new Backend[F, A] {
           val meta: InstrumentMeta[F] = InstrumentMeta.disabled
-          def add(value: A, attributes: Attribute[_]*): F[Unit] = meta.unit
-          def inc(attributes: Attribute[_]*): F[Unit] = meta.unit
+          def add(
+              value: A,
+              attributes: immutable.Iterable[Attribute[_]]
+          ): F[Unit] = meta.unit
+          def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+            meta.unit
         }
     }
 

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
@@ -20,6 +20,8 @@ package metrics
 import cats.Applicative
 import org.typelevel.otel4s.meta.InstrumentMeta
 
+import scala.collection.immutable
+
 /** A `Counter` instrument that records values of type `A`.
   *
   * The [[UpDownCounter]] is non-monotonic. This means the aggregated value can
@@ -89,37 +91,37 @@ object UpDownCounter {
       * @param attributes
       *   the set of attributes to associate with the value
       */
-    def add(value: A, attributes: Attribute[_]*): F[Unit]
+    def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit]
 
     /** Increments a counter by one.
       *
       * @param attributes
       *   the set of attributes to associate with the value
       */
-    def inc(attributes: Attribute[_]*): F[Unit]
+    def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
 
     /** Decrements a counter by one.
       *
       * @param attributes
       *   the set of attributes to associate with the value
       */
-    def dec(attributes: Attribute[_]*): F[Unit]
+    def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
   }
 
   trait LongBackend[F[_]] extends Backend[F, Long] {
-    final def inc(attributes: Attribute[_]*): F[Unit] =
-      add(1L, attributes: _*)
+    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(1L, attributes)
 
-    final def dec(attributes: Attribute[_]*): F[Unit] =
-      add(-1L, attributes: _*)
+    final def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(-1L, attributes)
   }
 
   trait DoubleBackend[F[_]] extends Backend[F, Double] {
-    final def inc(attributes: Attribute[_]*): F[Unit] =
-      add(1.0, attributes: _*)
+    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(1.0, attributes)
 
-    final def dec(attributes: Attribute[_]*): F[Unit] =
-      add(-1.0, attributes: _*)
+    final def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      add(-1.0, attributes)
   }
 
   def noop[F[_], A](implicit F: Applicative[F]): UpDownCounter[F, A] =
@@ -127,9 +129,14 @@ object UpDownCounter {
       val backend: UpDownCounter.Backend[F, A] =
         new UpDownCounter.Backend[F, A] {
           val meta: InstrumentMeta[F] = InstrumentMeta.disabled
-          def add(value: A, attributes: Attribute[_]*): F[Unit] = meta.unit
-          def inc(attributes: Attribute[_]*): F[Unit] = meta.unit
-          def dec(attributes: Attribute[_]*): F[Unit] = meta.unit
+          def add(
+              value: A,
+              attributes: immutable.Iterable[Attribute[_]]
+          ): F[Unit] = meta.unit
+          def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+            meta.unit
+          def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+            meta.unit
         }
     }
 

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
@@ -22,6 +22,8 @@ import cats.effect.Ref
 import munit.CatsEffectSuite
 import org.typelevel.otel4s.meta.InstrumentMeta
 
+import scala.collection.immutable
+
 class UpDownCounterSuite extends CatsEffectSuite {
   import UpDownCounterSuite._
 
@@ -35,10 +37,14 @@ class UpDownCounterSuite extends CatsEffectSuite {
       List(Attribute("key", "value"))
     }
 
+    // test varargs and Iterable overloads
     for {
       _ <- counter.add(1L, allocateAttribute: _*)
+      _ <- counter.add(1L, allocateAttribute)
       _ <- counter.inc(allocateAttribute: _*)
+      _ <- counter.inc(allocateAttribute)
       _ <- counter.dec(allocateAttribute: _*)
+      _ <- counter.dec(allocateAttribute)
     } yield assert(!allocated)
   }
 
@@ -47,14 +53,15 @@ class UpDownCounterSuite extends CatsEffectSuite {
 
     val expected =
       List(
-        Record(1L, Seq(attribute)),
-        Record(2L, Nil),
-        Record(3L, Seq(attribute, attribute))
+        Record(1L, Attributes(attribute)),
+        Record(2L, Attributes.empty),
+        Record(3L, Attributes(attribute, attribute))
       )
 
+    // test varargs and Iterable overloads
     for {
       counter <- inMemoryUpDownCounter
-      _ <- counter.add(1L, attribute)
+      _ <- counter.add(1L, Attributes(attribute))
       _ <- counter.add(2L)
       _ <- counter.add(3L, attribute, attribute)
       records <- counter.records
@@ -66,14 +73,15 @@ class UpDownCounterSuite extends CatsEffectSuite {
 
     val expected =
       List(
-        Record(1L, Seq(attribute)),
-        Record(1L, Nil),
-        Record(1L, Seq(attribute, attribute))
+        Record(1L, Attributes(attribute)),
+        Record(1L, Attributes.empty),
+        Record(1L, Attributes(attribute, attribute))
       )
 
+    // test varargs and Iterable overloads
     for {
       counter <- inMemoryUpDownCounter
-      _ <- counter.inc(attribute)
+      _ <- counter.inc(Attributes(attribute))
       _ <- counter.inc()
       _ <- counter.inc(attribute, attribute)
       records <- counter.records
@@ -85,14 +93,15 @@ class UpDownCounterSuite extends CatsEffectSuite {
 
     val expected =
       List(
-        Record(-1L, Seq(attribute)),
-        Record(-1L, Nil),
-        Record(-1L, Seq(attribute, attribute))
+        Record(-1L, Attributes(attribute)),
+        Record(-1L, Attributes.empty),
+        Record(-1L, Attributes(attribute, attribute))
       )
 
+    // test varargs and Iterable overloads
     for {
       counter <- inMemoryUpDownCounter
-      _ <- counter.dec(attribute)
+      _ <- counter.dec(Attributes(attribute))
       _ <- counter.dec()
       _ <- counter.dec(attribute, attribute)
       records <- counter.records
@@ -106,7 +115,7 @@ class UpDownCounterSuite extends CatsEffectSuite {
 
 object UpDownCounterSuite {
 
-  final case class Record[A](value: A, attributes: Seq[Attribute[_]])
+  final case class Record[A](value: A, attributes: Attributes)
 
   class InMemoryUpDownCounter(ref: Ref[IO, List[Record[Long]]])
       extends UpDownCounter[IO, Long] {
@@ -115,8 +124,11 @@ object UpDownCounterSuite {
       new UpDownCounter.LongBackend[IO] {
         val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
 
-        def add(value: Long, attributes: Attribute[_]*): IO[Unit] =
-          ref.update(_.appended(Record(value, attributes)))
+        def add(
+            value: Long,
+            attributes: immutable.Iterable[Attribute[_]]
+        ): IO[Unit] =
+          ref.update(_.appended(Record(value, attributes.to(Attributes))))
       }
 
     def records: IO[List[Record[Long]]] =

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -17,6 +17,8 @@
 package org.typelevel.otel4s
 package trace
 
+import scala.collection.immutable
+
 private[otel4s] trait TracerMacro[F[_]] {
   self: Tracer[F] =>
 
@@ -38,7 +40,7 @@ private[otel4s] trait TracerMacro[F[_]] {
     * val tracer: Tracer[F] = ???
     * val span: Span[F] = ???
     * val customParent: SpanOps[F] = tracer
-    *   .spanBuilder("custom-parent")
+    *   .spanBuilder("custom-parent", Attribute("key", "value"))
     *   .withParent(span.context)
     *   .build
     *   }}}
@@ -54,6 +56,44 @@ private[otel4s] trait TracerMacro[F[_]] {
     */
   def span(name: String, attributes: Attribute[_]*): SpanOps[F] =
     macro TracerMacro.span
+
+  /** Creates a new child span. The span is automatically attached to a parent
+    * span (based on the scope).
+    *
+    * The lifecycle of the span is managed automatically. That means the span is
+    * ended upon the finalization of a resource.
+    *
+    * The abnormal termination (error, cancelation) is recorded by
+    * [[SpanFinalizer.Strategy.reportAbnormal default finalization strategy]].
+    *
+    * To attach span to a specific parent, use [[childScope]] or
+    * [[SpanBuilder.withParent]].
+    *
+    * @example
+    *   attaching span to a specific parent
+    *   {{{
+    * val tracer: Tracer[F] = ???
+    * val span: Span[F] = ???
+    * val customParent: SpanOps[F] = tracer
+    *   .spanBuilder("custom-parent", Attributes(Attribute("key", "value")))
+    *   .withParent(span.context)
+    *   .build
+    *   }}}
+    *
+    * @see
+    *   [[spanBuilder]] to make a fully manual span (explicit end)
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  def span(
+      name: String,
+      attributes: immutable.Iterable[Attribute[_]]
+  ): SpanOps[F] =
+    macro TracerMacro.spanColl
 
   /** Creates a new root span. Even if a parent span is available in the scope,
     * the span is created without a parent.
@@ -72,6 +112,27 @@ private[otel4s] trait TracerMacro[F[_]] {
     */
   def rootSpan(name: String, attributes: Attribute[_]*): SpanOps[F] =
     macro TracerMacro.rootSpan
+
+  /** Creates a new root span. Even if a parent span is available in the scope,
+    * the span is created without a parent.
+    *
+    * The lifecycle of the span is managed automatically. That means the span is
+    * ended upon the finalization of a resource.
+    *
+    * The abnormal termination (error, cancelation) is recorded by
+    * [[SpanFinalizer.Strategy.reportAbnormal default finalization strategy]].
+    *
+    * @param name
+    *   the name of the span
+    *
+    * @param attributes
+    *   the set of attributes to associate with the span
+    */
+  def rootSpan(
+      name: String,
+      attributes: immutable.Iterable[Attribute[_]]
+  ): SpanOps[F] =
+    macro TracerMacro.rootSpanColl
 }
 
 object TracerMacro {
@@ -82,8 +143,16 @@ object TracerMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
+    spanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def spanColl(c: blackbox.Context)(
+      name: c.Expr[String],
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
     val meta = q"${c.prefix}.meta"
-    q"(if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).addAttributes(..$attributes) else $meta.noopSpanBuilder).build"
+    q"(if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).addAttributes($attributes) else $meta.noopSpanBuilder).build"
   }
 
   def rootSpan(c: blackbox.Context)(
@@ -91,8 +160,16 @@ object TracerMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
+    rootSpanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def rootSpanColl(c: blackbox.Context)(
+      name: c.Expr[String],
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
     val meta = q"${c.prefix}.meta"
-    q"(if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.addAttributes(..$attributes) else $meta.noopSpanBuilder).build"
+    q"(if ($meta.isEnabled) ${c.prefix}.spanBuilder($name).root.addAttributes($attributes) else $meta.noopSpanBuilder).build"
   }
 
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -21,6 +21,7 @@ import cats.Applicative
 import cats.~>
 import org.typelevel.otel4s.meta.InstrumentMeta
 
+import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 /** The API to trace an operation.
@@ -128,18 +129,21 @@ object Span {
 
     def updateName(name: String): F[Unit]
 
-    def addAttributes(attributes: Attribute[_]*): F[Unit]
-    def addEvent(name: String, attributes: Attribute[_]*): F[Unit]
+    def addAttributes(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
+    def addEvent(
+        name: String,
+        attributes: immutable.Iterable[Attribute[_]]
+    ): F[Unit]
 
     def addEvent(
         name: String,
         timestamp: FiniteDuration,
-        attributes: Attribute[_]*
+        attributes: immutable.Iterable[Attribute[_]]
     ): F[Unit]
 
     def recordException(
         exception: Throwable,
-        attributes: Attribute[_]*
+        attributes: immutable.Iterable[Attribute[_]]
     ): F[Unit]
 
     def setStatus(status: Status): F[Unit]
@@ -188,18 +192,23 @@ object Span {
 
         def updateName(name: String): F[Unit] = unit
 
-        def addAttributes(attributes: Attribute[_]*): F[Unit] = unit
-        def addEvent(name: String, attributes: Attribute[_]*): F[Unit] = unit
+        def addAttributes(
+            attributes: immutable.Iterable[Attribute[_]]
+        ): F[Unit] = unit
+        def addEvent(
+            name: String,
+            attributes: immutable.Iterable[Attribute[_]]
+        ): F[Unit] = unit
 
         def addEvent(
             name: String,
             timestamp: FiniteDuration,
-            attributes: Attribute[_]*
+            attributes: immutable.Iterable[Attribute[_]]
         ): F[Unit] = unit
 
         def recordException(
             exception: Throwable,
-            attributes: Attribute[_]*
+            attributes: immutable.Iterable[Attribute[_]]
         ): F[Unit] = unit
 
         def setStatus(status: Status): F[Unit] = unit
@@ -217,21 +226,24 @@ object Span {
       def context: SpanContext = backend.context
       def updateName(name: String): G[Unit] =
         f(backend.updateName(name))
-      def addAttributes(attributes: Attribute[_]*): G[Unit] =
-        f(backend.addAttributes(attributes: _*))
-      def addEvent(name: String, attributes: Attribute[_]*): G[Unit] =
-        f(backend.addEvent(name, attributes: _*))
+      def addAttributes(attributes: immutable.Iterable[Attribute[_]]): G[Unit] =
+        f(backend.addAttributes(attributes))
+      def addEvent(
+          name: String,
+          attributes: immutable.Iterable[Attribute[_]]
+      ): G[Unit] =
+        f(backend.addEvent(name, attributes))
       def addEvent(
           name: String,
           timestamp: FiniteDuration,
-          attributes: Attribute[_]*
+          attributes: immutable.Iterable[Attribute[_]]
       ): G[Unit] =
-        f(backend.addEvent(name, timestamp, attributes: _*))
+        f(backend.addEvent(name, timestamp, attributes))
       def recordException(
           exception: Throwable,
-          attributes: Attribute[_]*
+          attributes: immutable.Iterable[Attribute[_]]
       ): G[Unit] =
-        f(backend.recordException(exception, attributes: _*))
+        f(backend.recordException(exception, attributes))
       def setStatus(status: Status): G[Unit] =
         f(backend.setStatus(status))
       def setStatus(status: Status, description: String): G[Unit] =

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
@@ -44,7 +44,7 @@ class TracerSuite extends CatsEffectSuite {
       100.millis
     }
 
-    def attribute = {
+    def attribute: List[Attribute[String]] = {
       allocated = true
       List(Attribute("key", "value"))
     }
@@ -54,27 +54,38 @@ class TracerSuite extends CatsEffectSuite {
       new RuntimeException("exception")
     }
 
+    // test varargs and Iterable overloads
     for {
       _ <- tracer.span("span", attribute: _*).use { span =>
         for {
           _ <- span.addAttributes(attribute: _*)
+          _ <- span.addAttributes(attribute)
           _ <- span.addEvent(text, attribute: _*)
+          _ <- span.addEvent(text, attribute)
           _ <- span.addEvent(text, timestamp, attribute: _*)
+          _ <- span.addEvent(text, timestamp, attribute)
           _ <- span.recordException(exception, attribute: _*)
+          _ <- span.recordException(exception, attribute)
           _ <- span.setStatus(status)
           _ <- span.setStatus(status, text)
         } yield ()
       }
+      _ <- tracer.span("span", attribute).use_
       _ <- tracer.rootSpan("span", attribute: _*).use { span =>
         for {
           _ <- span.addAttributes(attribute: _*)
+          _ <- span.addAttributes(attribute)
           _ <- span.addEvent(text, attribute: _*)
+          _ <- span.addEvent(text, attribute)
           _ <- span.addEvent(text, timestamp, attribute: _*)
+          _ <- span.addEvent(text, timestamp, attribute)
           _ <- span.recordException(exception, attribute: _*)
+          _ <- span.recordException(exception, attribute)
           _ <- span.setStatus(status)
           _ <- span.setStatus(status, text)
         } yield ()
       }
+      _ <- tracer.rootSpan("span", attribute).use_
     } yield assert(!allocated)
   }
 

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
@@ -23,6 +23,8 @@ import io.opentelemetry.api.metrics.{Meter => JMeter}
 import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics._
 
+import scala.collection.immutable
+
 private[oteljava] case class CounterBuilderImpl[F[_], A](
     factory: CounterBuilderImpl.Factory[F, A],
     name: String,
@@ -82,12 +84,15 @@ private[oteljava] object CounterBuilderImpl {
           val backend = new Counter.Backend[F, A] {
             val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
-            def add(value: A, attributes: Attribute[_]*): F[Unit] =
+            def add(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 counter.add(cast(value), Conversions.toJAttributes(attributes))
               )
 
-            def inc(attributes: Attribute[_]*): F[Unit] =
+            def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(1L, Conversions.toJAttributes(attributes))
               )
@@ -116,12 +121,15 @@ private[oteljava] object CounterBuilderImpl {
           val backend = new Counter.Backend[F, A] {
             val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
-            def add(value: A, attributes: Attribute[_]*): F[Unit] =
+            def add(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 counter.add(cast(value), Conversions.toJAttributes(attributes))
               )
 
-            def inc(attributes: Attribute[_]*): F[Unit] =
+            def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(1.0, Conversions.toJAttributes(attributes))
               )

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -25,6 +25,7 @@ import cats.syntax.functor._
 import io.opentelemetry.api.metrics.{Meter => JMeter}
 import org.typelevel.otel4s.metrics._
 
+import scala.collection.immutable
 import scala.concurrent.duration.TimeUnit
 import scala.jdk.CollectionConverters._
 
@@ -100,7 +101,10 @@ object HistogramBuilderImpl {
           val backend = new Histogram.Backend[F, A] {
             val meta: Histogram.Meta[F] = Histogram.Meta.enabled
 
-            def record(value: A, attributes: Attribute[_]*): F[Unit] =
+            def record(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 histogram.record(
                   cast(value),
@@ -110,7 +114,7 @@ object HistogramBuilderImpl {
 
             def recordDuration(
                 timeUnit: TimeUnit,
-                attributes: Attribute[_]*
+                attributes: immutable.Iterable[Attribute[_]]
             ): Resource[F, Unit] =
               Resource
                 .makeCase(Sync[F].monotonic) { case (start, ec) =>
@@ -158,7 +162,10 @@ object HistogramBuilderImpl {
           val backend = new Histogram.Backend[F, A] {
             val meta: Histogram.Meta[F] = Histogram.Meta.enabled
 
-            def record(value: A, attributes: Attribute[_]*): F[Unit] =
+            def record(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 histogram.record(
                   cast(value),
@@ -168,7 +175,7 @@ object HistogramBuilderImpl {
 
             def recordDuration(
                 timeUnit: TimeUnit,
-                attributes: Attribute[_]*
+                attributes: immutable.Iterable[Attribute[_]]
             ): Resource[F, Unit] =
               Resource
                 .makeCase(Sync[F].monotonic) { case (start, ec) =>

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
@@ -23,6 +23,8 @@ import io.opentelemetry.api.metrics.{Meter => JMeter}
 import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics._
 
+import scala.collection.immutable
+
 private[oteljava] case class UpDownCounterBuilderImpl[F[_], A](
     factory: UpDownCounterBuilderImpl.Factory[F, A],
     name: String,
@@ -81,17 +83,20 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val backend = new UpDownCounter.Backend[F, A] {
             val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
-            def add(value: A, attributes: Attribute[_]*): F[Unit] =
+            def add(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 counter.add(cast(value), Conversions.toJAttributes(attributes))
               )
 
-            def inc(attributes: Attribute[_]*): F[Unit] =
+            def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(1L, Conversions.toJAttributes(attributes))
               )
 
-            def dec(attributes: Attribute[_]*): F[Unit] =
+            def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(-1L, Conversions.toJAttributes(attributes))
               )
@@ -120,17 +125,20 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val backend = new UpDownCounter.Backend[F, A] {
             val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
-            def add(value: A, attributes: Attribute[_]*): F[Unit] =
+            def add(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
               Sync[F].delay(
                 counter.add(cast(value), Conversions.toJAttributes(attributes))
               )
 
-            def inc(attributes: Attribute[_]*): F[Unit] =
+            def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(1.0, Conversions.toJAttributes(attributes))
               )
 
-            def dec(attributes: Attribute[_]*): F[Unit] =
+            def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
               Sync[F].delay(
                 counter.add(-1.0, Conversions.toJAttributes(attributes))
               )

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
@@ -27,6 +27,7 @@ import org.typelevel.otel4s.trace.Span
 import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.Status
 
+import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 private[oteljava] class SpanBackendImpl[F[_]: Sync](
@@ -46,13 +47,16 @@ private[oteljava] class SpanBackendImpl[F[_]: Sync](
       ()
     }
 
-  def addAttributes(attributes: Attribute[_]*): F[Unit] =
+  def addAttributes(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
     Sync[F].delay {
       jSpan.setAllAttributes(Conversions.toJAttributes(attributes))
       ()
     }
 
-  def addEvent(name: String, attributes: Attribute[_]*): F[Unit] =
+  def addEvent(
+      name: String,
+      attributes: immutable.Iterable[Attribute[_]]
+  ): F[Unit] =
     Sync[F].delay {
       jSpan.addEvent(name, Conversions.toJAttributes(attributes))
       ()
@@ -61,7 +65,7 @@ private[oteljava] class SpanBackendImpl[F[_]: Sync](
   def addEvent(
       name: String,
       timestamp: FiniteDuration,
-      attributes: Attribute[_]*
+      attributes: immutable.Iterable[Attribute[_]]
   ): F[Unit] =
     Sync[F].delay {
       jSpan.addEvent(
@@ -87,7 +91,7 @@ private[oteljava] class SpanBackendImpl[F[_]: Sync](
 
   def recordException(
       exception: Throwable,
-      attributes: Attribute[_]*
+      attributes: immutable.Iterable[Attribute[_]]
   ): F[Unit] =
     Sync[F].delay {
       jSpan.recordException(exception, Conversions.toJAttributes(attributes))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -40,6 +40,7 @@ import org.typelevel.otel4s.trace.TraceFlags
 import org.typelevel.otel4s.trace.TraceState
 import scodec.bits.ByteVector
 
+import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 private final case class SdkSpanBuilder[F[_]: Temporal: Console](
@@ -63,12 +64,14 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console](
   def addAttribute[A](attribute: Attribute[A]): SpanBuilder[F] =
     copy(attributes = attributes :+ attribute)
 
-  def addAttributes(attributes: Attribute[_]*): SpanBuilder[F] =
+  def addAttributes(
+      attributes: immutable.Iterable[Attribute[_]]
+  ): SpanBuilder[F] =
     copy(attributes = this.attributes ++ attributes)
 
   def addLink(
       spanContext: SpanContext,
-      attributes: Attribute[_]*
+      attributes: immutable.Iterable[Attribute[_]]
   ): SpanBuilder[F] =
     copy(links =
       links :+ LinkData(spanContext, Attributes.fromSpecific(attributes))

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -55,7 +55,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       for {
         span <- start(attributes = attributes)
         _ <- assertIO(span.toSpanData.map(_.attributes), attributes)
-        _ <- span.addAttributes(nextAttributes.toList: _*)
+        _ <- span.addAttributes(nextAttributes)
         _ <- assertIO(span.toSpanData.map(_.attributes), expected)
       } yield ()
     }
@@ -69,7 +69,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
         for {
           span <- start()
           _ <- assertIO(span.toSpanData.map(_.events), Vector.empty)
-          _ <- span.addEvent(name, attributes.toList: _*)
+          _ <- span.addEvent(name, attributes)
           _ <- assertIO(span.toSpanData.map(_.events), Vector(event))
         } yield ()
       }
@@ -84,7 +84,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
         for {
           span <- start()
           _ <- assertIO(span.toSpanData.map(_.events), Vector.empty)
-          _ <- span.addEvent(name, ts, attrs.toList: _*)
+          _ <- span.addEvent(name, ts, attrs)
           _ <- assertIO(span.toSpanData.map(_.events), Vector(event))
         } yield ()
       }
@@ -116,7 +116,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
         for {
           span <- start()
           _ <- assertIO(span.toSpanData.map(_.events), Vector.empty)
-          _ <- span.recordException(exception, attributes.toList: _*)
+          _ <- span.recordException(exception, attributes)
           _ <- assertIO(span.toSpanData.map(_.events), Vector(event))
         } yield ()
       }
@@ -229,7 +229,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
         )
 
         // add attributes
-        _ <- span.addAttributes(extra.toList: _*)
+        _ <- span.addAttributes(extra)
 
         _ <- assertIO(
           init.toList.traverse(a => span.getAttribute(a.key)),
@@ -392,8 +392,8 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           // should have zero effect
           _ <- IO.sleep(125.millis)
           _ <- span.updateName(name)
-          _ <- span.addAttributes(attributes.toList: _*)
-          _ <- span.addEvent("event")
+          _ <- span.addAttributes(attributes)
+          _ <- span.addEvent("event", Nil)
           _ <- span.setStatus(status)
           _ <- span.end
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
@@ -39,6 +39,7 @@ import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Status
 
+import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 class SimpleSpanProcessorSuite
@@ -150,24 +151,29 @@ class SimpleSpanProcessorSuite
       def updateName(name: String): IO[Unit] =
         noopBackend.updateName(name)
 
-      def addAttributes(attributes: Attribute[_]*): IO[Unit] =
-        noopBackend.addAttributes(attributes: _*)
+      def addAttributes(
+          attributes: immutable.Iterable[Attribute[_]]
+      ): IO[Unit] =
+        noopBackend.addAttributes(attributes)
 
-      def addEvent(name: String, attributes: Attribute[_]*): IO[Unit] =
-        noopBackend.addEvent(name, attributes: _*)
+      def addEvent(
+          name: String,
+          attributes: immutable.Iterable[Attribute[_]]
+      ): IO[Unit] =
+        noopBackend.addEvent(name, attributes)
 
       def addEvent(
           name: String,
           timestamp: FiniteDuration,
-          attributes: Attribute[_]*
+          attributes: immutable.Iterable[Attribute[_]]
       ): IO[Unit] =
-        noopBackend.addEvent(name, timestamp, attributes: _*)
+        noopBackend.addEvent(name, timestamp, attributes)
 
       def recordException(
           exception: Throwable,
-          attributes: Attribute[_]*
+          attributes: immutable.Iterable[Attribute[_]]
       ): IO[Unit] =
-        noopBackend.recordException(exception, attributes: _*)
+        noopBackend.recordException(exception, attributes)
 
       def setStatus(status: Status): IO[Unit] =
         noopBackend.setStatus(status)


### PR DESCRIPTION
Add overloads of `Attribute[_]` varargs methods that accept `immutable.Iterable[Attribute[_]]`, to support use of `Attributes`.