### PR TITLE
Use `.to(Attributes)` instead of `.fromSpecific`

### DIFF
--- a/core/common/src/test/scala/org/typelevel/otel4s/AttributesProps.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/AttributesProps.scala
@@ -29,7 +29,7 @@ class AttributesProps extends ScalaCheckSuite {
   property("Attributes#size is equal to the number of unique keys") {
     forAll(listOfAttributes) { attributes =>
       val keysSet = attributes.map(_.key).toSet
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
 
       keysSet.size == attrs.size
     }
@@ -38,7 +38,7 @@ class AttributesProps extends ScalaCheckSuite {
   property("Attributes#isEmpty is true when there are no attributes") {
     forAll(listOfAttributes) { attributes =>
       val keysSet = attributes.map(_.key).toSet
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
 
       keysSet.isEmpty == attrs.isEmpty
     }
@@ -47,7 +47,7 @@ class AttributesProps extends ScalaCheckSuite {
   property("Attributes#contains is true when the key is present") {
     forAll(listOfAttributes) { attributes =>
       val keysSet = attributes.map(_.key).toSet
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
 
       keysSet.forall(attrs.contains)
     }
@@ -55,7 +55,7 @@ class AttributesProps extends ScalaCheckSuite {
 
   property("Attributes#foreach iterates over all attributes") {
     forAll(listOfAttributes) { attributes =>
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
 
       var count = 0
       attrs.foreach(_ => count += 1)
@@ -66,7 +66,7 @@ class AttributesProps extends ScalaCheckSuite {
 
   property("Attributes#toList returns a list of all attributes") {
     forAll(listOfAttributes) { attributes =>
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
       val list = attrs.toList
 
       list.size == attrs.size && list.forall(a => attrs.contains(a.key))
@@ -75,7 +75,7 @@ class AttributesProps extends ScalaCheckSuite {
 
   property("Attributes#foldLeft folds over all attributes") {
     forAll(listOfAttributes) { attributes =>
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
       val list = attrs.toList
 
       val folded = attrs.foldLeft[Int](0) { (acc, _) => acc + 1 }
@@ -88,7 +88,7 @@ class AttributesProps extends ScalaCheckSuite {
     "Attributes#forall returns true when all attributes match the predicate"
   ) {
     forAll(listOfAttributes) { attributes =>
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
 
       attrs.forall(_ => true)
     }
@@ -96,7 +96,7 @@ class AttributesProps extends ScalaCheckSuite {
 
   property("Attributes#toMap returns a map of all attributes") {
     forAll(listOfAttributes) { attributes =>
-      val attrs = Attributes.fromSpecific(attributes)
+      val attrs = attributes.to(Attributes)
       val map = attrs.toMap
 
       map.size == attrs.size && map.forall { case (k, v) =>

--- a/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
@@ -64,7 +64,7 @@ trait Gens {
   val attributes: Gen[Attributes] =
     for {
       attributes <- Gen.listOf(attribute)
-    } yield Attributes.fromSpecific(attributes)
+    } yield attributes.to(Attributes)
 
 }
 

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Measurement.scala
@@ -54,7 +54,7 @@ object Measurement {
     *   the attributes to associate with the value
     */
   def apply[A](value: A, attributes: Attribute[_]*): Measurement[A] =
-    Impl(value, Attributes.fromSpecific(attributes))
+    Impl(value, attributes.to(Attributes))
 
   /** Creates a [[Measurement]] with the given `value` and `attributes`.
     *

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/ObservableMeasurement.scala
@@ -31,7 +31,7 @@ trait ObservableMeasurement[F[_], A] {
     *   the set of attributes to associate with the value
     */
   final def record(value: A, attributes: Attribute[_]*): F[Unit] =
-    record(value, Attributes.fromSpecific(attributes))
+    record(value, attributes.to(Attributes))
 
   /** Records a value with a set of attributes.
     *

--- a/oteljava/common-testkit/src/main/scala/org/typelevel/otel4s/oteljava/testkit/Conversions.scala
+++ b/oteljava/common-testkit/src/main/scala/org/typelevel/otel4s/oteljava/testkit/Conversions.scala
@@ -65,7 +65,7 @@ private[oteljava] object Conversions {
         Attribute(attribute.getKey, value.asScala.toList.map(_.doubleValue()))
     }
 
-    Attributes.fromSpecific(converted)
+    converted.to(Attributes)
   }
 
   def asyncFromCompletableResultCode[F[_]](

--- a/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporterSuite.scala
+++ b/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporterSuite.scala
@@ -215,7 +215,7 @@ class OtlpHttpSpanExporterSuite
       }
     }
 
-    Attributes.fromSpecific(adapted)
+    adapted.to(Attributes)
   }
 
   private def toJaegerTag(a: Attribute[_]): JaegerTag = {

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -103,7 +103,7 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
       attributes: immutable.Iterable[Attribute[_]]
   ): F[Unit] =
     addTimedEvent(
-      EventData(name, timestamp, Attributes.fromSpecific(attributes))
+      EventData(name, timestamp, attributes.to(Attributes))
     )
 
   def recordException(
@@ -116,7 +116,7 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
         EventData.fromException(
           now,
           exception,
-          Attributes.fromSpecific(attributes),
+          attributes.to(Attributes),
           escaped = false
         )
       )

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -75,9 +75,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console](
       spanContext: SpanContext,
       attributes: immutable.Iterable[Attribute[_]]
   ): SpanBuilder[F] =
-    copy(links =
-      links :+ LinkData(spanContext, Attributes.fromSpecific(attributes))
-    )
+    copy(links = links :+ LinkData(spanContext, attributes.to(Attributes)))
 
   def root: SpanBuilder[F] =
     copy(parent = Parent.Root)
@@ -141,7 +139,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console](
   private def start: F[Span.Backend[F]] = {
     val idGenerator = tracerSharedState.idGenerator
     val spanKind = kind.getOrElse(SpanKind.Internal)
-    val attrs = Attributes.fromSpecific(attributes)
+    val attrs = attributes.to(Attributes)
 
     def genTraceId(parent: Option[SpanContext]): F[ByteVector] =
       parent


### PR DESCRIPTION
As @NthPortal pointed out, `.to(Attributes)` is more idiomatic. 