### PR TITLE
sdk-metrics: add `AggregationTemporality`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s_2.13 otel4s_3 docs_2.13 docs_3 scalafix-output_2.13 scalafix-input_2.13 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 scalafix-tests_2.12
+          modules-ignore: otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s-sdk-metrics_native0.4_2.13 otel4s-sdk-metrics_native0.4_3 otel4s_2.13 otel4s_3 docs_2.13 docs_3 scalafix-output_2.13 scalafix-input_2.13 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 otel4s-sdk-metrics_2.13 otel4s-sdk-metrics_3 otel4s-sdk-metrics_sjs1_2.13 otel4s-sdk-metrics_sjs1_3 scalafix-tests_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val root = tlCrossRootProject
     `core-trace`,
     core,
     `sdk-common`,
+    `sdk-metrics`,
     `sdk-trace`,
     `sdk-trace-testkit`,
     sdk,
@@ -212,6 +213,23 @@ lazy val `sdk-common` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(munitDependencies)
   .settings(scalafixSettings)
 
+lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .enablePlugins(NoPublishPlugin)
+  .in(file("sdk/metrics"))
+  .dependsOn(`sdk-common`, `core-metrics`)
+  .settings(
+    name := "otel4s-sdk-metrics",
+    startYear := Some(2024),
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect" % CatsEffectVersion,
+      "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
+      "org.typelevel" %%% "discipline-munit" % MUnitDisciplineVersion % Test,
+    )
+  )
+  .settings(munitDependencies)
+  .settings(scalafixSettings)
+
 lazy val `sdk-trace` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("sdk/trace"))
@@ -250,6 +268,7 @@ lazy val sdk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(
     core,
     `sdk-common`,
+    `sdk-metrics`,
     `sdk-trace` % "compile->compile;test->test",
     `sdk-trace-testkit` % Test
   )
@@ -575,6 +594,7 @@ lazy val unidocs = project
       `core-trace`.jvm,
       core.jvm,
       `sdk-common`.jvm,
+      `sdk-metrics`.jvm,
       `sdk-trace`.jvm,
       `sdk-trace-testkit`.jvm,
       sdk.jvm,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/AggregationTemporality.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/AggregationTemporality.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Hash
+import cats.Show
+
+/** The time period over which the measurements are aggregated.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality]]
+  */
+sealed trait AggregationTemporality
+
+object AggregationTemporality {
+
+  /** Measurements are aggregated since the previous collection.
+    */
+  case object Delta extends AggregationTemporality
+
+  /** Measurements are aggregated over the lifetime of the instrument.
+    */
+  case object Cumulative extends AggregationTemporality
+
+  implicit val aggregationTemporalityHash: Hash[AggregationTemporality] =
+    Hash.fromUniversalHashCode
+
+  implicit val aggregationTemporalityShow: Show[AggregationTemporality] =
+    Show.fromToString
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/AggregationTemporalitySuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/AggregationTemporalitySuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk.metrics
+package data
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+
+class AggregationTemporalitySuite extends DisciplineSuite {
+
+  implicit val aggregationTemporalityArb: Arbitrary[AggregationTemporality] =
+    Arbitrary(
+      Gen.oneOf(AggregationTemporality.Delta, AggregationTemporality.Cumulative)
+    )
+
+  implicit val aggregationTemporalityCogen: Cogen[AggregationTemporality] =
+    Cogen[String].contramap(_.toString)
+
+  checkAll(
+    "AggregationTemporality.HashLaws",
+    HashTests[AggregationTemporality].hash
+  )
+
+  test("Show[AggregationTemporality]") {
+    Prop.forAll(aggregationTemporalityArb.arbitrary) { temporality =>
+      val expected = temporality match {
+        case AggregationTemporality.Delta      => "Delta"
+        case AggregationTemporality.Cumulative => "Cumulative"
+      }
+
+      assertEquals(Show[AggregationTemporality].show(temporality), expected)
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality |
| Java implementation | [AggregationTemporality.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/AggregationTemporality.java) |

Starting shaping `sdk-metrics` module. There is a working [prototype](https://github.com/iRevive/otel4s/pull/4/files).