### PR TITLE
sdk-metrics: add `MetricData`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricData.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricData.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Hash
+import cats.Show
+import cats.syntax.foldable._
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+
+/** Representation of the aggregated measurements of an instrument.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/data-model/#timeseries-model]]
+  */
+sealed trait MetricData {
+
+  /** The name of the metric.
+    *
+    * The name is typically the instrument name, but may be optionally
+    * overridden by a view.
+    */
+  def name: String
+
+  /** The description of the metric.
+    *
+    * The metric name is typically the instrument description, but may be
+    * optionally overridden by a view.
+    */
+  def description: Option[String]
+
+  /** The unit of the metric.
+    */
+  def unit: Option[String]
+
+  /** The datapoints (measurements) of the metric.
+    */
+  def data: MetricPoints
+
+  /** The instrumentation scope associated with the measurements.
+    */
+  def instrumentationScope: InstrumentationScope
+
+  /** The resource associated with the measurements.
+    */
+  def resource: TelemetryResource
+
+  /** Whether the measurements are empty.
+    */
+  final def isEmpty: Boolean = data.points.isEmpty
+
+  /** Whether the measurements are non empty.
+    */
+  final def nonEmpty: Boolean = !isEmpty
+
+  override final def hashCode(): Int =
+    Hash[MetricData].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: MetricData => Hash[MetricData].eqv(this, other)
+      case _                 => false
+    }
+
+  override final def toString: String =
+    Show[MetricData].show(this)
+}
+
+object MetricData {
+
+  /** Creates a new [[MetricData]] with the given values.
+    */
+  def apply(
+      resource: TelemetryResource,
+      scope: InstrumentationScope,
+      name: String,
+      description: Option[String],
+      unit: Option[String],
+      data: MetricPoints
+  ): MetricData =
+    Impl(
+      resource = resource,
+      instrumentationScope = scope,
+      name = name,
+      description = description,
+      unit = unit,
+      data = data
+    )
+
+  implicit val metricDataHash: Hash[MetricData] =
+    Hash.by { data =>
+      (
+        data.name,
+        data.description,
+        data.unit,
+        data.data,
+        data.instrumentationScope,
+        data.resource
+      )
+    }
+
+  implicit val metricDataShow: Show[MetricData] =
+    Show.show { data =>
+      val description = data.description.foldMap(d => s"description=$d, ")
+      val unit = data.unit.foldMap(d => s"unit=$d, ")
+      "MetricData{" +
+        s"name=${data.name}, " +
+        description +
+        unit +
+        s"data=${data.data}, " +
+        s"instrumentationScope=${data.instrumentationScope}, " +
+        s"resource=${data.resource}}"
+    }
+
+  private final case class Impl(
+      resource: TelemetryResource,
+      instrumentationScope: InstrumentationScope,
+      name: String,
+      description: Option[String],
+      unit: Option[String],
+      data: MetricPoints,
+  ) extends MetricData
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricDataSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricDataSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.data
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import cats.syntax.foldable._
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Cogens._
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+class MetricDataSuite extends DisciplineSuite {
+
+  checkAll("MetricData.Hash", HashTests[MetricData].hash)
+
+  test("Show[MetricData]") {
+    Prop.forAll(Gens.metricData) { data =>
+      val expected = {
+        val description = data.description.foldMap(d => s"description=$d, ")
+        val unit = data.unit.foldMap(d => s"unit=$d, ")
+        "MetricData{" +
+          s"name=${data.name}, " +
+          description +
+          unit +
+          s"data=${data.data}, " +
+          s"instrumentationScope=${data.instrumentationScope}, " +
+          s"resource=${data.resource}}"
+      }
+
+      assertEquals(Show[MetricData].show(data), expected)
+      assertEquals(data.toString, expected)
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Arbitraries.scala
@@ -20,6 +20,7 @@ package scalacheck
 import org.scalacheck.Arbitrary
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
@@ -54,6 +55,9 @@ trait Arbitraries extends org.typelevel.otel4s.sdk.scalacheck.Arbitraries {
 
   implicit val metricPointsArbitrary: Arbitrary[MetricPoints] =
     Arbitrary(Gens.metricPoints)
+
+  implicit val metricDataArbitrary: Arbitrary[MetricData] =
+    Arbitrary(Gens.metricData)
 
 }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
@@ -21,8 +21,11 @@ import org.scalacheck.Cogen
 import org.typelevel.ci.CIString
 import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
@@ -164,6 +167,27 @@ trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
         case histogram: MetricPoints.Histogram =>
           histogramMetricPointsCogen.perturb(seed, histogram)
       }
+    }
+
+  implicit val metricDataCogen: Cogen[MetricData] =
+    Cogen[
+      (
+          String,
+          Option[String],
+          Option[String],
+          MetricPoints,
+          InstrumentationScope,
+          TelemetryResource
+      )
+    ].contramap { d =>
+      (
+        d.name,
+        d.description,
+        d.unit,
+        d.data,
+        d.instrumentationScope,
+        d.resource
+      )
     }
 
 }

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -22,6 +22,7 @@ import org.typelevel.ci.CIString
 import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
@@ -227,6 +228,16 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
 
   val metricPoints: Gen[MetricPoints] =
     Gen.oneOf(sumMetricPoints, gaugeMetricPoints, histogramMetricPoints)
+
+  val metricData: Gen[MetricData] =
+    for {
+      resource <- Gens.telemetryResource
+      scope <- Gens.instrumentationScope
+      name <- Gens.nonEmptyString
+      description <- Gen.option(Gens.nonEmptyString)
+      unit <- Gen.option(Gens.nonEmptyString)
+      data <- Gens.metricPoints
+    } yield MetricData(resource, scope, name, description, unit, data)
 
 }
 


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/data-model/#timeseries-model|
| Java implementation | [MetricData.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/MetricData.java) |
