### PR TITLE
sdk-metrics: add `ExemplarReservoir`, `Exemplar`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,6 +232,7 @@ lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "case-insensitive" % CaseInsensitiveVersion,
       "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
       "org.typelevel" %%% "discipline-munit" % MUnitDisciplineVersion % Test,
+      "org.typelevel" %%% "scalacheck-effect-munit" % MUnitScalaCheckEffectVersion % Test
     )
   )
   .settings(munitDependencies)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/CellSelector.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/CellSelector.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import cats.Applicative
+import cats.effect.Concurrent
+import cats.effect.std.Random
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.sdk.metrics.internal.utils.Adder
+
+/** Selects which [[ReservoirCell]] within the [[ExemplarReservoir]] should
+  * receive the measurements.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  *
+  * @tparam A
+  *   the type of the values to record
+  */
+private[exemplar] trait CellSelector[F[_], A] {
+
+  /** Returns the [[ReservoirCell]] that should record the given value.
+    */
+  def select(
+      cells: Vector[ReservoirCell[F, A]],
+      value: A,
+  ): F[Option[ReservoirCell[F, A]]]
+
+  /** Resets the internal state.
+    */
+  def reset: F[Unit]
+}
+
+private[exemplar] object CellSelector {
+
+  def histogramBucket[F[_]: Applicative, A: Numeric](
+      boundaries: BucketBoundaries
+  ): CellSelector[F, A] =
+    new CellSelector[F, A] {
+      def select(
+          cells: Vector[ReservoirCell[F, A]],
+          value: A
+      ): F[Option[ReservoirCell[F, A]]] =
+        Applicative[F].pure(cells.lift(bucketIndex(Numeric[A].toDouble(value))))
+
+      def reset: F[Unit] = Applicative[F].unit
+
+      private def bucketIndex(value: Double): Int = {
+        val idx = boundaries.boundaries.indexWhere(b => value <= b)
+        if (idx == -1) boundaries.length else idx
+      }
+    }
+
+  def random[F[_]: Concurrent: Random, A]: F[CellSelector[F, A]] =
+    for {
+      adder <- Adder.create[F, Int]
+    } yield new CellSelector[F, A] {
+      def select(
+          cells: Vector[ReservoirCell[F, A]],
+          value: A
+      ): F[Option[ReservoirCell[F, A]]] =
+        for {
+          sum <- adder.sum(reset = false)
+          count = sum + 1
+          idx <- Random[F].nextIntBounded(if (count > 0) count else 1)
+          _ <- adder.add(1)
+        } yield cells.lift(idx)
+
+      def reset: F[Unit] = adder.reset
+    }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/Exemplar.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/Exemplar.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+
+import scala.concurrent.duration.FiniteDuration
+
+/** The recorded exemplar.
+  */
+private[exemplar] final case class Exemplar[A](
+    filteredAttributes: Attributes,
+    timestamp: FiniteDuration,
+    traceContext: Option[ExemplarData.TraceContext],
+    value: A
+)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoir.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoir.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import cats.Applicative
+import cats.Monad
+import cats.effect.Ref
+import cats.effect.Temporal
+import cats.effect.std.Random
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.context.Context
+
+/** The exemplar reservoir of samples.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplarreservoir]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  *
+  * @tparam A
+  *   the type of the values to record
+  */
+private[metrics] trait ExemplarReservoir[F[_], A] {
+
+  /** Offers a measurement to be sampled.
+    */
+  def offer(value: A, attributes: Attributes, context: Context): F[Unit]
+
+  /** Returns an collection of [[Exemplar]] for exporting from the current
+    * reservoir.
+    *
+    * Clears the reservoir for the next sampling period.
+    */
+  def collectAndReset(attributes: Attributes): F[Vector[Exemplar[A]]]
+}
+
+private[metrics] object ExemplarReservoir {
+
+  /** Creates a reservoir with fixed size that stores the given number of
+    * exemplars.
+    *
+    * @param size
+    *   the maximum number of exemplars to preserve
+    *
+    * @param lookup
+    *   extracts tracing information from the context
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def fixedSize[F[_]: Temporal: Random, A](
+      size: Int,
+      lookup: TraceContextLookup
+  ): F[ExemplarReservoir[F, A]] =
+    for {
+      selector <- CellSelector.random[F, A]
+      reservoir <- create(size, selector, lookup)
+    } yield reservoir
+
+  /** Creates a reservoir that preserves the latest seen measurement per
+    * histogram bucket.
+    *
+    * @param boundaries
+    *   the bucket boundaries of the histogram
+    *
+    * @param lookup
+    *   extracts tracing information from the context
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def histogramBucket[F[_]: Temporal, A: Numeric](
+      boundaries: BucketBoundaries,
+      lookup: TraceContextLookup
+  ): F[ExemplarReservoir[F, A]] =
+    create(
+      boundaries.length + 1,
+      CellSelector.histogramBucket(boundaries),
+      lookup
+    )
+
+  /** Creates a proxy reservoir that records offered values that have passed the
+    * filter.
+    *
+    * @param filter
+    *   filters the offered values
+    *
+    * @param original
+    *   the original reservoir
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def filtered[F[_]: Applicative, A: MeasurementValue](
+      filter: ExemplarFilter,
+      original: ExemplarReservoir[F, A]
+  ): ExemplarReservoir[F, A] =
+    new ExemplarReservoir[F, A] {
+      def offer(value: A, attributes: Attributes, context: Context): F[Unit] =
+        original
+          .offer(value, attributes, context)
+          .whenA(
+            filter.shouldSample(value, attributes, context)
+          )
+
+      def collectAndReset(attributes: Attributes): F[Vector[Exemplar[A]]] =
+        original.collectAndReset(attributes)
+    }
+
+  private def create[F[_]: Temporal, A](
+      size: Int,
+      cellSelector: CellSelector[F, A],
+      lookup: TraceContextLookup
+  ): F[ExemplarReservoir[F, A]] =
+    for {
+      cells <- ReservoirCell.create[F, A](lookup).replicateA(size)
+      hasMeasurement <- Temporal[F].ref(false)
+    } yield new FixedSize(cells.toVector, cellSelector, hasMeasurement)
+
+  private final class FixedSize[F[_]: Monad, A](
+      cells: Vector[ReservoirCell[F, A]],
+      selector: CellSelector[F, A],
+      hasMeasurement: Ref[F, Boolean],
+  ) extends ExemplarReservoir[F, A] {
+
+    def offer(value: A, attributes: Attributes, context: Context): F[Unit] =
+      selector.select(cells, value).flatMap {
+        case Some(cell) =>
+          for {
+            _ <- cell.record(value, attributes, context)
+            _ <- hasMeasurement.set(true)
+          } yield ()
+
+        case None =>
+          Monad[F].unit
+      }
+
+    def collectAndReset(attributes: Attributes): F[Vector[Exemplar[A]]] = {
+      def collect: F[Vector[Exemplar[A]]] =
+        for {
+          results <- cells.traverse(cell => cell.getAndReset(attributes))
+          _ <- selector.reset
+          _ <- hasMeasurement.set(false)
+        } yield results.flatten
+
+      hasMeasurement.get.ifM(collect, Monad[F].pure(Vector.empty))
+    }
+  }
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ReservoirCell.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ReservoirCell.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import cats.effect.Ref
+import cats.effect.Temporal
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+
+import scala.concurrent.duration.FiniteDuration
+
+/** A cell that stores exemplar data.
+  */
+private[exemplar] final class ReservoirCell[F[_]: Temporal, A] private (
+    stateRef: Ref[F, Option[ReservoirCell.State[A]]],
+    lookup: TraceContextLookup
+) {
+
+  /** Record the given `value` (measurement) to the cell.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the attributes to associate with the value
+    *
+    * @param context
+    *   the context to extract tracing information from
+    */
+  def record(value: A, attributes: Attributes, context: Context): F[Unit] =
+    for {
+      now <- Temporal[F].realTime
+      ctx <- Temporal[F].pure(lookup.get(context))
+      _ <- stateRef.set(Some(ReservoirCell.State(value, attributes, ctx, now)))
+    } yield ()
+
+  /** Retrieve the cell's exemplar and reset that state afterward.
+    */
+  def getAndReset(pointAttributes: Attributes): F[Option[Exemplar[A]]] =
+    stateRef.getAndSet(None).map { state =>
+      state.map { s =>
+        val attrs = filtered(s.attributes, pointAttributes)
+        Exemplar(attrs, s.recordTime, s.traceContext, s.value)
+      }
+    }
+
+  private def filtered(
+      original: Attributes,
+      metricPoint: Attributes
+  ): Attributes =
+    if (metricPoint.isEmpty) original
+    else original.filterNot(a => metricPoint.get(a.key).isDefined)
+}
+
+private[exemplar] object ReservoirCell {
+
+  private final case class State[A](
+      value: A,
+      attributes: Attributes,
+      traceContext: Option[ExemplarData.TraceContext],
+      recordTime: FiniteDuration
+  )
+
+  def create[F[_]: Temporal, A](
+      lookup: TraceContextLookup
+  ): F[ReservoirCell[F, A]] =
+    for {
+      stateRef <- Temporal[F].ref(Option.empty[State[A]])
+    } yield new ReservoirCell(stateRef, lookup)
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/utils/Adder.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/utils/Adder.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.internal.utils
+
+import cats.effect.Concurrent
+import cats.syntax.functor._
+
+private[metrics] trait Adder[F[_], A] {
+  def add(a: A): F[Unit]
+  def sum(reset: Boolean): F[A]
+  def reset: F[Unit]
+}
+
+private[metrics] object Adder {
+
+  def create[F[_]: Concurrent, A: Numeric]: F[Adder[F, A]] =
+    Concurrent[F].ref(Numeric[A].zero).map { ref =>
+      new Adder[F, A] {
+        def add(a: A): F[Unit] =
+          ref.update(v => Numeric[A].plus(v, a))
+
+        def sum(reset: Boolean): F[A] =
+          if (reset) ref.getAndSet(Numeric[A].zero) else ref.get
+
+        def reset: F[Unit] =
+          ref.set(Numeric[A].zero)
+      }
+    }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoirSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoirSuite.scala
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import cats.effect.IO
+import cats.effect.SyncIO
+import cats.effect.std.Random
+import cats.effect.testkit.TestControl
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData.TraceContext
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+
+import scala.concurrent.duration._
+
+class ExemplarReservoirSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite {
+
+  private val traceContextKey = Context.Key
+    .unique[SyncIO, TraceContext]("trace-context")
+    .unsafeRunSync()
+
+  private val contextLookup: TraceContextLookup =
+    _.get(traceContextKey)
+
+  private val boundaries: BucketBoundaries =
+    BucketBoundaries(Vector(1.0, 5.0, 10.0))
+
+  //
+  // Fixed size
+  //
+
+  test("fixed size - no measurements - return empty exemplar") {
+    Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+      for {
+        reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+        result <- reservoir.collectAndReset(Attributes.empty)
+      } yield assertEquals(result, Vector.empty)
+    }
+  }
+
+  test("fixed size - extract trace context") {
+    PropF.forAllF { (value: Long, attrs: Attributes, trace: TraceContext) =>
+      Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+        val ctx = Context.root.updated(traceContextKey, trace)
+
+        val expected = Exemplar(
+          filteredAttributes = attrs,
+          timestamp = Duration.Zero,
+          traceContext = Some(trace),
+          value = value
+        )
+
+        TestControl.executeEmbed {
+          for {
+            reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+            _ <- reservoir.offer(value, attrs, ctx)
+            result <- reservoir.collectAndReset(Attributes.empty)
+          } yield assertEquals(result, Vector(expected))
+        }
+      }
+    }
+  }
+
+  test("fixed size - filter attributes (keep unique)") {
+    PropF.forAllF { (value: Long, trace: TraceContext) =>
+      Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+        val ctx = Context.root.updated(traceContextKey, trace)
+
+        val string = Attribute("string", "value")
+        val long = Attribute("long", 1L)
+
+        val exemplarAttributes = Attributes(string, long)
+        val metricPointAttributes = Attributes(string)
+
+        val expected = Exemplar(
+          filteredAttributes = Attributes(long),
+          timestamp = Duration.Zero,
+          traceContext = Some(trace),
+          value = value
+        )
+
+        TestControl.executeEmbed {
+          for {
+            reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+            _ <- reservoir.offer(value, exemplarAttributes, ctx)
+            result <- reservoir.collectAndReset(metricPointAttributes)
+          } yield assertEquals(result, Vector(expected))
+        }
+      }
+    }
+  }
+
+  test("fixed size - size = 1 - reset the state after collection") {
+    Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+      val ctx = Context.root
+      val attrs = Attributes.empty
+
+      def expected(value: Long) = Exemplar(
+        filteredAttributes = attrs,
+        timestamp = Duration.Zero,
+        traceContext = None,
+        value = value
+      )
+
+      TestControl.executeEmbed {
+        for {
+          reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+          _ <- reservoir.offer(1L, attrs, ctx)
+          result1 <- reservoir.collectAndReset(Attributes.empty)
+          _ <- reservoir.offer(2L, attrs, ctx)
+          result2 <- reservoir.collectAndReset(Attributes.empty)
+        } yield {
+          assertEquals(result1, Vector(expected(1L)))
+          assertEquals(result2, Vector(expected(2L)))
+        }
+      }
+    }
+  }
+
+  test("fixed size - size = 2 - preserve latest samples") {
+    // put first 2 samples into bucket 0 and all other into bucket 1
+    val rnd = new java.util.Random {
+      override def nextInt(bound: Int): Int = {
+        bound match {
+          case 1 | 2 => 0
+          case _     => 1
+        }
+      }
+    }
+
+    Random.javaUtilRandom[IO](rnd).flatMap { implicit R: Random[IO] =>
+      val ctx = Context.root
+
+      def exemplar(value: Long) = Exemplar(
+        filteredAttributes = Attributes(Attribute("idx", value)),
+        timestamp = Duration.Zero,
+        traceContext = None,
+        value = value
+      )
+
+      val expected = Vector(
+        exemplar(2L),
+        exemplar(3L)
+      )
+
+      TestControl.executeEmbed {
+        for {
+          reservoir <- ExemplarReservoir.fixedSize[IO, Long](2, contextLookup)
+          _ <- reservoir.offer(1L, Attributes(Attribute("idx", 1L)), ctx)
+          _ <- reservoir.offer(2L, Attributes(Attribute("idx", 2L)), ctx)
+          _ <- reservoir.offer(3L, Attributes(Attribute("idx", 3L)), ctx)
+          result <- reservoir.collectAndReset(Attributes.empty)
+        } yield assertEquals(result, expected)
+      }
+    }
+  }
+
+  //
+  // Histogram bucket
+  //
+
+  test("histogram bucket - no measurements - return empty exemplar") {
+    for {
+      reservoir <- ExemplarReservoir.histogramBucket[IO, Long](
+        boundaries,
+        contextLookup
+      )
+      result <- reservoir.collectAndReset(Attributes.empty)
+    } yield assertEquals(result, Vector.empty)
+  }
+
+  test("histogram bucket - extract trace context") {
+    PropF.forAllF { (value: Long, attrs: Attributes, trace: TraceContext) =>
+      val ctx = Context.root.updated(traceContextKey, trace)
+
+      val expected = Exemplar(
+        filteredAttributes = attrs,
+        timestamp = Duration.Zero,
+        traceContext = Some(trace),
+        value = value
+      )
+
+      TestControl.executeEmbed {
+        for {
+          reservoir <- ExemplarReservoir.histogramBucket[IO, Long](
+            boundaries,
+            contextLookup
+          )
+          _ <- reservoir.offer(value, attrs, ctx)
+          result <- reservoir.collectAndReset(Attributes.empty)
+        } yield assertEquals(result, Vector(expected))
+      }
+    }
+  }
+
+  test("histogram bucket - filter attributes (keep unique)") {
+    PropF.forAllF { (value: Long, trace: TraceContext) =>
+      val ctx = Context.root.updated(traceContextKey, trace)
+
+      val string = Attribute("string", "value")
+      val long = Attribute("long", 1L)
+
+      val exemplarAttributes = Attributes(string, long)
+      val metricPointAttributes = Attributes(string)
+
+      val expected = Exemplar(
+        filteredAttributes = Attributes(long),
+        timestamp = Duration.Zero,
+        traceContext = Some(trace),
+        value = value
+      )
+
+      TestControl.executeEmbed {
+        for {
+          reservoir <- ExemplarReservoir.histogramBucket[IO, Long](
+            boundaries,
+            contextLookup
+          )
+          _ <- reservoir.offer(value, exemplarAttributes, ctx)
+          result <- reservoir.collectAndReset(metricPointAttributes)
+        } yield assertEquals(result, Vector(expected))
+      }
+    }
+  }
+
+  test("histogram bucket - multiple bucket - preserve latest samples") {
+    PropF.forAllF { (trace: TraceContext) =>
+      val ctx = Context.root.updated(traceContextKey, trace)
+
+      def exemplar(value: Long, idx: Long) = Exemplar(
+        filteredAttributes = Attributes(Attribute("idx", idx)),
+        timestamp = Duration.Zero,
+        traceContext = Some(trace),
+        value = value
+      )
+
+      val expected = Vector(
+        exemplar(1L, 1L),
+        exemplar(2L, 2L),
+        exemplar(10L, 4L),
+        exemplar(11L, 5L)
+      )
+
+      TestControl.executeEmbed {
+        for {
+          reservoir <- ExemplarReservoir.histogramBucket[IO, Long](
+            boundaries,
+            contextLookup
+          )
+          _ <- reservoir.offer(1L, Attributes(Attribute("idx", 1L)), ctx)
+          _ <- reservoir.offer(2L, Attributes(Attribute("idx", 2L)), ctx)
+          _ <- reservoir.offer(7L, Attributes(Attribute("idx", 3L)), ctx)
+          _ <- reservoir.offer(10L, Attributes(Attribute("idx", 4L)), ctx)
+          _ <- reservoir.offer(11L, Attributes(Attribute("idx", 5L)), ctx)
+          result <- reservoir.collectAndReset(Attributes.empty)
+        } yield assertEquals(result, expected)
+      }
+    }
+  }
+
+  //
+  // Filtered
+  //
+
+  test("filtered - always off filter - prevent sampling") {
+    PropF.forAllF { (value: Long, attrs: Attributes, trace: TraceContext) =>
+      Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+        val filter = ExemplarFilter.alwaysOff
+        val ctx = Context.root.updated(traceContextKey, trace)
+
+        for {
+          reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+          filtered = ExemplarReservoir.filtered(filter, reservoir)
+          _ <- filtered.offer(value, attrs, ctx)
+          result <- filtered.collectAndReset(Attributes.empty)
+        } yield assertEquals(result, Vector.empty)
+      }
+    }
+  }
+
+  test("filtered - always on filter - sample all") {
+    PropF.forAllF { (value: Long, attrs: Attributes, trace: TraceContext) =>
+      Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+        val filter = ExemplarFilter.alwaysOn
+        val ctx = Context.root.updated(traceContextKey, trace)
+        val expected = Exemplar(
+          filteredAttributes = attrs,
+          timestamp = Duration.Zero,
+          traceContext = Some(trace),
+          value = value
+        )
+
+        TestControl.executeEmbed {
+          for {
+            reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+            filtered = ExemplarReservoir.filtered(filter, reservoir)
+            _ <- filtered.offer(value, attrs, ctx)
+            result <- filtered.collectAndReset(Attributes.empty)
+          } yield assertEquals(result, Vector(expected))
+        }
+      }
+    }
+  }
+
+  test("filtered - trace based filter - sample according to the context") {
+    PropF.forAllF { (value: Long, attrs: Attributes, trace: TraceContext) =>
+      Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+        val filter = ExemplarFilter.traceBased(contextLookup)
+        val ctx = Context.root.updated(traceContextKey, trace)
+        val exemplar = Exemplar(
+          filteredAttributes = attrs,
+          timestamp = Duration.Zero,
+          traceContext = Some(trace),
+          value = value
+        )
+        val expected = if (trace.isSampled) Vector(exemplar) else Vector.empty
+
+        TestControl.executeEmbed {
+          for {
+            reservoir <- ExemplarReservoir.fixedSize[IO, Long](1, contextLookup)
+            filtered = ExemplarReservoir.filtered(filter, reservoir)
+            _ <- filtered.offer(value, attrs, ctx)
+            result <- filtered.collectAndReset(Attributes.empty)
+          } yield assertEquals(result, expected)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplarreservoir |
| Java implementation | [ExemplarReservoir.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ExemplarReservoir.java) <br> [HistogramExemplarReservoir.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/HistogramExemplarReservoir.java) <br> [FixedSizeExemplarReservoir.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FixedSizeExemplarReservoir.java) <br> [FilteredExemplarReservoir.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/FilteredExemplarReservoir.java) <br> [ReservoirCell.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCell.java) <br> [ReservoirCellSelector.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/exemplar/ReservoirCellSelector.java)  |

The implementation of the exemplar reservoir.
