### PR TITLE
sdk-metrics: add `PointData`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/PointData.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/PointData.scala
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Hash
+import cats.Show
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.BucketBoundaries
+
+/** A point in the metric data model.
+  *
+  * A point represents the aggregation of measurements recorded with a
+  * particular set of [[Attributes]] over some time interval.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points]]
+  */
+sealed trait PointData {
+
+  /** A [[TimeWindow]] for which the point data was calculated.
+    */
+  def timeWindow: TimeWindow
+
+  /** An [[Attributes]] associated with the point data.
+    */
+  def attributes: Attributes
+
+  override final def hashCode(): Int =
+    Hash[PointData].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: PointData => Hash[PointData].eqv(this, other)
+      case _                => false
+    }
+
+  override final def toString: String =
+    Show[PointData].show(this)
+}
+
+object PointData {
+
+  /** The number point represents a single value.
+    *
+    * Can hold either Long or Double values.
+    *
+    * Used by Sum and Gauge metrics.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge]]
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums]]
+    */
+  sealed trait NumberPoint extends PointData {
+    type Exemplar <: ExemplarData
+    type Value
+
+    /** The [[ExemplarData]] associated with the point data.
+      */
+    def exemplars: Vector[Exemplar]
+
+    /** The measurement value.
+      */
+    def value: Value
+  }
+
+  sealed trait LongNumber extends NumberPoint {
+    type Exemplar = ExemplarData.LongExemplar
+    type Value = Long
+  }
+
+  sealed trait DoubleNumber extends NumberPoint {
+    type Exemplar = ExemplarData.DoubleExemplar
+    type Value = Double
+  }
+
+  /** A population of recorded measurements. A histogram bundles a set of events
+    * into divided populations with an overall event count and aggregate sum for
+    * all events.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram]]
+    */
+  sealed trait Histogram extends PointData {
+
+    /** The [[ExemplarData]] associated with the histogram data.
+      */
+    def exemplars: Vector[ExemplarData.DoubleExemplar]
+
+    /** The [[Histogram.Stats]] of the current measurement. `None` means the
+      * histogram is empty.
+      */
+    def stats: Option[Histogram.Stats]
+
+    /** The boundaries of this histogram.
+      */
+    def boundaries: BucketBoundaries
+
+    /** The numbers of observations that fell within each bucket.
+      */
+    def counts: Vector[Long]
+  }
+
+  object Histogram {
+
+    /** The aggregated stats of the histogram */
+    sealed trait Stats {
+
+      /** A sum of all values in the histogram. */
+      def sum: Double
+
+      /** The min of all values in the histogram. */
+      def min: Double
+
+      /** The max of all values in the histogram. */
+      def max: Double
+
+      /** The total population of points in the histogram. */
+      def count: Long
+
+      override final def hashCode(): Int =
+        Hash[Stats].hash(this)
+
+      override final def equals(obj: Any): Boolean =
+        obj match {
+          case other: Stats => Hash[Stats].eqv(this, other)
+          case _            => false
+        }
+
+      override final def toString: String =
+        Show[Stats].show(this)
+    }
+
+    object Stats {
+
+      /** Creates [[Stats]] with the given values.
+        */
+      def apply(sum: Double, min: Double, max: Double, count: Long): Stats =
+        Impl(sum, min, max, count)
+
+      implicit val statsHash: Hash[Stats] =
+        Hash.by(s => (s.sum, s.min, s.max, s.count))
+
+      implicit val statsShow: Show[Stats] =
+        Show.show { s =>
+          s"Stats{sum=${s.sum}, min=${s.min}, max=${s.max}, count=${s.count}}"
+        }
+
+      private final case class Impl(
+          sum: Double,
+          min: Double,
+          max: Double,
+          count: Long
+      ) extends Stats
+
+    }
+
+  }
+
+  /** Creates a [[LongNumber]] with the given values.
+    */
+  def longNumber(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.LongExemplar],
+      value: Long
+  ): LongNumber =
+    LongNumberImpl(timeWindow, attributes, exemplars, value)
+
+  /** Creates a [[DoubleNumber]] with the given values.
+    */
+  def doubleNumber(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.DoubleExemplar],
+      value: Double
+  ): DoubleNumber =
+    DoubleNumberImpl(timeWindow, attributes, exemplars, value)
+
+  /** Creates a [[Histogram]] with the given values.
+    */
+  def histogram(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.DoubleExemplar],
+      stats: Option[Histogram.Stats],
+      boundaries: BucketBoundaries,
+      counts: Vector[Long]
+  ): Histogram =
+    HistogramImpl(timeWindow, attributes, exemplars, stats, boundaries, counts)
+
+  implicit val pointDataHash: Hash[PointData] = {
+    val numberHash: Hash[NumberPoint] = {
+      // a value can be either Long or Double. The universal hashcode is safe
+      implicit val valueHash: Hash[NumberPoint#Value] =
+        Hash.fromUniversalHashCode
+
+      Hash.by { d =>
+        (
+          d.timeWindow,
+          d.attributes,
+          d.exemplars: Vector[ExemplarData],
+          d.value: NumberPoint#Value
+        )
+      }
+    }
+
+    val histogramHash: Hash[Histogram] =
+      Hash.by { h =>
+        (
+          h.timeWindow,
+          h.attributes,
+          h.exemplars: Vector[ExemplarData],
+          h.stats,
+          h.boundaries,
+          h.counts
+        )
+      }
+
+    new Hash[PointData] {
+      def hash(x: PointData): Int =
+        x match {
+          case point: NumberPoint   => numberHash.hash(point)
+          case histogram: Histogram => histogramHash.hash(histogram)
+        }
+
+      def eqv(x: PointData, y: PointData): Boolean =
+        (x, y) match {
+          case (left: NumberPoint, right: NumberPoint) =>
+            numberHash.eqv(left, right)
+          case (left: Histogram, right: Histogram) =>
+            histogramHash.eqv(left, right)
+          case _ =>
+            false
+        }
+    }
+  }
+
+  implicit val pointDataShow: Show[PointData] =
+    Show.show {
+      case data: NumberPoint =>
+        val prefix = data match {
+          case _: LongNumber   => "LongNumber"
+          case _: DoubleNumber => "DoubleNumber"
+        }
+
+        s"PointData.$prefix{" +
+          s"timeWindow=${data.timeWindow}, " +
+          s"attribute=${data.attributes}, " +
+          s"exemplars=${data.exemplars}, " +
+          s"value=${data.value}}"
+
+      case data: Histogram =>
+        "PointData.Histogram{" +
+          s"timeWindow=${data.timeWindow}, " +
+          s"attribute=${data.attributes}, " +
+          s"exemplars=${data.exemplars}, " +
+          s"stats=${data.stats}, " +
+          s"boundaries=${data.boundaries}, " +
+          s"counts=${data.counts}}"
+    }
+
+  private final case class LongNumberImpl(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.LongExemplar],
+      value: Long
+  ) extends LongNumber
+
+  private final case class DoubleNumberImpl(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.DoubleExemplar],
+      value: Double
+  ) extends DoubleNumber
+
+  private final case class HistogramImpl(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[ExemplarData.DoubleExemplar],
+      stats: Option[Histogram.Stats],
+      boundaries: BucketBoundaries,
+      counts: Vector[Long]
+  ) extends Histogram
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/PointDataSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/PointDataSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.typelevel.otel4s.sdk.metrics.data.PointData.DoubleNumber
+import org.typelevel.otel4s.sdk.metrics.data.PointData.LongNumber
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Cogens._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+class PointDataSuite extends DisciplineSuite {
+
+  checkAll("PointData.Hash", HashTests[PointData].hash)
+
+  test("Show[PointData]") {
+    Prop.forAll(Gens.pointData) { pointData =>
+      val expected = pointData match {
+        case data: PointData.NumberPoint =>
+          val prefix = data match {
+            case _: LongNumber   => "LongNumber"
+            case _: DoubleNumber => "DoubleNumber"
+          }
+
+          s"PointData.$prefix{" +
+            s"timeWindow=${data.timeWindow}, " +
+            s"attribute=${data.attributes}, " +
+            s"exemplars=${data.exemplars}, " +
+            s"value=${data.value}}"
+
+        case data: PointData.Histogram =>
+          "PointData.Histogram{" +
+            s"timeWindow=${data.timeWindow}, " +
+            s"attribute=${data.attributes}, " +
+            s"exemplars=${data.exemplars}, " +
+            s"stats=${data.stats}, " +
+            s"boundaries=${data.boundaries}, " +
+            s"counts=${data.counts}}"
+      }
+
+      assertEquals(Show[PointData].show(pointData), expected)
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
@@ -19,6 +19,7 @@ package org.typelevel.otel4s.sdk.metrics.scalacheck
 import org.scalacheck.Arbitrary
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
 
@@ -38,6 +39,9 @@ trait Arbitraries extends org.typelevel.otel4s.sdk.scalacheck.Arbitraries {
 
   implicit val exemplarDataArbitrary: Arbitrary[ExemplarData] =
     Arbitrary(Gens.exemplarData)
+
+  implicit val pointDataArbitrary: Arbitrary[PointData] =
+    Arbitrary(Gens.pointData)
 
 }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
@@ -20,8 +20,10 @@ package scalacheck
 import org.scalacheck.Cogen
 import org.typelevel.ci.CIString
 import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
 
@@ -34,6 +36,9 @@ trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
 
   implicit val aggregationTemporalityCogen: Cogen[AggregationTemporality] =
     Cogen[String].contramap(_.toString)
+
+  implicit val boundariesCogen: Cogen[BucketBoundaries] =
+    Cogen[Vector[Double]].contramap(_.boundaries)
 
   implicit val instrumentTypeCogen: Cogen[InstrumentType] =
     Cogen[String].contramap(_.toString)
@@ -65,6 +70,53 @@ trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
       (e.filteredAttributes, e.timestamp, e.traceContext, value)
     }
 
+  implicit val numberPointDataCogen: Cogen[PointData.NumberPoint] =
+    Cogen[(TimeWindow, Attributes, Vector[ExemplarData], Either[Long, Double])]
+      .contramap { p =>
+        val value = p match {
+          case long: PointData.LongNumber     => Left(long.value)
+          case double: PointData.DoubleNumber => Right(double.value)
+        }
+
+        (p.timeWindow, p.attributes, p.exemplars: Vector[ExemplarData], value)
+      }
+
+  implicit val histogramPointDataCogen: Cogen[PointData.Histogram] = {
+    implicit val statsCogen: Cogen[PointData.Histogram.Stats] =
+      Cogen[(Double, Double, Double, Long)].contramap { s =>
+        (s.sum, s.min, s.max, s.count)
+      }
+
+    Cogen[
+      (
+          TimeWindow,
+          Attributes,
+          Vector[ExemplarData],
+          Option[PointData.Histogram.Stats],
+          BucketBoundaries,
+          Vector[Long]
+      )
+    ].contramap { h =>
+      (
+        h.timeWindow,
+        h.attributes,
+        h.exemplars: Vector[ExemplarData],
+        h.stats,
+        h.boundaries,
+        h.counts
+      )
+    }
+  }
+
+  implicit val pointDataCogen: Cogen[PointData] =
+    Cogen { (seed, pointData) =>
+      pointData match {
+        case point: PointData.NumberPoint =>
+          numberPointDataCogen.perturb(seed, point)
+        case histogram: PointData.Histogram =>
+          histogramPointDataCogen.perturb(seed, histogram)
+      }
+    }
 }
 
 object Cogens extends Cogens

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -19,8 +19,10 @@ package scalacheck
 
 import org.scalacheck.Gen
 import org.typelevel.ci.CIString
+import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
 import scodec.bits.ByteVector
@@ -31,6 +33,12 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
 
   val aggregationTemporality: Gen[AggregationTemporality] =
     Gen.oneOf(AggregationTemporality.Delta, AggregationTemporality.Cumulative)
+
+  val bucketBoundaries: Gen[BucketBoundaries] =
+    for {
+      size <- Gen.choose(0, 20)
+      b <- Gen.containerOfN[Vector, Double](size, Gen.choose(-100.0, 100.0))
+    } yield BucketBoundaries(b.distinct.sorted)
 
   val ciString: Gen[CIString] =
     Gens.nonEmptyString.map(CIString(_))
@@ -100,6 +108,62 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
 
   val exemplarData: Gen[ExemplarData] =
     Gen.oneOf(longExemplarData, doubleExemplarData)
+
+  val longNumberPointData: Gen[PointData.LongNumber] =
+    for {
+      window <- Gens.timeWindow
+      attributes <- Gens.attributes
+      exemplars <- Gen.listOf(Gens.longExemplarData)
+      value <- Gen.long
+    } yield PointData.longNumber(window, attributes, exemplars.toVector, value)
+
+  val doubleNumberPointData: Gen[PointData.DoubleNumber] =
+    for {
+      window <- Gens.timeWindow
+      attributes <- Gens.attributes
+      exemplars <- Gen.listOf(Gens.doubleExemplarData)
+      value <- Gen.double
+    } yield PointData.doubleNumber(
+      window,
+      attributes,
+      exemplars.toVector,
+      value
+    )
+
+  val histogramPointData: Gen[PointData.Histogram] = {
+    val statsGen =
+      for {
+        sum <- Gen.double
+        min <- Gen.double
+        max <- Gen.double
+        count <- Gen.long
+      } yield PointData.Histogram.Stats(sum, min, max, count)
+
+    for {
+      window <- Gens.timeWindow
+      attributes <- Gens.attributes
+      exemplars <- Gen.listOf(Gens.doubleExemplarData)
+      stats <- Gen.option(statsGen)
+      boundaries <- Gens.bucketBoundaries
+      counts <- Gen.listOfN(
+        boundaries.length,
+        if (stats.isEmpty) Gen.const(0L) else Gen.choose(0L, Long.MaxValue)
+      )
+    } yield PointData.histogram(
+      window,
+      attributes,
+      exemplars.toVector,
+      stats,
+      boundaries,
+      counts.toVector
+    )
+  }
+
+  val pointDataNumber: Gen[PointData.NumberPoint] =
+    Gen.oneOf(longNumberPointData, doubleNumberPointData)
+
+  val pointData: Gen[PointData] =
+    Gen.oneOf(longNumberPointData, doubleNumberPointData, histogramPointData)
 
 }
 


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points |
| Java implementation | [PointData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/PointData.java) <br> [DoublePointData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DoublePointData.java) <br> [LongPointData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/LongPointData.java) <br> [HistogramPointData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramPointData.java) |

`PointData` will be used by the [Data](https://github.com/iRevive/otel4s/blob/3fc44a6a824fd068a52ef2958497ab24090d02c2/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/Data.scala).  `PointData` is generated by an aggregator, for example [ExplicitBucketHistogramAggregator.scala](https://github.com/iRevive/otel4s/blob/3fc44a6a824fd068a52ef2958497ab24090d02c2/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/aggregation/ExplicitBucketHistogramAggregator.scala#L109-L147).

There should also be `Summary` and `ExponentialHistogram`, but I decided to add them later because they aren't implemented in my prototype yet.
