### PR TITLE
remove `sdk-metrics` dependency from the `sdk`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,7 +268,6 @@ lazy val sdk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(
     core,
     `sdk-common`,
-    `sdk-metrics`,
     `sdk-trace` % "compile->compile;test->test",
     `sdk-trace-testkit` % Test
   )


### PR DESCRIPTION
`sdk` depends on the `sdk-metrics` and the `sdk-metrics` artifact is required.
But `sdk-metrics` will not be published soon. 

https://discord.com/channels/632277896739946517/1093154207328108634/1221385839435583499

