### PR TITLE
Fix bug in `PassThroughPropagator`

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagator.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagator.scala
@@ -33,10 +33,10 @@ final class PassThroughPropagator[Ctx, K[X] <: Key[X]] private (
   def extract[A](ctx: Ctx, carrier: A)(implicit
       getter: TextMapGetter[A]
   ): Ctx = {
-    val list = fields.view
+    val entries = fields.view
       .flatMap(k => getter.get(carrier, k).map(k -> _))
       .toList
-    if (list.isEmpty) ctx else ctx.updated(entriesKey, list)
+    ctx.updated(entriesKey, entries)
   }
 
   def inject[A](ctx: Ctx, carrier: A)(implicit updater: TextMapUpdater[A]): A =

--- a/core/common/src/test/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagatorProps.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagatorProps.scala
@@ -62,4 +62,14 @@ class PassThroughPropagatorProps extends ScalaCheckSuite {
       assert(injected.isEmpty)
     }
   }
+
+  property("does not inject fields after extracting none") {
+    forAll { (entries: Map[String, String]) =>
+      val propagator = vaultPropagator(entries.keySet)
+      val extracted1 = propagator.extract(VaultContext.root, entries)
+      val extracted2 = propagator.extract(extracted1, Map.empty[String, String])
+      val injected = propagator.inject(extracted2, Map.empty[String, String])
+      assert(injected.isEmpty)
+    }
+  }
 }

--- a/core/common/src/test/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagatorSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/context/propagation/PassThroughPropagatorSuite.scala
@@ -36,4 +36,11 @@ class PassThroughPropagatorSuite extends FunSuite {
     val injected = propagator.inject(extracted, Map.empty[String, String])
     assert(injected.isEmpty)
   }
+
+  test("does not inject fields after extracting none") {
+    val extracted1 = propagator.extract(VaultContext.root, Map("foo" -> "0"))
+    val extracted2 = propagator.extract(extracted1, Map.empty[String, String])
+    val injected = propagator.inject(extracted2, Map.empty[String, String])
+    assert(injected.isEmpty)
+  }
 }


### PR DESCRIPTION
Fix incorrect/invalid optimisation in `PassThroughPropagator` in which extracting values and then extracting nothing still left the values that were extracted the first time.