### PR TITLE
Move `KeySelect` to `AttributeKey`

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/Attribute.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/Attribute.scala
@@ -33,42 +33,8 @@ final case class Attribute[A](key: AttributeKey[A], value: A)
 
 object Attribute {
 
-  @annotation.implicitNotFound("""
-Could not find the `KeySelect` for ${A}. The `KeySelect` is defined for the following types:
-String, Boolean, Long, Double, List[String], List[Boolean], List[Long], List[Double].
-""")
-  sealed trait KeySelect[A] {
-    def make(name: String): AttributeKey[A]
-  }
-
-  object KeySelect {
-    def apply[A](implicit ev: KeySelect[A]): KeySelect[A] = ev
-
-    implicit val stringKey: KeySelect[String] = instance(AttributeKey.string)
-    implicit val booleanKey: KeySelect[Boolean] = instance(AttributeKey.boolean)
-    implicit val longKey: KeySelect[Long] = instance(AttributeKey.long)
-    implicit val doubleKey: KeySelect[Double] = instance(AttributeKey.double)
-
-    implicit val stringListKey: KeySelect[List[String]] =
-      instance(AttributeKey.stringList)
-
-    implicit val booleanListKey: KeySelect[List[Boolean]] =
-      instance(AttributeKey.booleanList)
-
-    implicit val longListKey: KeySelect[List[Long]] =
-      instance(AttributeKey.longList)
-
-    implicit val doubleListKey: KeySelect[List[Double]] =
-      instance(AttributeKey.doubleList)
-
-    private def instance[A](f: String => AttributeKey[A]): KeySelect[A] =
-      new KeySelect[A] {
-        def make(name: String): AttributeKey[A] = f(name)
-      }
-  }
-
-  def apply[A: KeySelect](name: String, value: A): Attribute[A] =
-    Attribute(KeySelect[A].make(name), value)
+  def apply[A: AttributeKey.KeySelect](name: String, value: A): Attribute[A] =
+    Attribute(AttributeKey.KeySelect[A].make(name), value)
 
   implicit val showAttribute: Show[Attribute[_]] = (a: Attribute[_]) =>
     s"${show"${a.key}"}=${a.value}"

--- a/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
@@ -62,6 +62,43 @@ object AttributeKey {
       }
   }
 
+  @annotation.implicitNotFound("""
+Could not find the `KeySelect` for ${A}. The `KeySelect` is defined for the following types:
+String, Boolean, Long, Double, List[String], List[Boolean], List[Long], List[Double].
+""")
+  sealed trait KeySelect[A] {
+    def make(name: String): AttributeKey[A]
+  }
+
+  object KeySelect {
+    def apply[A](implicit ev: KeySelect[A]): KeySelect[A] = ev
+
+    implicit val stringKey: KeySelect[String] = instance(AttributeKey.string)
+    implicit val booleanKey: KeySelect[Boolean] = instance(AttributeKey.boolean)
+    implicit val longKey: KeySelect[Long] = instance(AttributeKey.long)
+    implicit val doubleKey: KeySelect[Double] = instance(AttributeKey.double)
+
+    implicit val stringListKey: KeySelect[List[String]] =
+      instance(AttributeKey.stringList)
+
+    implicit val booleanListKey: KeySelect[List[Boolean]] =
+      instance(AttributeKey.booleanList)
+
+    implicit val longListKey: KeySelect[List[Long]] =
+      instance(AttributeKey.longList)
+
+    implicit val doubleListKey: KeySelect[List[Double]] =
+      instance(AttributeKey.doubleList)
+
+    private def instance[A](f: String => AttributeKey[A]): KeySelect[A] =
+      new KeySelect[A] {
+        def make(name: String): AttributeKey[A] = f(name)
+      }
+  }
+
+  def apply[A: KeySelect](name: String): AttributeKey[A] =
+    KeySelect[A].make(name)
+
   def string(name: String): AttributeKey[String] =
     new Impl(name, AttributeType.String)
 

--- a/core/common/src/main/scala/org/typelevel/otel4s/Attributes.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/Attributes.scala
@@ -20,7 +20,7 @@ import cats.Hash
 import cats.Monoid
 import cats.Show
 import cats.syntax.show._
-import org.typelevel.otel4s.Attribute.KeySelect
+import org.typelevel.otel4s.AttributeKey.KeySelect
 
 import scala.collection.IterableOps
 import scala.collection.SpecificIterableFactory

--- a/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
@@ -19,7 +19,6 @@ package scalacheck
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.typelevel.otel4s.Attribute.KeySelect
 
 trait Gens {
 
@@ -33,7 +32,7 @@ trait Gens {
     implicit def listArb[A: Arbitrary]: Arbitrary[List[A]] =
       Arbitrary(Gen.nonEmptyListOf(Arbitrary.arbitrary[A]))
 
-    def attribute[A: KeySelect: Arbitrary]: Gen[Attribute[A]] =
+    def attribute[A: AttributeKey.KeySelect: Arbitrary]: Gen[Attribute[A]] =
       for {
         key <- nonEmptyString
         value <- Arbitrary.arbitrary[A]

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
@@ -189,7 +189,7 @@ object Histogram {
         }
     }
 
-  private val CauseKey: AttributeKey[String] = AttributeKey.string("cause")
+  private val CauseKey: AttributeKey[String] = AttributeKey("cause")
 
   def causeAttributes(ec: Resource.ExitCase): List[Attribute[String]] =
     ec match {


### PR DESCRIPTION
### Motivation 

OpenTelemetry Java [encourages](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/common/AttributesBuilder.java#L44-L45) preallocating attribute keys and reusing them later.

For example:
```scala
class JobProcessor[F[_]]
object JobProcessor {
  object AttributeKeys {
    val ExecutionLatency: AttributeKey[Double] = AttributeKey("job.processor.execution.latency")
  }
}
```

1) `KeySelect` belongs more to the `AttributeKey` rather than `Attribute`
2) We can provide a generic `AttributeKey.apply`: `AttributeKey[Double]("key")` vs `AttributeKey.double("key")`
3) For most users, the migration should be seamless

WDYT?