### PR TITLE
sdk: use `TelemetryResource.default` as an initial resource

### DIFF
--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -47,7 +47,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
 
   private val DefaultSdk =
     sdkToString(
-      TelemetryResource.empty,
+      TelemetryResource.default,
       Sampler.parentBased(Sampler.AlwaysOn)
     )
 
@@ -261,7 +261,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   }
 
   private def sdkToString(
-      resource: TelemetryResource = TelemetryResource.empty,
+      resource: TelemetryResource = TelemetryResource.default,
       sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,

--- a/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -64,6 +64,7 @@ private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
               ConfigurationError("Unable to decode resource attributes", e)
             }
         }
+        .map(_.to(Attributes))
 
     val attempt = for {
       disabledKeys <-
@@ -80,9 +81,10 @@ private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
         .flatten
         .map(value => ResourceAttributes.ServiceName(value))
 
-      TelemetryResource(
-        Attributes.fromSpecific(attributes ++ serviceName.toSeq)
-      )
+      val default = TelemetryResource.default
+      val fromEnv = TelemetryResource(attributes ++ serviceName)
+
+      default.mergeUnsafe(fromEnv)
     }
 
     Resource.eval(MonadThrow[F].fromEither(attempt))

--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
@@ -23,14 +23,14 @@ import munit.CatsEffectSuite
 
 class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
 
-  test("load from an empty config") {
+  test("load from an empty config - use default as a fallback") {
     val config = Config(Map.empty, Map.empty, Map.empty)
     TelemetryResourceAutoConfigure[IO].configure(config).use { resource =>
-      IO(assertEquals(resource, TelemetryResource.empty))
+      IO(assertEquals(resource, TelemetryResource.default))
     }
   }
 
-  test("load from the config") {
+  test("load from the config - use default as an initial resource") {
     val props = Map(
       "otel.service.name" -> "some-service",
       "otel.resource.attributes" -> "key1=val1,key2=val2,key3=val3",
@@ -44,8 +44,12 @@ class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
       Attribute("service.name", "some-service")
     )
 
+    val expected = TelemetryResource.default.mergeUnsafe(
+      TelemetryResource(expectedAttributes)
+    )
+
     TelemetryResourceAutoConfigure[IO].configure(config).use { resource =>
-      IO(assertEquals(resource, TelemetryResource(expectedAttributes)))
+      IO(assertEquals(resource, expected))
     }
   }
 }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -47,7 +47,7 @@ class SdkTracesSuite extends CatsEffectSuite {
 
   private val DefaultTraces =
     tracesToString(
-      TelemetryResource.empty,
+      TelemetryResource.default,
       Sampler.parentBased(Sampler.AlwaysOn)
     )
 
@@ -258,7 +258,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   }
 
   private def tracesToString(
-      resource: TelemetryResource = TelemetryResource.empty,
+      resource: TelemetryResource = TelemetryResource.default,
       sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,


### PR DESCRIPTION
### Motivation

We should use the default TelemetryResource as an initial one. Otherwise, mandatory build-time information (library version, etc) is missing.

OpenTelemetry Java has identical logic: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/ResourceConfiguration.java#L88.