### PR TITLE
sdk-metrics: add `Aggregation`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/Aggregation.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/Aggregation.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Hash
+import cats.Show
+import cats.syntax.show._
+import org.typelevel.otel4s.metrics.BucketBoundaries
+
+/** The aggregation strategy for measurements.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation]]
+  *
+  * @param supportedInstruments
+  *   the set of supported instruments
+  */
+sealed abstract class Aggregation(
+    supportedInstruments: Set[InstrumentType]
+) {
+  def compatibleWith(tpe: InstrumentType): Boolean =
+    supportedInstruments.contains(tpe)
+
+  override final def toString: String =
+    Show[Aggregation].show(this)
+}
+
+object Aggregation {
+
+  private object Defaults {
+    // See https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation
+    val Boundaries: BucketBoundaries = BucketBoundaries(
+      Vector(
+        0d, 5d, 10d, 25d, 50d, 75d, 100d, 250d, 500d, 750d, 1000d, 2500d, 5000d,
+        7500d, 10000d
+      )
+    )
+  }
+
+  /** Drops all measurements and doesn't export any metric.
+    */
+  def drop: Aggregation = Drop
+
+  /** Chooses an aggregator based on the [[InstrumentType]]:
+    *   - counter - [[sum]]
+    *   - up down counter - [[sum]]
+    *   - observable counter - [[sum]]
+    *   - observable up down counter - [[sum]]
+    *   - histogram - `explicitBucketHistogram`
+    *   - observable gauge - [[lastValue]]
+    */
+  def default: Aggregation = Default
+
+  /** Aggregates measurements into
+    * [[org.typelevel.otel4s.sdk.metrics.data.MetricPoints.Sum MetricPoints.Sum]].
+    *
+    * Compatible instruments:
+    *   - [[org.typelevel.otel4s.metrics.Counter Counter]]
+    *   - [[org.typelevel.otel4s.metrics.UpDownCounter UpDownCounter]]
+    *   - [[org.typelevel.otel4s.metrics.Histogram Histogram]]
+    *   - [[org.typelevel.otel4s.metrics.ObservableGauge ObservableGauge]]
+    *   - [[org.typelevel.otel4s.metrics.ObservableCounter ObservableCounter]]
+    */
+  def sum: Aggregation = Sum
+
+  /** Aggregates measurements into
+    * [[org.typelevel.otel4s.sdk.metrics.data.MetricPoints.Gauge MetricPoints.Gauge]]
+    * using the last seen measurement.
+    *
+    * Compatible instruments:
+    *   - [[org.typelevel.otel4s.metrics.ObservableGauge ObservableGauge]]
+    */
+  def lastValue: Aggregation = LastValue
+
+  /** Aggregates measurements into an explicit bucket
+    * [[org.typelevel.otel4s.sdk.metrics.data.MetricPoints.Histogram MetricPoints.Histogram]]
+    * using the default bucket boundaries.
+    *
+    * Compatible instruments:
+    *   - [[org.typelevel.otel4s.metrics.Counter Counter]]
+    *   - [[org.typelevel.otel4s.metrics.Histogram Histogram]]
+    */
+  def explicitBucketHistogram: Aggregation =
+    ExplicitBucketHistogram(Defaults.Boundaries)
+
+  /** Aggregates measurements into an explicit bucket
+    * [[org.typelevel.otel4s.sdk.metrics.data.MetricPoints.Histogram MetricPoints.Histogram]]
+    * using the given bucket boundaries.
+    *
+    * Compatible instruments:
+    *   - [[org.typelevel.otel4s.metrics.Counter Counter]]
+    *   - [[org.typelevel.otel4s.metrics.Histogram Histogram]]
+    *
+    * @param boundaries
+    *   the boundaries to use
+    */
+  def explicitBucketHistogram(boundaries: BucketBoundaries): Aggregation =
+    ExplicitBucketHistogram(boundaries)
+
+  implicit val aggregationHash: Hash[Aggregation] =
+    Hash.fromUniversalHashCode
+
+  implicit val aggregationShow: Show[Aggregation] =
+    Show.show {
+      case Drop      => "Aggregation.Drop"
+      case Default   => "Aggregation.Default"
+      case Sum       => "Aggregation.Sum"
+      case LastValue => "Aggregation.LastValue"
+      case ExplicitBucketHistogram(boundaries) =>
+        show"Aggregation.ExplicitBucketHistogram{boundaries=$boundaries}"
+    }
+
+  private[metrics] sealed trait Synchronous { self: Aggregation => }
+  private[metrics] sealed trait Asynchronous { self: Aggregation => }
+
+  private[metrics] case object Drop extends Aggregation(Compatability.Drop)
+
+  private[metrics] case object Default
+      extends Aggregation(Compatability.Default)
+      with Synchronous
+      with Asynchronous
+
+  private[metrics] case object Sum
+      extends Aggregation(Compatability.Sum)
+      with Synchronous
+      with Asynchronous
+
+  private[metrics] case object LastValue
+      extends Aggregation(Compatability.LastValue)
+      with Synchronous
+      with Asynchronous
+
+  private[metrics] final case class ExplicitBucketHistogram(
+      boundaries: BucketBoundaries
+  ) extends Aggregation(Compatability.ExplicitBucketHistogram)
+      with Synchronous
+
+  private object Compatability {
+    val Drop: Set[InstrumentType] =
+      InstrumentType.values
+
+    val Default: Set[InstrumentType] =
+      InstrumentType.values
+
+    val Sum: Set[InstrumentType] = Set(
+      InstrumentType.Counter,
+      InstrumentType.UpDownCounter,
+      InstrumentType.ObservableGauge,
+      InstrumentType.ObservableUpDownCounter,
+      InstrumentType.Histogram
+    )
+
+    val LastValue: Set[InstrumentType] =
+      Set(InstrumentType.ObservableGauge)
+
+    val ExplicitBucketHistogram: Set[InstrumentType] =
+      Set(InstrumentType.Counter, InstrumentType.Histogram)
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/AggregationSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/AggregationSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+class AggregationSuite extends DisciplineSuite {
+
+  private implicit val aggregationArbitrary: Arbitrary[Aggregation] =
+    Arbitrary(
+      Gen.oneOf(
+        Gen.const(Aggregation.drop),
+        Gen.const(Aggregation.sum),
+        Gen.const(Aggregation.lastValue),
+        Gen.const(Aggregation.explicitBucketHistogram),
+        Gens.bucketBoundaries.map(Aggregation.explicitBucketHistogram)
+      )
+    )
+
+  private implicit val aggregationCogen: Cogen[Aggregation] =
+    Cogen[String].contramap(_.toString)
+
+  checkAll("Aggregation.HashLaws", HashTests[Aggregation].hash)
+
+  test("Show[Aggregation]") {
+    Prop.forAll(aggregationArbitrary.arbitrary) { aggregation =>
+      val expected = aggregation match {
+        case Aggregation.Drop      => "Aggregation.Drop"
+        case Aggregation.Default   => "Aggregation.Default"
+        case Aggregation.Sum       => "Aggregation.Sum"
+        case Aggregation.LastValue => "Aggregation.LastValue"
+        case Aggregation.ExplicitBucketHistogram(boundaries) =>
+          s"Aggregation.ExplicitBucketHistogram{boundaries=$boundaries}"
+      }
+
+      assertEquals(Show[Aggregation].show(aggregation), expected)
+      assertEquals(aggregation.toString, expected)
+    }
+  }
+
+  test("compatible with") {
+    Prop.forAll(aggregationArbitrary.arbitrary) {
+      case drop @ Aggregation.Drop =>
+        InstrumentType.values.foreach { tpe =>
+          assert(drop.compatibleWith(tpe))
+        }
+
+      case default @ Aggregation.Default =>
+        InstrumentType.values.foreach { tpe =>
+          assert(default.compatibleWith(tpe))
+        }
+
+      case sum @ Aggregation.Sum =>
+        val compatible: Set[InstrumentType] = Set(
+          InstrumentType.Counter,
+          InstrumentType.UpDownCounter,
+          InstrumentType.ObservableGauge,
+          InstrumentType.ObservableUpDownCounter,
+          InstrumentType.Histogram
+        )
+
+        compatible.foreach(tpe => assert(sum.compatibleWith(tpe)))
+
+        InstrumentType.values.filterNot(compatible).foreach { tpe =>
+          assert(!sum.compatibleWith(tpe))
+        }
+
+      case lastValue @ Aggregation.LastValue =>
+        val compatible: Set[InstrumentType] = Set(
+          InstrumentType.ObservableGauge
+        )
+
+        compatible.foreach(tpe => assert(lastValue.compatibleWith(tpe)))
+
+        InstrumentType.values.filterNot(compatible).foreach { tpe =>
+          assert(!lastValue.compatibleWith(tpe))
+        }
+
+      case bucket @ Aggregation.ExplicitBucketHistogram(_) =>
+        val compatible: Set[InstrumentType] = Set(
+          InstrumentType.Counter,
+          InstrumentType.Histogram
+        )
+
+        compatible.foreach(tpe => assert(bucket.compatibleWith(tpe)))
+
+        InstrumentType.values.filterNot(compatible).foreach { tpe =>
+          assert(!bucket.compatibleWith(tpe))
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation |
| Java implementation | [Aggregation.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/Aggregation.java) |

Unlike otel-java, we will split `Aggregation` and [Aggregator](https://github.com/iRevive/otel4s/blob/e5c1d041f4a7b025ee264c2358996f9e3a6031b1/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala). In other words, `Aggregation` defines only the aggregation strategy, and that's it. 

P.S. `Base2ExponentialBucketHistogram` is missing because I haven't implemented an aggregator for this strategy yet. I will add it later. 