### PR TITLE
sdk-trace: add `SdkTraces`

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/TracerProvider.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/TracerProvider.scala
@@ -81,6 +81,8 @@ object TracerProvider {
     new TracerProvider[F] {
       def tracer(name: String): TracerBuilder[F] =
         TracerBuilder.noop
+      override def toString: String =
+        "TracerProvider.Noop"
     }
 
   private class MappedK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/CommonConfigKeys.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/CommonConfigKeys.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.autoconfigure
+
+private[sdk] object CommonConfigKeys {
+  val SdkDisabled: Config.Key[Boolean] = Config.Key("otel.sdk.disabled")
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.Applicative
+import cats.Parallel
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.effect.std.Random
+import cats.mtl.Local
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.context.LocalProvider
+import org.typelevel.otel4s.context.propagation.ContextPropagators
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.CommonConfigKeys
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.autoconfigure.TelemetryResourceAutoConfigure
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.context.LocalContext
+import org.typelevel.otel4s.sdk.context.LocalContextProvider
+import org.typelevel.otel4s.sdk.trace.autoconfigure.ContextPropagatorsAutoConfigure
+import org.typelevel.otel4s.sdk.trace.autoconfigure.TracerProviderAutoConfigure
+import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
+import org.typelevel.otel4s.sdk.trace.samplers.Sampler
+import org.typelevel.otel4s.trace.TracerProvider
+
+/** The configured tracing module.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+sealed trait SdkTraces[F[_]] {
+
+  /** The [[org.typelevel.otel4s.trace.TracerProvider TracerProvider]].
+    */
+  def tracerProvider: TracerProvider[F]
+
+  /** The propagators used by the
+    * [[org.typelevel.otel4s.trace.TracerProvider TracerProvider]].
+    */
+  def propagators: ContextPropagators[Context]
+
+  /** The [[org.typelevel.otel4s.sdk.context.LocalContext LocalContext]] used by
+    * the [[org.typelevel.otel4s.trace.TracerProvider TracerProvider]].
+    */
+  def localContext: LocalContext[F]
+}
+
+object SdkTraces {
+
+  /** Autoconfigures [[SdkTraces]] using [[AutoConfigured.Builder]].
+    *
+    * @note
+    *   the external components (e.g. OTLP exporter) must be registered
+    *   manually. Add the `otel4s-sdk-exporter` dependency to the build file:
+    *   {{{
+    * libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
+    *   }}}
+    *   and register the configurer manually:
+    *   {{{
+    * import org.typelevel.otel4s.sdk.trace.Traces
+    * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
+    *
+    * SdkTraces.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
+    *   }}}
+    *
+    * @param customize
+    *   a function for customizing the auto-configured SDK builder
+    */
+  def autoConfigured[F[_]: Async: Parallel: Console: LocalContextProvider](
+      customize: AutoConfigured.Builder[F] => AutoConfigured.Builder[F] =
+        (a: AutoConfigured.Builder[F]) => a
+  ): Resource[F, SdkTraces[F]] =
+    customize(AutoConfigured.builder[F]).build
+
+  def noop[F[_]: Applicative: LocalContext]: SdkTraces[F] =
+    new Impl(
+      TracerProvider.noop,
+      ContextPropagators.noop,
+      Local[F, Context]
+    )
+
+  object AutoConfigured {
+
+    type Customizer[A] = (A, Config) => A
+
+    /** A builder of [[SdkTraces]].
+      */
+    sealed trait Builder[F[_]] {
+
+      /** Sets the given config to use when resolving properties.
+        *
+        * @note
+        *   [[addPropertiesLoader]] and [[addPropertiesCustomizer]] will have no
+        *   effect if the custom config is provided.
+        *
+        * @param config
+        *   the config to use
+        */
+      def withConfig(config: Config): Builder[F]
+
+      /** Adds the properties loader. Multiple loaders will be added. The loaded
+        * properties will be merged with the default config. Loaded properties
+        * take precedence over the default ones.
+        *
+        * @param loader
+        *   the additional loader to add
+        */
+      def addPropertiesLoader(loader: F[Map[String, String]]): Builder[F]
+
+      /** Adds the properties customizer. Multiple customizers can be added, and
+        * they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addPropertiesCustomizer(
+          customizer: Config => Map[String, String]
+      ): Builder[F]
+
+      /** Adds the tracer provider builder customizer. Multiple customizers can
+        * be added, and they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addTracerProviderCustomizer(
+          customizer: Customizer[SdkTracerProvider.Builder[F]]
+      ): Builder[F]
+
+      /** Adds the telemetry resource customizer. Multiple customizers can be
+        * added, and they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addResourceCustomizer(
+          customizer: Customizer[TelemetryResource]
+      ): Builder[F]
+
+      /** Adds the exporter configurer. Can be used to register exporters that
+        * aren't included in the SDK.
+        *
+        * @example
+        *   Add the `otel4s-sdk-exporter` dependency to the build file:
+        *   {{{
+        * libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
+        *   }}}
+        *   and register the configurer manually:
+        *   {{{
+        * import org.typelevel.otel4s.sdk.trace.Traces
+        * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
+        *
+        * SdkTraces.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
+        *   }}}
+        *
+        * @param configurer
+        *   the configurer to add
+        */
+      def addExporterConfigurer(
+          configurer: AutoConfigure.Named[F, SpanExporter[F]]
+      ): Builder[F]
+
+      /** Adds the sampler configurer. Can be used to register samplers that
+        * aren't included in the SDK.
+        *
+        * @param configurer
+        *   the configurer to add
+        */
+      def addSamplerConfigurer(
+          configurer: AutoConfigure.Named[F, Sampler]
+      ): Builder[F]
+
+      /** Adds the text map propagator configurer. Can be used to register
+        * propagators that aren't included in the SDK.
+        *
+        * @param configurer
+        *   the configurer to add
+        */
+      def addTextMapPropagatorConfigurer(
+          configurer: AutoConfigure.Named[F, TextMapPropagator[Context]]
+      ): Builder[F]
+
+      /** Creates [[SdkTraces]] using the configuration of this builder.
+        */
+      def build: Resource[F, SdkTraces[F]]
+    }
+
+    /** Creates a [[Builder]].
+      */
+    def builder[
+        F[_]: Async: Parallel: Console: LocalContextProvider
+    ]: Builder[F] =
+      BuilderImpl(
+        customConfig = None,
+        propertiesLoader = Async[F].pure(Map.empty),
+        propertiesCustomizers = Nil,
+        resourceCustomizer = (a, _) => a,
+        tracerProviderCustomizer = (a: SdkTracerProvider.Builder[F], _) => a,
+        exporterConfigurers = Set.empty,
+        samplerConfigurers = Set.empty,
+        textMapPropagatorConfigurers = Set.empty
+      )
+
+    private final case class BuilderImpl[
+        F[_]: Async: Parallel: Console: LocalContextProvider
+    ](
+        customConfig: Option[Config],
+        propertiesLoader: F[Map[String, String]],
+        propertiesCustomizers: List[Config => Map[String, String]],
+        resourceCustomizer: Customizer[TelemetryResource],
+        tracerProviderCustomizer: Customizer[SdkTracerProvider.Builder[F]],
+        exporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]],
+        samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
+        textMapPropagatorConfigurers: Set[
+          AutoConfigure.Named[F, TextMapPropagator[Context]]
+        ]
+    ) extends Builder[F] {
+
+      def withConfig(config: Config): Builder[F] =
+        copy(customConfig = Some(config))
+
+      def addPropertiesLoader(
+          loader: F[Map[String, String]]
+      ): Builder[F] =
+        copy(propertiesLoader = (this.propertiesLoader, loader).mapN(_ ++ _))
+
+      def addPropertiesCustomizer(
+          customizer: Config => Map[String, String]
+      ): Builder[F] =
+        copy(propertiesCustomizers = this.propertiesCustomizers :+ customizer)
+
+      def addResourceCustomizer(
+          customizer: Customizer[TelemetryResource]
+      ): Builder[F] =
+        copy(resourceCustomizer = merge(this.resourceCustomizer, customizer))
+
+      def addTracerProviderCustomizer(
+          customizer: Customizer[SdkTracerProvider.Builder[F]]
+      ): Builder[F] =
+        copy(tracerProviderCustomizer =
+          merge(this.tracerProviderCustomizer, customizer)
+        )
+
+      def addExporterConfigurer(
+          configurer: AutoConfigure.Named[F, SpanExporter[F]]
+      ): Builder[F] =
+        copy(exporterConfigurers = exporterConfigurers + configurer)
+
+      def addSamplerConfigurer(
+          configurer: AutoConfigure.Named[F, Sampler]
+      ): Builder[F] =
+        copy(samplerConfigurers = samplerConfigurers + configurer)
+
+      def addTextMapPropagatorConfigurer(
+          configurer: AutoConfigure.Named[F, TextMapPropagator[Context]]
+      ): Builder[F] =
+        copy(textMapPropagatorConfigurers =
+          textMapPropagatorConfigurers + configurer
+        )
+
+      def build: Resource[F, SdkTraces[F]] = {
+        def loadConfig: F[Config] =
+          for {
+            props <- propertiesLoader
+            config <- Config.load(props)
+          } yield propertiesCustomizers.foldLeft(config)((cfg, c) =>
+            cfg.withOverrides(c(cfg))
+          )
+
+        def loadNoop: Resource[F, SdkTraces[F]] =
+          Resource.eval(
+            for {
+              local <- LocalProvider[F, Context].local
+            } yield SdkTraces.noop[F](Async[F], local)
+          )
+
+        def loadTraces(
+            config: Config,
+            resource: TelemetryResource
+        ): Resource[F, SdkTraces[F]] = {
+          def makeLocalContext = LocalProvider[F, Context].local
+
+          Resource.eval(makeLocalContext).flatMap { implicit local =>
+            Resource.eval(Random.scalaUtilRandom).flatMap { implicit random =>
+              val propagatorsConfigure = ContextPropagatorsAutoConfigure[F](
+                textMapPropagatorConfigurers
+              )
+
+              propagatorsConfigure.configure(config).flatMap { propagators =>
+                val tracerProviderConfigure =
+                  TracerProviderAutoConfigure[F](
+                    resource,
+                    propagators,
+                    tracerProviderCustomizer,
+                    samplerConfigurers,
+                    exporterConfigurers
+                  )
+
+                for {
+                  tracerProvider <- tracerProviderConfigure.configure(config)
+                } yield new Impl[F](tracerProvider, propagators, local)
+              }
+            }
+          }
+        }
+
+        for {
+          config <- Resource.eval(customConfig.fold(loadConfig)(Async[F].pure))
+
+          resource <- TelemetryResourceAutoConfigure[F]
+            .configure(config)
+            .map(resourceCustomizer(_, config))
+
+          isDisabled <- Resource.eval(
+            Async[F].fromEither(
+              config.getOrElse(CommonConfigKeys.SdkDisabled, false)
+            )
+          )
+
+          traces <- if (isDisabled) loadNoop else loadTraces(config, resource)
+        } yield traces
+      }
+
+      private def merge[A](
+          first: Customizer[A],
+          second: Customizer[A]
+      ): Customizer[A] =
+        (a, config) => second(first(a, config), config)
+
+    }
+  }
+
+  private final class Impl[F[_]](
+      val tracerProvider: TracerProvider[F],
+      val propagators: ContextPropagators[Context],
+      val localContext: LocalContext[F]
+  ) extends SdkTraces[F] {
+    override def toString: String =
+      s"SdkTraces{tracerProvider=$tracerProvider, propagators=$propagators}"
+  }
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.Foldable
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.context.propagation.ContextPropagators
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.context.propagation.TextMapUpdater
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.context.propagation.W3CBaggagePropagator
+import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropagator
+import org.typelevel.otel4s.sdk.trace.data.LinkData
+import org.typelevel.otel4s.sdk.trace.data.SpanData
+import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
+import org.typelevel.otel4s.sdk.trace.samplers.Sampler
+import org.typelevel.otel4s.sdk.trace.samplers.SamplingResult
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.SpanKind
+import scodec.bits.ByteVector
+
+class SdkTracesSuite extends CatsEffectSuite {
+
+  private val DefaultTraces =
+    tracesToString(
+      TelemetryResource.empty,
+      Sampler.parentBased(Sampler.AlwaysOn)
+    )
+
+  private val NoopTraces =
+    "SdkTraces{tracerProvider=TracerProvider.Noop, propagators=ContextPropagators.Noop}"
+
+  test("withConfig - use the given config") {
+    val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
+
+    SdkTraces
+      .autoConfigured[IO](_.withConfig(config))
+      .use(traces => IO(assertEquals(traces.toString, DefaultTraces)))
+  }
+
+  test("load noop instance when 'otel.sdk.disabled=true'") {
+    val config = Config.ofProps(Map("otel.sdk.disabled" -> "true"))
+
+    SdkTraces
+      .autoConfigured[IO](_.withConfig(config))
+      .use(traces => IO(assertEquals(traces.toString, NoopTraces)))
+  }
+
+  test(
+    "withConfig - ignore 'addPropertiesCustomizer' and 'addPropertiesLoader'"
+  ) {
+    val config = Config.ofProps(Map("otel.sdk.disabled" -> "true"))
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "false"))
+          .addPropertiesLoader(IO.pure(Map("otel.sdk.disabled" -> "false")))
+      )
+      .use(traces => IO(assertEquals(traces.toString, NoopTraces)))
+  }
+
+  // the latter loader should prevail
+  test("addPropertiesLoader - use the loaded properties") {
+    SdkTraces
+      .autoConfigured[IO](
+        _.addPropertiesLoader(IO.pure(Map("otel.sdk.disabled" -> "false")))
+          .addPropertiesLoader(IO.delay(Map("otel.sdk.disabled" -> "true")))
+      )
+      .use(traces => IO(assertEquals(traces.toString, NoopTraces)))
+  }
+
+  // the latter customizer should prevail
+  test("addPropertiesCustomizer - customize properties") {
+    SdkTraces
+      .autoConfigured[IO](
+        _.addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "false"))
+          .addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "true"))
+      )
+      .use(traces => IO(assertEquals(traces.toString, NoopTraces)))
+  }
+
+  test("addTracerProviderCustomizer - customize tracer provider") {
+    val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
+
+    val sampler = Sampler.AlwaysOff
+    val resource = TelemetryResource.default
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addTracerProviderCustomizer((t, _) => t.withSampler(sampler))
+          .addTracerProviderCustomizer((t, _) => t.withResource(resource))
+      )
+      .use { traces =>
+        IO(assertEquals(traces.toString, tracesToString(resource, sampler)))
+      }
+  }
+
+  test("addResourceCustomizer - customize a resource") {
+    val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
+
+    val default = TelemetryResource.default
+    val withAttributes =
+      TelemetryResource(Attributes(Attribute("key", "value")))
+    val withSchema = TelemetryResource(Attributes.empty, Some("schema"))
+    val result = default.mergeUnsafe(withAttributes).mergeUnsafe(withSchema)
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(default))
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(withAttributes))
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(withSchema))
+      )
+      .use { traces =>
+        IO(
+          assertEquals(traces.toString, tracesToString(result))
+        )
+      }
+  }
+
+  test("addExporterConfigurer - support external configurers") {
+    val config = Config.ofProps(
+      Map("otel.traces.exporter" -> "custom-1,custom-2")
+    )
+
+    def customExporter(exporterName: String): SpanExporter[IO] =
+      new SpanExporter[IO] {
+        def name: String = exporterName
+        def exportSpans[G[_]: Foldable](spans: G[SpanData]): IO[Unit] = IO.unit
+        def flush: IO[Unit] = IO.unit
+      }
+
+    val exporter1: SpanExporter[IO] = customExporter("CustomExporter1")
+    val exporter2: SpanExporter[IO] = customExporter("CustomExporter2")
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addExporterConfigurer(
+            AutoConfigure.Named.const("custom-1", exporter1)
+          )
+          .addExporterConfigurer(
+            AutoConfigure.Named.const("custom-2", exporter2)
+          )
+      )
+      .use { traces =>
+        IO(
+          assertEquals(
+            traces.toString,
+            tracesToString(
+              exporter = "SpanExporter.Multi(CustomExporter1, CustomExporter2)"
+            )
+          )
+        )
+      }
+  }
+
+  test("addSamplerConfigurer - support external configurers") {
+    val config = Config.ofProps(
+      Map(
+        "otel.traces.exporter" -> "none",
+        "otel.traces.sampler" -> "custom-sampler",
+      )
+    )
+
+    val sampler: Sampler = new Sampler {
+      def shouldSample(
+          parentContext: Option[SpanContext],
+          traceId: ByteVector,
+          name: String,
+          spanKind: SpanKind,
+          attributes: Attributes,
+          parentLinks: Vector[LinkData]
+      ): SamplingResult =
+        SamplingResult.Drop
+
+      def description: String = "CustomSampler"
+    }
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config).addSamplerConfigurer(
+          AutoConfigure.Named.const("custom-sampler", sampler)
+        )
+      )
+      .use { traces =>
+        IO(assertEquals(traces.toString, tracesToString(sampler = sampler)))
+      }
+  }
+
+  test("addTextMapPropagatorConfigurer - support external configurers") {
+    val config = Config.ofProps(
+      Map(
+        "otel.traces.exporter" -> "none",
+        "otel.propagators" -> "tracecontext,custom-1,custom-2,baggage",
+      )
+    )
+
+    def customPropagator(name: String): TextMapPropagator[Context] =
+      new TextMapPropagator[Context] {
+        def fields: Iterable[String] = Nil
+        def extract[A: TextMapGetter](ctx: Context, carrier: A): Context = ???
+        def inject[A: TextMapUpdater](ctx: Context, carrier: A): A = ???
+        override def toString: String = name
+      }
+
+    val propagator1 = customPropagator("CustomPropagator1")
+    val propagator2 = customPropagator("CustomPropagator2")
+
+    val expected = ContextPropagators.of(
+      W3CTraceContextPropagator.default,
+      propagator1,
+      propagator2,
+      W3CBaggagePropagator.default
+    )
+
+    SdkTraces
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addTextMapPropagatorConfigurer(
+            AutoConfigure.Named.const("custom-1", propagator1)
+          )
+          .addTextMapPropagatorConfigurer(
+            AutoConfigure.Named.const("custom-2", propagator2)
+          )
+      )
+      .use { traces =>
+        IO(
+          assertEquals(traces.toString, tracesToString(propagators = expected))
+        )
+      }
+  }
+
+  private def tracesToString(
+      resource: TelemetryResource = TelemetryResource.empty,
+      sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      propagators: ContextPropagators[Context] = ContextPropagators.of(
+        W3CTraceContextPropagator.default,
+        W3CBaggagePropagator.default
+      ),
+      exporter: String = "SpanExporter.Noop"
+  ) =
+    "SdkTraces{tracerProvider=" +
+      s"SdkTracerProvider{resource=$resource, sampler=$sampler, " +
+      "spanProcessor=SpanProcessor.Multi(" +
+      s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
+      "SpanStorage)}, " +
+      s"propagators=$propagators}"
+
+}


### PR DESCRIPTION
`SdkTraces` provides a handy way to load the SDK tracing module:

```scala
SdkTraces.autoConfigured[IO]().use { traces =>
  val provider = traces.tracerProvider
  ...
}
```