### PR TITLE
Partially redesign `Attributes`

### DIFF
--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -213,7 +213,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   test(".getAttribute(:AttributeKey)") {
     PropF.forAllF { (init: Attributes, extraAttrs: Attributes) =>
       // 'init' and 'extra' may have attributes under the same key. we need only unique keys in extra
-      val extra = extraAttrs.filterNot(a => init.contains(a.key))
+      val extra = extraAttrs.filterNot(a => init.get(a.key).isDefined)
 
       for {
         span <- start(attributes = init)

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -213,7 +213,10 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   test(".getAttribute(:AttributeKey)") {
     PropF.forAllF { (init: Attributes, extraAttrs: Attributes) =>
       // 'init' and 'extra' may have attributes under the same key. we need only unique keys in extra
-      val extra = extraAttrs.filterNot(a => init.get(a.key).isDefined)
+      val extra = {
+        val initMap = init.toMap
+        extraAttrs.filterNot(a => initMap.contains(a.key.name))
+      }
 
       for {
         span <- start(attributes = init)


### PR DESCRIPTION
Disallow having multiple `Attribute`s with the same name, even if they are of different types.

Simplify `Attributes` by no longer having its API treat it like a map—rename `updated` to `added`, make `toMap` package private, and remove the following methods:
`contains`, `removed`, `-`, `removedAll`, `--`, `keys`

Fixes #513

Alternative (that I prefer) to #515