### PR TITLE
sdk-metrics: add `AggregationSelector`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/AggregationSelector.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/AggregationSelector.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package exporter
+
+/** Used by the `MetricReader` to decide the default aggregation.
+  */
+trait AggregationSelector {
+
+  /** Returns preferred [[Aggregation]] for the given [[InstrumentType]].
+    */
+  def select(instrumentType: InstrumentType): Aggregation
+}
+
+object AggregationSelector {
+
+  /** Returns [[Aggregation.default]] for all instruments.
+    */
+  def default: AggregationSelector = _ => Aggregation.default
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/AggregationSelectorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/AggregationSelectorSuite.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import munit.FunSuite
+import org.typelevel.otel4s.sdk.metrics.Aggregation
+import org.typelevel.otel4s.sdk.metrics.InstrumentType
+
+class AggregationSelectorSuite extends FunSuite {
+
+  test("default") {
+    val selector = AggregationSelector.default
+    InstrumentType.values.foreach { tpe =>
+      assertEquals(selector.select(tpe), Aggregation.Default)
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader |
| Java implementation | [DefaultAggregationSelector.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/DefaultAggregationSelector.java)  |

The selector is required by the upcoming `MetricReader`.