### PR TITLE
sdk-metrics: add `CardinalityLimitSelector`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/CardinalityLimitSelector.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/CardinalityLimitSelector.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package exporter
+
+/** Used by the `MetricReader` to decide the default aggregation.
+  */
+trait CardinalityLimitSelector {
+
+  /** Returns preferred cardinality limit for the given [[InstrumentType]].
+    */
+  def select(instrumentType: InstrumentType): Int
+}
+
+object CardinalityLimitSelector {
+
+  private object Defaults {
+    // see https://opentelemetry.io/docs/specs/otel/metrics/sdk/#cardinality-limits
+    val CardinalityLimit: Int = 2000
+  }
+
+  /** Returns default cardinality limit (2000) for all instruments.
+    */
+  def default: CardinalityLimitSelector = _ => Defaults.CardinalityLimit
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/CardinalityLimitSelectorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/CardinalityLimitSelectorSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import munit.FunSuite
+import org.typelevel.otel4s.sdk.metrics.InstrumentType
+
+class CardinalityLimitSelectorSuite extends FunSuite {
+
+  test("default") {
+    val selector = CardinalityLimitSelector.default
+    InstrumentType.values.foreach { tpe =>
+      assertEquals(selector.select(tpe), 2000)
+    }
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader |
| Java implementation | [CardinalityLimitSelector.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/export/CardinalityLimitSelector.java)  |

The selector is required by the upcoming `MetricReader`.