### PR TITLE
Add transformName to Attribute

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
@@ -39,7 +39,8 @@ sealed trait AttributeKey[A] {
     *   an [[`AttributeKey`]] of the same type as this key, with name
     *   transformed by `f`
     */
-  def transformName(f: String => String): AttributeKey[A]
+  final def transformName(f: String => String): AttributeKey[A] =
+    new AttributeKey.Impl[A](f(name), `type`)
 }
 
 object AttributeKey {
@@ -59,9 +60,6 @@ object AttributeKey {
         case _ =>
           false
       }
-
-    override def transformName(f: String => String): AttributeKey[A] =
-      new Impl[A](f(name), `type`)
   }
 
   def string(name: String): AttributeKey[String] =

--- a/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
@@ -34,6 +34,12 @@ sealed trait AttributeKey[A] {
     *   an [[`Attribute`]] associating this key with the given value
     */
   final def apply(value: A): Attribute[A] = Attribute(this, value)
+
+  /** @return
+    *   an [[`AttributeKey`]] of the same type as this key, with name
+    *   transformed by `f`
+    */
+  def transformName(f: String => String): AttributeKey[A]
 }
 
 object AttributeKey {
@@ -53,6 +59,9 @@ object AttributeKey {
         case _ =>
           false
       }
+
+    override def transformName(f: String => String): AttributeKey[A] =
+      new Impl[A](f(name), `type`)
   }
 
   def string(name: String): AttributeKey[String] =


### PR DESCRIPTION
Use case: code that adds a prefix to all the names in a `Seq[Attribute[_]]`.  ``Attribute.apply(prefix + old.name, old.`type`)`` won't work, because there is no access to `KeySelect[A]`.