### PR TITLE
sdk-metrics: add `Aggregator`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.PointData
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+import org.typelevel.otel4s.sdk.metrics.internal.AsynchronousMeasurement
+import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
+
+/** Aggregators are responsible for holding aggregated values and taking a
+  * snapshot of these values upon export.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation]]
+  */
+private[metrics] object Aggregator {
+
+  /** An aggregator for synchronous instruments:
+    *   - Counter
+    *   - UpDownCounter
+    *   - Histogram
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  trait Synchronous[F[_], A] {
+    type Point <: PointData
+
+    /** Creates an empty accumulator to aggregate measurements.
+      */
+    def createAccumulator: F[Aggregator.Accumulator[F, A, Point]]
+
+    /** Returns the MetricData using the given values.
+      *
+      * @param resource
+      *   the resource to associate the `MetricData` with
+      *
+      * @param scope
+      *   the instrumentation scope to associate the `MetricData` with
+      *
+      * @param descriptor
+      *   the descriptor of the instrument
+      *
+      * @param points
+      *   the measurements to create a `MetricData` with
+      *
+      * @param temporality
+      *   the aggregation temporality of the resulting `MetricData`
+      */
+    def toMetricData(
+        resource: TelemetryResource,
+        scope: InstrumentationScope,
+        descriptor: MetricDescriptor,
+        points: Vector[Point],
+        temporality: AggregationTemporality
+    ): F[MetricData]
+  }
+
+  /** An aggregator for asynchronous instruments:
+    *   - ObservableCounter
+    *   - ObservableUpDownCounter
+    *   - ObservableGauge
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  trait Asynchronous[F[_], A] {
+
+    /** Returns a new delta aggregation by comparing two cumulative
+      * measurements.
+      *
+      * @param previous
+      *   the previously captured measurement
+      *
+      * @param current
+      *   the newly captured (delta) measurement
+      */
+    def diff(
+        previous: AsynchronousMeasurement[A],
+        current: AsynchronousMeasurement[A]
+    ): AsynchronousMeasurement[A]
+
+    /** Returns the `MetricData` using the given values.
+      *
+      * @param resource
+      *   the resource to associate the `MetricData` with
+      *
+      * @param scope
+      *   the instrumentation scope to associate the `MetricData` with
+      *
+      * @param descriptor
+      *   the descriptor of the instrument
+      *
+      * @param measurements
+      *   the measurements to create a `MetricData` with
+      *
+      * @param temporality
+      *   the aggregation temporality of the resulting `MetricData`
+      */
+    def toMetricData(
+        resource: TelemetryResource,
+        scope: InstrumentationScope,
+        descriptor: MetricDescriptor,
+        measurements: Vector[AsynchronousMeasurement[A]],
+        temporality: AggregationTemporality
+    ): F[MetricData]
+  }
+
+  /** Records incoming raw values (measurements) and aggregates them into the
+    * `P` (PointData).
+    *
+    * Used by the synchronous instruments.
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    *
+    * @tparam P
+    *   the type of the aggregated PointData
+    */
+  trait Accumulator[F[_], A, P <: PointData] {
+
+    /** Creates a `PointData` using accumulated data.
+      *
+      * @param timeWindow
+      *   the time window to associate the points with
+      *
+      * @param attributes
+      *   the attributes to associate the points with
+      *
+      * @param reset
+      *   whether to reset the internal state
+      */
+    def aggregate(
+        timeWindow: TimeWindow,
+        attributes: Attributes,
+        reset: Boolean
+    ): F[Option[P]]
+
+    /** Records the value.
+      *
+      * @param value
+      *   the value to record
+      *
+      * @param attributes
+      *   the attributes to record
+      *
+      * @param context
+      *   the context to record
+      */
+    def record(
+        value: A,
+        attributes: Attributes,
+        context: Context
+    ): F[Unit]
+  }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Target.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Target.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData.TraceContext
+import org.typelevel.otel4s.sdk.metrics.data.PointData
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+
+import scala.concurrent.duration.FiniteDuration
+
+/** A utility trait to select matching `ExemplarData` and `PointData`.
+  *
+  * Used by the `Sum` and `LastValue` aggregators.
+  *
+  * @tparam A
+  *   the type of the values to record
+  */
+private sealed trait Target[A] { self =>
+  type Exemplar <: ExemplarData
+  type Point <: PointData.NumberPoint
+
+  /** Creates a `Point` with the given values.
+    */
+  def makePointData(
+      timeWindow: TimeWindow,
+      attributes: Attributes,
+      exemplars: Vector[Exemplar],
+      value: A
+  ): Point
+
+  /** Creates an `Exemplar` with the given values.
+    */
+  def makeExemplar(
+      attributes: Attributes,
+      timestamp: FiniteDuration,
+      traceContext: Option[TraceContext],
+      value: A
+  ): Exemplar
+
+}
+
+private object Target {
+
+  def apply[A: MeasurementValue]: Target[A] =
+    MeasurementValue[A] match {
+      case MeasurementValue.LongMeasurementValue(cast) =>
+        new LongTarget[A](cast)
+      case MeasurementValue.DoubleMeasurementValue(cast) =>
+        new DoubleTarget[A](cast)
+    }
+
+  private[aggregation] final class LongTarget[A](
+      cast: A => Long
+  ) extends Target[A] {
+
+    type Exemplar = ExemplarData.LongExemplar
+    type Point = PointData.LongNumber
+
+    def makePointData(
+        timeWindow: TimeWindow,
+        attributes: Attributes,
+        exemplars: Vector[ExemplarData.LongExemplar],
+        value: A
+    ): PointData.LongNumber =
+      PointData.longNumber(
+        timeWindow,
+        attributes,
+        exemplars,
+        cast(value)
+      )
+
+    def makeExemplar(
+        attributes: Attributes,
+        timestamp: FiniteDuration,
+        traceContext: Option[TraceContext],
+        value: A
+    ): ExemplarData.LongExemplar =
+      ExemplarData.long(attributes, timestamp, traceContext, cast(value))
+  }
+
+  private[aggregation] final class DoubleTarget[A](
+      cast: A => Double
+  ) extends Target[A] {
+
+    type Exemplar = ExemplarData.DoubleExemplar
+    type Point = PointData.DoubleNumber
+
+    def makePointData(
+        timeWindow: TimeWindow,
+        attributes: Attributes,
+        exemplars: Vector[ExemplarData.DoubleExemplar],
+        value: A
+    ): PointData.DoubleNumber =
+      PointData.doubleNumber(
+        timeWindow,
+        attributes,
+        exemplars,
+        cast(value)
+      )
+
+    def makeExemplar(
+        attributes: Attributes,
+        timestamp: FiniteDuration,
+        traceContext: Option[TraceContext],
+        value: A
+    ): ExemplarData.DoubleExemplar =
+      ExemplarData.double(
+        attributes,
+        timestamp,
+        traceContext,
+        cast(value)
+      )
+  }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/AsynchronousMeasurement.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/AsynchronousMeasurement.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.internal
+
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+
+private[metrics] final case class AsynchronousMeasurement[A](
+    timeWindow: TimeWindow,
+    attributes: Attributes,
+    value: A
+)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MetricDescriptor.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MetricDescriptor.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.internal
+
+import org.typelevel.otel4s.sdk.metrics.view.View
+
+/** Describes a metric that will be output.
+  */
+private[metrics] sealed trait MetricDescriptor {
+
+  /** The name of the descriptor.
+    *
+    * Either the [[View.name]] or [[InstrumentDescriptor.name]].
+    */
+  def name: String
+
+  /** The description of the descriptor.
+    *
+    * Either the [[View.description]] or [[InstrumentDescriptor.description]].
+    */
+  def description: Option[String]
+
+  /** The instrument used by this metric.
+    */
+  def sourceInstrument: InstrumentDescriptor
+
+}
+
+private[metrics] object MetricDescriptor {
+
+  /** Creates a [[MetricDescriptor]] using the given `view` and
+    * `instrumentDescriptor`.
+    *
+    * The `name` and `description` from the `view` are prioritized.
+    *
+    * @param view
+    *   the view associated with the instrument
+    *
+    * @param instrumentDescriptor
+    *   the descriptor of the instrument
+    */
+  def apply(
+      view: Option[View],
+      instrumentDescriptor: InstrumentDescriptor
+  ): MetricDescriptor =
+    Impl(
+      view.flatMap(_.name).getOrElse(instrumentDescriptor.name.toString),
+      view.flatMap(_.description).orElse(instrumentDescriptor.description),
+      instrumentDescriptor
+    )
+
+  private final case class Impl(
+      name: String,
+      description: Option[String],
+      sourceInstrument: InstrumentDescriptor
+  ) extends MetricDescriptor
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/TargetSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/TargetSuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import munit.ScalaCheckSuite
+
+class TargetSuite extends ScalaCheckSuite {
+
+  test("detect target automatically") {
+    assert(Target[Long].isInstanceOf[Target.LongTarget[Long]])
+    assert(Target[Double].isInstanceOf[Target.DoubleTarget[Double]])
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation |

There two basic traits for `Asynchronous` and `Synchronous` aggregators.