### PR TITLE
sdk-metrics: add `InstrumentSelector`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/view/InstrumentSelector.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/view/InstrumentSelector.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package view
+
+import cats.Hash
+import cats.Show
+
+/** Instrument selection criteria for applying views registered via meter
+  * provider.
+  *
+  * The predicate is built by the logical conjunction of the present properties.
+  */
+sealed trait InstrumentSelector {
+
+  /** The required [[InstrumentType type]] of an instrument.
+    *
+    * `None` means all instruments match.
+    */
+  def instrumentType: Option[InstrumentType]
+
+  /** The required name of an instrument.
+    *
+    * Instrument name may contain the wildcard characters `*` and `?` with the
+    * following matching criteria:
+    *   - `*` - matches 0 or more instances of any character
+    *   - `?` - matches exactly one instance of any character
+    *
+    * `None` means all instruments match.
+    */
+  def instrumentName: Option[String]
+
+  /** The required unit of an instrument.
+    *
+    * `None` means all instruments match.
+    */
+  def instrumentUnit: Option[String]
+
+  /** The required name of a meter.
+    *
+    * `None` means all meters match.
+    */
+  def meterName: Option[String]
+
+  /** The required version of a meter.
+    *
+    * `None` means all meters match.
+    */
+  def meterVersion: Option[String]
+
+  /** The required schema URL of a meter.
+    *
+    * `None` means all meters match.
+    */
+  def meterSchemaUrl: Option[String]
+
+  override final def toString: String =
+    Show[InstrumentSelector].show(this)
+
+  override final def hashCode(): Int =
+    Hash[InstrumentSelector].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: InstrumentSelector =>
+        Hash[InstrumentSelector].eqv(this, other)
+      case _ =>
+        false
+    }
+}
+
+object InstrumentSelector {
+
+  /** A builder of an [[InstrumentSelector]].
+    */
+  sealed trait Builder {
+
+    /** Adds the given `tpe` as a predicate for an instrument.
+      *
+      * @param tpe
+      *   the instrument type to filter by
+      */
+    def withInstrumentType(tpe: InstrumentType): Builder
+
+    /** Adds the given `name` as a predicate for an instrument.
+      *
+      * Instrument name may contain the wildcard characters `*` and `?` with the
+      * following matching criteria:
+      *   - `*` - matches 0 or more instances of any character
+      *   - `?` - matches exactly one instance of any character
+      *
+      * @note
+      *   empty string is ignored
+      *
+      * @param name
+      *   the instrument name to filter by
+      */
+    def withInstrumentName(name: String): Builder
+
+    /** Adds the given `unit` as a predicate for an instrument.
+      *
+      * @note
+      *   empty string is ignored
+      *
+      * @param unit
+      *   the instrument type to filter by
+      */
+    def withInstrumentUnit(unit: String): Builder
+
+    /** Adds the given `name` as a predicate for a meter.
+      *
+      * @note
+      *   empty string is ignored
+      *
+      * @param name
+      *   the meter name to filter by
+      */
+    def withMeterName(name: String): Builder
+
+    /** Adds the given `version` as a predicate for a meter.
+      *
+      * @note
+      *   empty string is ignored
+      *
+      * @param version
+      *   the instrument type to filter by
+      */
+    def withMeterVersion(version: String): Builder
+
+    /** Adds the given `schemaUrl` as a predicate for a meter.
+      *
+      * @note
+      *   empty string is ignored
+      *
+      * @param schemaUrl
+      *   the instrument type to filter by
+      */
+    def withMeterSchemaUrl(schemaUrl: String): Builder
+
+    /** Creates an [[InstrumentSelector]] with the configuration of this
+      * builder.
+      */
+    def build: InstrumentSelector
+  }
+
+  /** Returns an empty [[Builder]] of an [[InstrumentSelector]].
+    */
+  def builder: Builder =
+    BuilderImpl()
+
+  implicit val instrumentSelectorHash: Hash[InstrumentSelector] =
+    Hash.by { selector =>
+      (
+        selector.instrumentType,
+        selector.instrumentName,
+        selector.instrumentUnit,
+        selector.meterName,
+        selector.meterVersion,
+        selector.meterSchemaUrl
+      )
+    }
+
+  implicit val instrumentSelectorShow: Show[InstrumentSelector] = {
+    Show.show { selector =>
+      def prop(focus: InstrumentSelector => Option[String], name: String) =
+        focus(selector).map(value => s"$name=$value")
+
+      Seq(
+        prop(_.instrumentType.map(_.toString), "instrumentType"),
+        prop(_.instrumentName, "instrumentName"),
+        prop(_.instrumentUnit, "instrumentUnit"),
+        prop(_.meterName, "meterName"),
+        prop(_.meterVersion, "meterVersion"),
+        prop(_.meterSchemaUrl, "meterSchemaUrl"),
+      ).collect { case Some(k) => k }.mkString("InstrumentSelector{", ", ", "}")
+    }
+  }
+
+  private final case class BuilderImpl(
+      instrumentType: Option[InstrumentType] = None,
+      instrumentName: Option[String] = None,
+      instrumentUnit: Option[String] = None,
+      meterName: Option[String] = None,
+      meterVersion: Option[String] = None,
+      meterSchemaUrl: Option[String] = None
+  ) extends Builder
+      with InstrumentSelector {
+
+    def withInstrumentType(tpe: InstrumentType): Builder =
+      copy(instrumentType = Some(tpe))
+
+    def withInstrumentName(name: String): Builder =
+      copy(instrumentName = keepNonEmpty(name))
+
+    def withInstrumentUnit(unit: String): Builder =
+      copy(instrumentUnit = keepNonEmpty(unit))
+
+    def withMeterName(name: String): Builder =
+      copy(meterName = keepNonEmpty(name))
+
+    def withMeterVersion(version: String): Builder =
+      copy(meterVersion = keepNonEmpty(version))
+
+    def withMeterSchemaUrl(schemaUrl: String): Builder =
+      copy(meterSchemaUrl = keepNonEmpty(schemaUrl))
+
+    def build: InstrumentSelector = {
+      require(
+        instrumentType.isDefined || instrumentName.isDefined ||
+          instrumentUnit.isDefined || meterName.isDefined ||
+          meterVersion.isDefined || meterSchemaUrl.isDefined,
+        "at least one criteria must be defined"
+      )
+
+      this
+    }
+
+    private def keepNonEmpty(value: String): Option[String] = {
+      val trimmed = value.trim
+      Option.when(trimmed.nonEmpty)(trimmed)
+    }
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.sdk.metrics.scalacheck
+package org.typelevel.otel4s.sdk.metrics
+package scalacheck
 
 import org.scalacheck.Arbitrary
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
@@ -22,14 +23,21 @@ import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
+import org.typelevel.otel4s.sdk.metrics.view.InstrumentSelector
 
 trait Arbitraries extends org.typelevel.otel4s.sdk.scalacheck.Arbitraries {
 
   implicit val aggregationTemporalityArb: Arbitrary[AggregationTemporality] =
     Arbitrary(Gens.aggregationTemporality)
 
+  implicit val instrumentTypeArbitrary: Arbitrary[InstrumentType] =
+    Arbitrary(Gens.instrumentType)
+
   implicit val instrumentDescriptorArbitrary: Arbitrary[InstrumentDescriptor] =
     Arbitrary(Gens.instrumentDescriptor)
+
+  implicit val instrumentSelectorArbitrary: Arbitrary[InstrumentSelector] =
+    Arbitrary(Gens.instrumentSelector)
 
   implicit val timeWindowArbitrary: Arbitrary[TimeWindow] =
     Arbitrary(Gens.timeWindow)

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
@@ -26,6 +26,7 @@ import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
+import org.typelevel.otel4s.sdk.metrics.view.InstrumentSelector
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -46,6 +47,27 @@ trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
   implicit val instrumentDescriptorCogen: Cogen[InstrumentDescriptor] =
     Cogen[(CIString, Option[String], Option[String], InstrumentType)]
       .contramap(d => (d.name, d.description, d.unit, d.instrumentType))
+
+  implicit val instrumentSelectorCogen: Cogen[InstrumentSelector] =
+    Cogen[
+      (
+          Option[InstrumentType],
+          Option[String],
+          Option[String],
+          Option[String],
+          Option[String],
+          Option[String]
+      )
+    ].contramap { selector =>
+      (
+        selector.instrumentType,
+        selector.instrumentName,
+        selector.instrumentUnit,
+        selector.meterName,
+        selector.meterVersion,
+        selector.meterSchemaUrl
+      )
+    }
 
   implicit val timeWindowCogen: Cogen[TimeWindow] =
     Cogen[(FiniteDuration, FiniteDuration)].contramap(w => (w.start, w.end))

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/view/InstrumentSelectorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/view/InstrumentSelectorSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package view
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Cogens._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+class InstrumentSelectorSuite extends DisciplineSuite {
+
+  checkAll("InstrumentSelector.HashLaws", HashTests[InstrumentSelector].hash)
+
+  test("Show[InstrumentSelector]") {
+    Prop.forAll(Gens.instrumentSelector) { selector =>
+      def prop(name: String, focus: InstrumentSelector => Option[String]) =
+        focus(selector).map(v => s"$name=$v")
+
+      val params = Seq(
+        prop("instrumentType", _.instrumentType.map(_.toString)),
+        prop("instrumentName", _.instrumentName),
+        prop("instrumentUnit", _.instrumentUnit),
+        prop("meterName", _.meterName),
+        prop("meterVersion", _.meterVersion),
+        prop("meterSchemaUrl", _.meterSchemaUrl)
+      ).collect { case Some(v) => v }
+
+      val expected = params.mkString("InstrumentSelector{", ", ", "}")
+
+      assertEquals(Show[InstrumentSelector].show(selector), expected)
+    }
+  }
+
+  test("fail when none of the criteria is defined") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: at least one criteria must be defined"
+    )(
+      InstrumentSelector.builder.build
+    )
+  }
+
+  test("ignore empty strings") {
+    val selector = InstrumentSelector.builder
+      .withInstrumentType(InstrumentType.Counter)
+      .withInstrumentName("")
+      .withInstrumentUnit("     ")
+      .withMeterName(" ")
+      .withMeterVersion("   ")
+      .withMeterSchemaUrl("")
+      .build
+
+    assertEquals(selector.instrumentType, Some(InstrumentType.Counter))
+    assert(selector.instrumentName.isEmpty)
+    assert(selector.instrumentUnit.isEmpty)
+    assert(selector.meterName.isEmpty)
+    assert(selector.meterVersion.isEmpty)
+    assert(selector.meterSchemaUrl.isEmpty)
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Java implementation | [InstrumentSelector.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/InstrumentSelector.java) |

`InstrumentSelector` is public. A user can utilize it to configure a view for a matching instrument. A view allows customizing aggregation strategy, the name of the instrument, etc.
