### PR TITLE
sdk-metrics: add `SumAggregator`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
@@ -171,10 +171,10 @@ private[metrics] object Aggregator {
       *   the value to record
       *
       * @param attributes
-      *   the attributes to record
+      *   the attributes to record by the exemplar reservoir
       *
       * @param context
-      *   the context to record
+      *   the context to record by the exemplar reservoir
       */
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregator.scala
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import cats.Applicative
+import cats.effect.Temporal
+import cats.effect.std.Random
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.InstrumentType
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarReservoir
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.internal.AsynchronousMeasurement
+import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
+import org.typelevel.otel4s.sdk.metrics.internal.utils.Adder
+
+private object SumAggregator {
+
+  /** Creates a sum aggregator for synchronous instruments. Calculates the
+    * arithmetic sum of the measurement values.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#sum-aggregation]]
+    *
+    * @param reservoirSize
+    *   the maximum number of exemplars to preserve
+    *
+    * @param filter
+    *   filters the offered values
+    *
+    * @param lookup
+    *   extracts tracing information from the context
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def synchronous[F[_]: Temporal: Random, A: MeasurementValue: Numeric](
+      reservoirSize: Int,
+      filter: ExemplarFilter,
+      lookup: TraceContextLookup
+  ): Aggregator.Synchronous[F, A] =
+    new Synchronous(reservoirSize, filter, lookup)
+
+  /** Creates a sum aggregator for asynchronous instruments.
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#sum-aggregation]]
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def asynchronous[
+      F[_]: Applicative,
+      A: MeasurementValue: Numeric
+  ]: Aggregator.Asynchronous[F, A] =
+    new Asynchronous[F, A]
+
+  private final class Synchronous[
+      F[_]: Temporal: Random,
+      A: MeasurementValue: Numeric
+  ](
+      reservoirSize: Int,
+      filter: ExemplarFilter,
+      traceContextLookup: TraceContextLookup
+  ) extends Aggregator.Synchronous[F, A] {
+
+    val target: Target[A] = Target[A]
+
+    type Point = target.Point
+
+    def createAccumulator: F[Aggregator.Accumulator[F, A, Point]] =
+      for {
+        adder <- Adder.create[F, A]
+        reservoir <- makeReservoir
+      } yield new Accumulator(adder, reservoir)
+
+    def toMetricData(
+        resource: TelemetryResource,
+        scope: InstrumentationScope,
+        descriptor: MetricDescriptor,
+        points: Vector[Point],
+        temporality: AggregationTemporality
+    ): F[MetricData] =
+      Temporal[F].pure(
+        MetricData(
+          resource,
+          scope,
+          descriptor.name,
+          descriptor.description,
+          descriptor.sourceInstrument.unit,
+          MetricPoints.sum(points, isMonotonic(descriptor), temporality)
+        )
+      )
+
+    private def makeReservoir: F[ExemplarReservoir[F, A]] =
+      ExemplarReservoir
+        .fixedSize[F, A](
+          size = reservoirSize,
+          lookup = traceContextLookup
+        )
+        .map(r => ExemplarReservoir.filtered(filter, r))
+
+    private class Accumulator(
+        adder: Adder[F, A],
+        reservoir: ExemplarReservoir[F, A]
+    ) extends Aggregator.Accumulator[F, A, Point] {
+
+      def aggregate(
+          timeWindow: TimeWindow,
+          attributes: Attributes,
+          reset: Boolean
+      ): F[Option[Point]] =
+        for {
+          value <- adder.sum(reset)
+          exemplars <- reservoir.collectAndReset(attributes)
+        } yield Some(
+          target.makePointData(
+            timeWindow,
+            attributes,
+            exemplars.map { e =>
+              target.makeExemplar(
+                e.filteredAttributes,
+                e.timestamp,
+                e.traceContext,
+                e.value
+              )
+            },
+            value
+          )
+        )
+
+      def record(value: A, attributes: Attributes, context: Context): F[Unit] =
+        reservoir.offer(value, attributes, context) >> adder.add(value)
+
+    }
+
+  }
+
+  private final class Asynchronous[
+      F[_]: Applicative,
+      A: MeasurementValue: Numeric
+  ] extends Aggregator.Asynchronous[F, A] {
+
+    private val target: Target[A] = Target[A]
+
+    def diff(
+        previous: AsynchronousMeasurement[A],
+        current: AsynchronousMeasurement[A]
+    ): AsynchronousMeasurement[A] =
+      current.copy(value = Numeric[A].minus(current.value, previous.value))
+
+    def toMetricData(
+        resource: TelemetryResource,
+        scope: InstrumentationScope,
+        descriptor: MetricDescriptor,
+        measurements: Vector[AsynchronousMeasurement[A]],
+        temporality: AggregationTemporality
+    ): F[MetricData] = {
+      val points = measurements.map { m =>
+        target.makePointData(m.timeWindow, m.attributes, Vector.empty, m.value)
+      }
+
+      Applicative[F].pure(
+        MetricData(
+          resource,
+          scope,
+          descriptor.name,
+          descriptor.description,
+          descriptor.sourceInstrument.unit,
+          MetricPoints.sum(points, isMonotonic(descriptor), temporality)
+        )
+      )
+    }
+
+  }
+
+  private def isMonotonic(descriptor: MetricDescriptor): Boolean =
+    descriptor.sourceInstrument.instrumentType match {
+      case InstrumentType.Counter           => true
+      case InstrumentType.Histogram         => true
+      case InstrumentType.ObservableCounter => true
+      case _                                => false
+    }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregatorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregatorSuite.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import cats.effect.IO
+import cats.effect.SyncIO
+import cats.effect.std.Random
+import cats.effect.testkit.TestControl
+import cats.syntax.foldable._
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Gen
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.InstrumentType
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData.TraceContext
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.data.PointData
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+import scala.concurrent.duration._
+
+class SumAggregatorSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+
+  private val traceContextKey = Context.Key
+    .unique[SyncIO, TraceContext]("trace-context")
+    .unsafeRunSync()
+
+  private val filter: ExemplarFilter =
+    ExemplarFilter.alwaysOn
+
+  private val contextLookup: TraceContextLookup =
+    _.get(traceContextKey)
+
+  // we need to put all exemplar values into the first cell
+  private val random = new java.util.Random {
+    override def nextInt(bound: Int): Int = 0
+  }
+
+  test("synchronous - aggregate with reset - return delta sum") {
+    PropF.forAllF(
+      Gen.listOf(Gen.long),
+      Gens.attributes,
+      Gens.attributes,
+      Gens.traceContext
+    ) { (values, exemplarAttributes, attributes, traceContext) =>
+      Random.javaUtilRandom[IO](random).flatMap { implicit R: Random[IO] =>
+        val ctx = Context.root.updated(traceContextKey, traceContext)
+
+        val aggregator =
+          SumAggregator.synchronous[IO, Long](1, filter, contextLookup)
+
+        val timeWindow =
+          TimeWindow(100.millis, 200.millis)
+
+        val expected =
+          PointData.longNumber(
+            timeWindow,
+            attributes,
+            values.lastOption.map { last =>
+              ExemplarData.long(
+                exemplarAttributes,
+                Duration.Zero,
+                Some(traceContext),
+                last
+              )
+            }.toVector,
+            values.sum
+          )
+
+        TestControl.executeEmbed {
+          for {
+            accumulator <- aggregator.createAccumulator
+            _ <- values.traverse_ { value =>
+              accumulator.record(value, exemplarAttributes, ctx)
+            }
+            r <- accumulator.aggregate(timeWindow, attributes, reset = true)
+          } yield assertEquals(r: Option[PointData], Some(expected))
+        }
+      }
+    }
+  }
+
+  test("synchronous - aggregate without reset - return cumulative sum") {
+    PropF.forAllF(
+      Gen.listOf(Gen.long),
+      Gens.attributes,
+      Gens.attributes,
+      Gens.traceContext
+    ) { (values, exemplarAttributes, attributes, traceContext) =>
+      Random.javaUtilRandom[IO](random).flatMap { implicit R: Random[IO] =>
+        val ctx = Context.root.updated(traceContextKey, traceContext)
+
+        val aggregator =
+          SumAggregator.synchronous[IO, Long](1, filter, contextLookup)
+
+        val timeWindow =
+          TimeWindow(100.millis, 200.millis)
+
+        def expected(values: List[Long]): PointData.LongNumber =
+          PointData.longNumber(
+            timeWindow,
+            attributes,
+            values.lastOption.map { last =>
+              ExemplarData.long(
+                exemplarAttributes,
+                Duration.Zero,
+                Some(traceContext),
+                last
+              )
+            }.toVector,
+            values.sum
+          )
+
+        TestControl.executeEmbed {
+          for {
+            accumulator <- aggregator.createAccumulator
+            _ <- values.traverse_ { value =>
+              accumulator.record(value, exemplarAttributes, ctx)
+            }
+            r1 <- accumulator.aggregate(timeWindow, attributes, reset = false)
+            _ <- values.traverse_ { value =>
+              accumulator.record(value, exemplarAttributes, ctx)
+            }
+            r2 <- accumulator.aggregate(timeWindow, attributes, reset = false)
+          } yield {
+            assertEquals(r1: Option[PointData], Some(expected(values)))
+            assertEquals(
+              r2: Option[PointData],
+              Some(expected(values ++ values))
+            )
+          }
+        }
+      }
+    }
+  }
+
+  test("synchronous - toMetricData") {
+    PropF.forAllF(
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.instrumentDescriptor,
+      Gen.listOf(Gens.longNumberPointData),
+      Gens.aggregationTemporality
+    ) { (resource, scope, descriptor, points, temporality) =>
+      Random.javaUtilRandom[IO](random).flatMap { implicit R: Random[IO] =>
+        type LongAggregator = Aggregator.Synchronous[IO, Long] {
+          type Point = PointData.LongNumber
+        }
+
+        val aggregator =
+          SumAggregator
+            .synchronous[IO, Long](1, filter, contextLookup)
+            .asInstanceOf[LongAggregator]
+
+        val monotonic =
+          descriptor.instrumentType match {
+            case InstrumentType.Counter           => true
+            case InstrumentType.Histogram         => true
+            case InstrumentType.ObservableCounter => true
+            case _                                => false
+          }
+
+        val expected =
+          MetricData(
+            resource = resource,
+            scope = scope,
+            name = descriptor.name.toString,
+            description = descriptor.description,
+            unit = descriptor.unit,
+            data = MetricPoints.sum(points.toVector, monotonic, temporality)
+          )
+
+        for {
+          metricData <- aggregator.toMetricData(
+            resource,
+            scope,
+            MetricDescriptor(None, descriptor),
+            points.toVector,
+            temporality
+          )
+        } yield assertEquals(metricData, expected)
+      }
+    }
+  }
+
+  test("asynchronous - diff - calculate difference between measurements") {
+    val aggregator = SumAggregator.asynchronous[IO, Long]
+
+    PropF.forAllF(
+      Gens.asynchronousMeasurement(Gen.long),
+      Gens.asynchronousMeasurement(Gen.long)
+    ) { (previous, current) =>
+      val result = aggregator.diff(previous, current)
+      val expected = current.copy(value = current.value - previous.value)
+
+      IO(assertEquals(result, expected))
+    }
+  }
+
+  test("asynchronous - toMetricData") {
+    PropF.forAllF(
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.instrumentDescriptor,
+      Gen.listOf(Gens.asynchronousMeasurement(Gen.long)),
+      Gens.aggregationTemporality
+    ) { (resource, scope, descriptor, measurements, temporality) =>
+      val aggregator = SumAggregator.asynchronous[IO, Long]
+
+      val monotonic =
+        descriptor.instrumentType match {
+          case InstrumentType.Counter           => true
+          case InstrumentType.Histogram         => true
+          case InstrumentType.ObservableCounter => true
+          case _                                => false
+        }
+
+      val points = measurements.map { m =>
+        PointData.longNumber(m.timeWindow, m.attributes, Vector.empty, m.value)
+      }
+
+      val expected =
+        MetricData(
+          resource = resource,
+          scope = scope,
+          name = descriptor.name.toString,
+          description = descriptor.description,
+          unit = descriptor.unit,
+          data = MetricPoints.sum(points.toVector, monotonic, temporality)
+        )
+
+      for {
+        metricData <- aggregator.toMetricData(
+          resource,
+          scope,
+          MetricDescriptor(None, descriptor),
+          measurements.toVector,
+          temporality
+        )
+      } yield assertEquals(metricData, expected)
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -26,6 +26,7 @@ import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+import org.typelevel.otel4s.sdk.metrics.internal.AsynchronousMeasurement
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
 import org.typelevel.otel4s.sdk.metrics.view.InstrumentSelector
 import scodec.bits.ByteVector
@@ -238,6 +239,13 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
       unit <- Gen.option(Gens.nonEmptyString)
       data <- Gens.metricPoints
     } yield MetricData(resource, scope, name, description, unit, data)
+
+  def asynchronousMeasurement[A](gen: Gen[A]): Gen[AsynchronousMeasurement[A]] =
+    for {
+      timeWindow <- Gens.timeWindow
+      attributes <- Gens.attributes
+      value <- gen
+    } yield AsynchronousMeasurement(timeWindow, attributes, value)
 
 }
 


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#sum-aggregation |
| Java implementation | [LongSumAggregator.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/LongSumAggregator.java)  |