### PR TITLE
sdk-metrics: add `MetricPoints`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPoints.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPoints.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Hash
+import cats.Show
+
+/** A collection of metric data points.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points]]
+  */
+sealed trait MetricPoints {
+
+  /** The collection of the metric [[PointData]]s.
+    */
+  def points: Vector[PointData]
+
+  override final def hashCode(): Int =
+    Hash[MetricPoints].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: MetricPoints => Hash[MetricPoints].eqv(this, other)
+      case _                   => false
+    }
+
+  override final def toString: String =
+    Show[MetricPoints].show(this)
+}
+
+object MetricPoints {
+
+  /** Sum represents the type of a numeric double scalar metric that is
+    * calculated as a sum of all reported measurements over a time interval.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums]]
+    */
+  sealed trait Sum extends MetricPoints {
+    type Point <: PointData.NumberPoint
+
+    def points: Vector[Point]
+
+    /** Whether the points are monotonic. If true, it means the data points are
+      * nominally increasing.
+      */
+    def monotonic: Boolean
+
+    /** The aggregation temporality of this aggregation.
+      */
+    def aggregationTemporality: AggregationTemporality
+  }
+
+  /** Gauge represents a sampled value at a given type.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge]]
+    */
+  sealed trait Gauge extends MetricPoints {
+    type Point <: PointData.NumberPoint
+
+    def points: Vector[Point]
+  }
+
+  /** Histogram represents the type of a metric that is calculated by
+    * aggregating as a histogram of all reported double measurements over a time
+    * interval.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram]]
+    */
+  sealed trait Histogram extends MetricPoints {
+    def points: Vector[PointData.Histogram]
+
+    /** The aggregation temporality of this aggregation.
+      */
+    def aggregationTemporality: AggregationTemporality
+  }
+
+  /** Creates a [[Sum]] with the given values.
+    */
+  def sum[A <: PointData.NumberPoint](
+      points: Vector[A],
+      monotonic: Boolean,
+      aggregationTemporality: AggregationTemporality
+  ): Sum =
+    SumImpl(points, monotonic, aggregationTemporality)
+
+  /** Creates a [[Gauge]] with the given values.
+    */
+  def gauge[A <: PointData.NumberPoint](
+      points: Vector[A]
+  ): Gauge =
+    GaugeImpl(points)
+
+  /** Creates a [[Histogram]] with the given values.
+    */
+  def histogram(
+      points: Vector[PointData.Histogram],
+      aggregationTemporality: AggregationTemporality
+  ): Histogram =
+    HistogramImpl(points, aggregationTemporality)
+
+  implicit val metricPointsHash: Hash[MetricPoints] = {
+    val sumHash: Hash[Sum] =
+      Hash.by { s =>
+        (s.points: Vector[PointData], s.monotonic, s.aggregationTemporality)
+      }
+
+    val gaugeHash: Hash[Gauge] =
+      Hash.by(_.points: Vector[PointData])
+
+    val histogramHash: Hash[Histogram] =
+      Hash.by(h => (h.points: Vector[PointData], h.aggregationTemporality))
+
+    new Hash[MetricPoints] {
+      def hash(x: MetricPoints): Int =
+        x match {
+          case sum: Sum             => sumHash.hash(sum)
+          case gauge: Gauge         => gaugeHash.hash(gauge)
+          case histogram: Histogram => histogramHash.hash(histogram)
+        }
+
+      def eqv(x: MetricPoints, y: MetricPoints): Boolean =
+        (x, y) match {
+          case (left: Sum, right: Sum) =>
+            sumHash.eqv(left, right)
+          case (left: Gauge, right: Gauge) =>
+            gaugeHash.eqv(left, right)
+          case (left: Histogram, right: Histogram) =>
+            histogramHash.eqv(left, right)
+          case _ =>
+            false
+        }
+    }
+  }
+
+  implicit val metricPointsShow: Show[MetricPoints] = {
+    Show.show {
+      case sum: Sum =>
+        "MetricPoints.Sum{" +
+          s"points=${sum.points.mkString("{", ",", "}")}, " +
+          s"monotonic=${sum.monotonic}, " +
+          s"aggregationTemporality=${sum.aggregationTemporality}}"
+
+      case gauge: Gauge =>
+        s"MetricPoints.Gauge{points=${gauge.points.mkString("{", ",", "}")}}"
+
+      case h: Histogram =>
+        s"MetricPoints.Histogram{points=${h.points.mkString("{", ",", "}")}, aggregationTemporality=${h.aggregationTemporality}}"
+    }
+  }
+
+  private final case class SumImpl[A <: PointData.NumberPoint](
+      points: Vector[A],
+      monotonic: Boolean,
+      aggregationTemporality: AggregationTemporality
+  ) extends Sum { type Point = A }
+
+  private final case class GaugeImpl[A <: PointData.NumberPoint](
+      points: Vector[A]
+  ) extends Gauge { type Point = A }
+
+  private final case class HistogramImpl(
+      points: Vector[PointData.Histogram],
+      aggregationTemporality: AggregationTemporality
+  ) extends Histogram
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPointsSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPointsSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Cogens._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+class MetricPointsSuite extends DisciplineSuite {
+
+  checkAll("MetricPoints.Hash", HashTests[MetricPoints].hash)
+
+  test("Show[MetricPoints]") {
+    Prop.forAll(Gens.metricPoints) { data =>
+      val expected = data match {
+        case sum: MetricPoints.Sum =>
+          "MetricPoints.Sum{" +
+            s"points=${sum.points.mkString("{", ",", "}")}, " +
+            s"monotonic=${sum.monotonic}, " +
+            s"aggregationTemporality=${sum.aggregationTemporality}}"
+
+        case gauge: MetricPoints.Gauge =>
+          s"MetricPoints.Gauge{points=${gauge.points.mkString("{", ",", "}")}}"
+
+        case histogram: MetricPoints.Histogram =>
+          "MetricPoints.Histogram{" +
+            s"points=${histogram.points.mkString("{", ",", "}")}, " +
+            s"aggregationTemporality=${histogram.aggregationTemporality}}"
+      }
+
+      assertEquals(Show[MetricPoints].show(data), expected)
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
@@ -20,6 +20,7 @@ package scalacheck
 import org.scalacheck.Arbitrary
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
@@ -50,6 +51,9 @@ trait Arbitraries extends org.typelevel.otel4s.sdk.scalacheck.Arbitraries {
 
   implicit val pointDataArbitrary: Arbitrary[PointData] =
     Arbitrary(Gens.pointData)
+
+  implicit val metricPointsArbitrary: Arbitrary[MetricPoints] =
+    Arbitrary(Gens.metricPoints)
 
 }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -22,6 +22,7 @@ import org.typelevel.ci.CIString
 import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
@@ -197,6 +198,33 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
 
   val pointData: Gen[PointData] =
     Gen.oneOf(longNumberPointData, doubleNumberPointData, histogramPointData)
+
+  val sumMetricPoints: Gen[MetricPoints.Sum] =
+    for {
+      points <- Gen.oneOf(
+        Gen.listOf(longNumberPointData),
+        Gen.listOf(doubleNumberPointData)
+      )
+      isMonotonic <- Gen.oneOf(true, false)
+      temporality <- Gens.aggregationTemporality
+    } yield MetricPoints.sum(points.toVector, isMonotonic, temporality)
+
+  val gaugeMetricPoints: Gen[MetricPoints.Gauge] =
+    for {
+      points <- Gen.oneOf(
+        Gen.listOf(longNumberPointData),
+        Gen.listOf(doubleNumberPointData)
+      )
+    } yield MetricPoints.gauge(points.toVector)
+
+  val histogramMetricPoints: Gen[MetricPoints.Histogram] =
+    for {
+      points <- Gen.listOf(histogramPointData)
+      temporality <- Gens.aggregationTemporality
+    } yield MetricPoints.histogram(points.toVector, temporality)
+
+  val metricPoints: Gen[MetricPoints] =
+    Gen.oneOf(sumMetricPoints, gaugeMetricPoints, histogramMetricPoints)
 
 }
 


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Java implementation | [Data.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/Data.java) <br> [SumData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/SumData.java) <br> [GaugeData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/GaugeData.java) <br> [HistogramData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/HistogramData.java) |


