### PR TITLE
sdk-metrics: add `TimeWindow`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,7 @@ lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .enablePlugins(NoPublishPlugin)
   .in(file("sdk/metrics"))
-  .dependsOn(`sdk-common`, `core-metrics`)
+  .dependsOn(`sdk-common` % "compile->compile;test->test", `core-metrics`)
   .settings(
     name := "otel4s-sdk-metrics",
     startYear := Some(2024),

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindow.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindow.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Hash
+import cats.Show
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Represents a time window for data collection.
+  */
+sealed trait TimeWindow {
+
+  /** The start of the time window.
+    */
+  def start: FiniteDuration
+
+  /** The end of the time window. In most cases represents the sampling
+    * (collection) time.
+    */
+  def end: FiniteDuration
+
+  override final def hashCode(): Int =
+    Hash[TimeWindow].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: TimeWindow => Hash[TimeWindow].eqv(this, other)
+      case _                 => false
+    }
+
+  override final def toString: String =
+    Show[TimeWindow].show(this)
+}
+
+object TimeWindow {
+
+  /** Creates a [[TimeWindow]] with the given values.
+    *
+    * @param start
+    *   the start of the window
+    *
+    * @param end
+    *   the end of the window
+    */
+  def apply(start: FiniteDuration, end: FiniteDuration): TimeWindow = {
+    require(end >= start, "end must be greater than or equal to start")
+    Impl(start, end)
+  }
+
+  implicit val timeWindowHash: Hash[TimeWindow] =
+    Hash.by(w => (w.start, w.end))
+
+  implicit val timeWindowShow: Show[TimeWindow] =
+    Show.show(w => s"TimeWindow{start=${w.start}, end=${w.end}}")
+
+  private final case class Impl(
+      start: FiniteDuration,
+      end: FiniteDuration
+  ) extends TimeWindow
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindowSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindowSuite.scala
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s
-package sdk.metrics
-package data
+package org.typelevel.otel4s.sdk.metrics.data
 
 import cats.Show
 import cats.kernel.laws.discipline.HashTests
@@ -26,21 +24,25 @@ import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
 import org.typelevel.otel4s.sdk.metrics.scalacheck.Cogens._
 import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
 
-class AggregationTemporalitySuite extends DisciplineSuite {
+import scala.concurrent.duration._
 
-  checkAll(
-    "AggregationTemporality.HashLaws",
-    HashTests[AggregationTemporality].hash
-  )
+class TimeWindowSuite extends DisciplineSuite {
 
-  test("Show[AggregationTemporality]") {
-    Prop.forAll(Gens.aggregationTemporality) { temporality =>
-      val expected = temporality match {
-        case AggregationTemporality.Delta      => "Delta"
-        case AggregationTemporality.Cumulative => "Cumulative"
-      }
+  checkAll("TimeWindow.Hash", HashTests[TimeWindow].hash)
 
-      assertEquals(Show[AggregationTemporality].show(temporality), expected)
+  test("fail when start <= end") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: end must be greater than or equal to start"
+    )(
+      TimeWindow(2.nanos, 1.nanos)
+    )
+  }
+
+  test("Show[TimeWindow]") {
+    Prop.forAll(Gens.timeWindow) { window =>
+      val expected = s"TimeWindow{start=${window.start}, end=${window.end}}"
+
+      assertEquals(Show[TimeWindow].show(window), expected)
     }
   }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindowSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/TimeWindowSuite.scala
@@ -30,7 +30,7 @@ class TimeWindowSuite extends DisciplineSuite {
 
   checkAll("TimeWindow.Hash", HashTests[TimeWindow].hash)
 
-  test("fail when start <= end") {
+  test("fail when start > end") {
     interceptMessage[IllegalArgumentException](
       "requirement failed: end must be greater than or equal to start"
     )(

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.scalacheck
+
+import org.scalacheck.Arbitrary
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+
+trait Arbitraries extends org.typelevel.otel4s.sdk.scalacheck.Arbitraries {
+
+  implicit val aggregationTemporalityArb: Arbitrary[AggregationTemporality] =
+    Arbitrary(Gens.aggregationTemporality)
+
+  implicit val timeWindowArbitrary: Arbitrary[TimeWindow] =
+    Arbitrary(Gens.timeWindow)
+
+}
+
+object Arbitraries extends Arbitraries

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.scalacheck
+
+import org.scalacheck.Cogen
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+
+import scala.concurrent.duration.FiniteDuration
+
+trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
+
+  implicit val aggregationTemporalityCogen: Cogen[AggregationTemporality] =
+    Cogen[String].contramap(_.toString)
+
+  implicit val timeWindowCogen: Cogen[TimeWindow] =
+    Cogen[(FiniteDuration, FiniteDuration)].contramap(w => (w.start, w.end))
+
+}
+
+object Cogens extends Cogens

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.scalacheck
+
+import org.scalacheck.Gen
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+
+import scala.concurrent.duration._
+
+trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
+
+  val aggregationTemporality: Gen[AggregationTemporality] =
+    Gen.oneOf(AggregationTemporality.Delta, AggregationTemporality.Cumulative)
+
+  val timeWindow: Gen[TimeWindow] =
+    for {
+      start <- Gen.chooseNum(1L, Long.MaxValue - 5)
+      end <- Gen.chooseNum(start, Long.MaxValue)
+    } yield TimeWindow(start.nanos, end.nanos)
+
+}
+
+object Gens extends Gens


### PR DESCRIPTION
There is no direct equivalent in the OpenTelemetry Java. The `TimeWindow` will be actively used in the SDK module, for example in the [data points](https://github.com/iRevive/otel4s/pull/4/files#diff-d8444dbbfdcddec27a953cc4f7d2b5f88e5e8f8d7a81f85198dacab3acfd5ecf).