### PR TITLE
OpenTelemetrySdk: rename `addExporterConfigurer` to `addSpanExporterConfigurer`

### DIFF
--- a/examples/src/main/scala/SdkTracingExample.scala
+++ b/examples/src/main/scala/SdkTracingExample.scala
@@ -45,7 +45,7 @@ object SdkTracingExample extends IOApp.Simple {
   def run: IO[Unit] =
     OpenTelemetrySdk
       .autoConfigured[IO](
-        _.addExporterConfigurer(
+        _.addSpanExporterConfigurer(
           OtlpSpanExporterAutoConfigure[IO]
         ) // register OTLP exporter configurer
       )

--- a/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
+++ b/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
@@ -72,7 +72,7 @@ object OpenTelemetrySdk {
     * import org.typelevel.otel4s.sdk.OpenTelemetrySdk
     * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
     *
-    * OpenTelemetrySdk.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
+    * OpenTelemetrySdk.autoConfigured[IO](_.addSpanExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
     *   }}}
     *
     * @param customize
@@ -183,13 +183,13 @@ object OpenTelemetrySdk {
         * import org.typelevel.otel4s.sdk.OpenTelemetrySdk
         * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
         *
-        * OpenTelemetrySdk.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
+        * OpenTelemetrySdk.autoConfigured[IO](_.addSpanExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
         *   }}}
         *
         * @param configurer
         *   the configurer to add
         */
-      def addExporterConfigurer(
+      def addSpanExporterConfigurer(
           configurer: AutoConfigure.Named[F, SpanExporter[F]]
       ): Builder[F]
 
@@ -229,7 +229,7 @@ object OpenTelemetrySdk {
         propertiesCustomizers = Nil,
         resourceCustomizer = (a, _) => a,
         tracerProviderCustomizer = (a: SdkTracerProvider.Builder[F], _) => a,
-        exporterConfigurers = Set.empty,
+        spanExporterConfigurers = Set.empty,
         samplerConfigurers = Set.empty,
         textMapPropagatorConfigurers = Set.empty
       )
@@ -242,7 +242,7 @@ object OpenTelemetrySdk {
         propertiesCustomizers: List[Config => Map[String, String]],
         resourceCustomizer: Customizer[TelemetryResource],
         tracerProviderCustomizer: Customizer[SdkTracerProvider.Builder[F]],
-        exporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]],
+        spanExporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]],
         samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
         textMapPropagatorConfigurers: Set[
           AutoConfigure.Named[F, TextMapPropagator[Context]]
@@ -274,10 +274,10 @@ object OpenTelemetrySdk {
           merge(this.tracerProviderCustomizer, customizer)
         )
 
-      def addExporterConfigurer(
+      def addSpanExporterConfigurer(
           configurer: AutoConfigure.Named[F, SpanExporter[F]]
       ): Builder[F] =
-        copy(exporterConfigurers = exporterConfigurers + configurer)
+        copy(spanExporterConfigurers = spanExporterConfigurers + configurer)
 
       def addSamplerConfigurer(
           configurer: AutoConfigure.Named[F, Sampler]
@@ -328,7 +328,7 @@ object OpenTelemetrySdk {
                   propagators,
                   tracerProviderCustomizer,
                   samplerConfigurers,
-                  exporterConfigurers
+                  spanExporterConfigurers
                 )
 
                 for {

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -165,10 +165,10 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
     OpenTelemetrySdk
       .autoConfigured[IO](
         _.withConfig(config)
-          .addExporterConfigurer(
+          .addSpanExporterConfigurer(
             AutoConfigure.Named.const("custom-1", exporter1)
           )
-          .addExporterConfigurer(
+          .addSpanExporterConfigurer(
             AutoConfigure.Named.const("custom-2", exporter2)
           )
       )

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
@@ -77,7 +77,7 @@ object SdkTraces {
     *   }}}
     *   and register the configurer manually:
     *   {{{
-    * import org.typelevel.otel4s.sdk.trace.Traces
+    * import org.typelevel.otel4s.sdk.trace.SdkTraces
     * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
     *
     * SdkTraces.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))
@@ -167,7 +167,7 @@ object SdkTraces {
         *   }}}
         *   and register the configurer manually:
         *   {{{
-        * import org.typelevel.otel4s.sdk.trace.Traces
+        * import org.typelevel.otel4s.sdk.trace.SdkTraces
         * import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
         *
         * SdkTraces.autoConfigured[IO](_.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO]))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
@@ -105,12 +105,21 @@ private final class SpanExportersAutoConfigure[F[_]: MonadThrow: Console](
         |
         |libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
         |
-        |and register the configurer:
+        |and register the configurer via OpenTelemetrySdk:
         |
         |import org.typelevel.otel4s.sdk.OpenTelemetrySdk
         |import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
         |
         |OpenTelemetrySdk.autoConfigured[IO](
+        |  _.addSpanExporterConfigurer(OtlpSpanExporterAutoConfigure[IO])
+        |)
+        |
+        |or via SdkTraces:
+        |
+        |import org.typelevel.otel4s.sdk.trace.SdkTraces
+        |import org.typelevel.otel4s.sdk.exporter.otlp.trace.autoconfigure.OtlpSpanExporterAutoConfigure
+        |
+        |SdkTraces.autoConfigured[IO](
         |  _.addExporterConfigurer(OtlpSpanExporterAutoConfigure[IO])
         |)
         |""".stripMargin


### PR DESCRIPTION
### Motivation 

Both metrics and tracing modules have separate exporters. We need to registered confiugrers for both of them.
To make things clear, it is better to distinguish names. 

So once the metrics module is ready, we will have:

```scala
trait Builder[F[_]] {
  def addSpanExporterConfigurer(configurer: AutoConfigure.Named[F, SpanExporter[F]]): Builder[F]
  def addMetricExporterConfigurer(configurer: AutoConfigure.Named[F, MetricExporter[F]]): Builder[F]
}
```