### PR TITLE
sdk-metrics: add `ExplicitBucketHistogramAggregator`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregator.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import cats.FlatMap
+import cats.effect.Concurrent
+import cats.effect.Ref
+import cats.effect.Temporal
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data._
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarReservoir
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
+
+/** The histogram aggregation that aggregates values into the corresponding
+  * buckets.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  *
+  * @tparam A
+  *   the type of the values to record
+  */
+private final class ExplicitBucketHistogramAggregator[
+    F[_]: Concurrent,
+    A: MeasurementValue
+](
+    boundaries: BucketBoundaries,
+    makeReservoir: F[ExemplarReservoir[F, A]]
+) extends Aggregator.Synchronous[F, A] {
+  import ExplicitBucketHistogramAggregator._
+
+  type Point = PointData.Histogram
+
+  def createAccumulator: F[Aggregator.Accumulator[F, A, PointData.Histogram]] =
+    for {
+      state <- Concurrent[F].ref(emptyState(boundaries.length))
+      reservoir <- makeReservoir
+    } yield new Accumulator(state, boundaries, reservoir)
+
+  def toMetricData(
+      resource: TelemetryResource,
+      scope: InstrumentationScope,
+      descriptor: MetricDescriptor,
+      points: Vector[PointData.Histogram],
+      temporality: AggregationTemporality
+  ): F[MetricData] =
+    Concurrent[F].pure(
+      MetricData(
+        resource,
+        scope,
+        descriptor.name,
+        descriptor.description,
+        descriptor.sourceInstrument.unit,
+        MetricPoints.histogram(points, temporality)
+      )
+    )
+}
+
+private object ExplicitBucketHistogramAggregator {
+
+  /** Creates a histogram aggregation with the given values.
+    *
+    * @param boundaries
+    *   the bucket boundaries to aggregate values at
+    *
+    * @param filter
+    *   filters the offered values
+    *
+    * @param lookup
+    *   extracts tracing information from the context
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def apply[F[_]: Temporal, A: MeasurementValue: Numeric](
+      boundaries: BucketBoundaries,
+      filter: ExemplarFilter,
+      lookup: TraceContextLookup
+  ): Aggregator.Synchronous[F, A] = {
+    val reservoir = ExemplarReservoir
+      .histogramBucket[F, A](boundaries, lookup)
+      .map(r => ExemplarReservoir.filtered(filter, r))
+
+    new ExplicitBucketHistogramAggregator[F, A](boundaries, reservoir)
+  }
+
+  private final case class State(
+      sum: Double,
+      min: Double,
+      max: Double,
+      count: Long,
+      counts: Vector[Long]
+  )
+
+  private def emptyState(buckets: Int): State =
+    State(0, Double.MaxValue, -1, 0L, Vector.fill(buckets + 1)(0))
+
+  private class Accumulator[F[_]: FlatMap, A: MeasurementValue](
+      stateRef: Ref[F, State],
+      boundaries: BucketBoundaries,
+      reservoir: ExemplarReservoir[F, A]
+  ) extends Aggregator.Accumulator[F, A, PointData.Histogram] {
+
+    private val toDouble: A => Double =
+      MeasurementValue[A] match {
+        case MeasurementValue.LongMeasurementValue(cast) =>
+          cast.andThen(_.toDouble)
+        case MeasurementValue.DoubleMeasurementValue(cast) =>
+          cast
+      }
+
+    def aggregate(
+        timeWindow: TimeWindow,
+        attributes: Attributes,
+        reset: Boolean
+    ): F[Option[PointData.Histogram]] =
+      reservoir.collectAndReset(attributes).flatMap { rawExemplars =>
+        stateRef.modify { state =>
+          val exemplars = rawExemplars.map { e =>
+            ExemplarData.double(
+              e.filteredAttributes,
+              e.timestamp,
+              e.traceContext,
+              toDouble(e.value)
+            )
+          }
+
+          val stats = Option.when(state.count > 0) {
+            PointData.Histogram.Stats(
+              state.sum,
+              state.min,
+              state.max,
+              state.count
+            )
+          }
+
+          val histogram = PointData.histogram(
+            timeWindow = timeWindow,
+            attributes = attributes,
+            exemplars = exemplars,
+            stats = stats,
+            boundaries = boundaries,
+            counts = state.counts
+          )
+
+          val next = if (reset) emptyState(boundaries.length) else state
+
+          (next, Some(histogram))
+        }
+      }
+
+    def record(value: A, attributes: Attributes, context: Context): F[Unit] = {
+      val doubleValue = toDouble(value)
+
+      reservoir.offer(value, attributes, context) >> stateRef.update { state =>
+        val idx = bucketIndex(doubleValue)
+        state.copy(
+          sum = state.sum + doubleValue,
+          min = math.min(state.min, doubleValue),
+          max = math.max(state.max, doubleValue),
+          count = state.count + 1,
+          counts = state.counts.updated(idx, state.counts(idx) + 1)
+        )
+      }
+    }
+
+    private def bucketIndex(value: Double): Int = {
+      val idx = boundaries.boundaries.indexWhere(b => value <= b)
+      if (idx == -1) boundaries.length else idx
+    }
+
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregatorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregatorSuite.scala
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.aggregation
+
+import cats.effect.IO
+import cats.effect.SyncIO
+import cats.effect.testkit.TestControl
+import cats.syntax.foldable._
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Gen
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData
+import org.typelevel.otel4s.sdk.metrics.data.ExemplarData.TraceContext
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.data.PointData
+import org.typelevel.otel4s.sdk.metrics.data.PointData.Histogram
+import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+
+import scala.concurrent.duration._
+
+class ExplicitBucketHistogramAggregatorSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite {
+
+  private val traceContextKey = Context.Key
+    .unique[SyncIO, TraceContext]("trace-context")
+    .unsafeRunSync()
+
+  private val filter: ExemplarFilter =
+    ExemplarFilter.alwaysOn
+
+  private val contextLookup: TraceContextLookup =
+    _.get(traceContextKey)
+
+  test("aggregate with reset - return a snapshot and reset the state") {
+    PropF.forAllF(
+      Gen.listOf(Gen.double),
+      Gens.bucketBoundaries,
+      Gens.attributes,
+      Gens.attributes,
+      Gens.traceContext
+    ) { (values, boundaries, exemplarAttributes, attributes, traceContext) =>
+      val ctx = Context.root.updated(traceContextKey, traceContext)
+
+      val aggregator =
+        ExplicitBucketHistogramAggregator[IO, Double](
+          boundaries,
+          filter,
+          contextLookup
+        )
+
+      val timeWindow =
+        TimeWindow(100.millis, 200.millis)
+
+      val expected = {
+        val stats = makeStats(values)
+        val counts = makeCounts(values, boundaries)
+
+        val exemplars =
+          makeExemplarValues(values, boundaries).map { value =>
+            ExemplarData.double(
+              exemplarAttributes,
+              Duration.Zero,
+              Some(traceContext),
+              value
+            )
+          }
+
+        PointData.histogram(
+          timeWindow,
+          attributes,
+          exemplars,
+          stats,
+          boundaries,
+          counts
+        )
+      }
+
+      val empty =
+        PointData.histogram(
+          timeWindow = timeWindow,
+          attributes = attributes,
+          exemplars = Vector.empty,
+          stats = None,
+          boundaries = boundaries,
+          counts = Vector.fill(boundaries.length + 1)(0L)
+        )
+
+      TestControl.executeEmbed {
+        for {
+          accumulator <- aggregator.createAccumulator
+          _ <- values.traverse_ { value =>
+            accumulator.record(value, exemplarAttributes, ctx)
+          }
+          r1 <- accumulator.aggregate(timeWindow, attributes, reset = true)
+          r2 <- accumulator.aggregate(timeWindow, attributes, reset = true)
+        } yield {
+          assertEquals(r1: Option[PointData], Some(expected))
+          assertEquals(r2: Option[PointData], Some(empty))
+        }
+      }
+    }
+  }
+
+  test("aggregate without reset - return a cumulative snapshot") {
+    PropF.forAllF(
+      Gen.listOf(Gen.double),
+      Gens.bucketBoundaries,
+      Gens.attributes,
+      Gens.attributes,
+      Gens.traceContext
+    ) { (values, boundaries, exemplarAttributes, attributes, traceContext) =>
+      val ctx = Context.root.updated(traceContextKey, traceContext)
+
+      val aggregator =
+        ExplicitBucketHistogramAggregator[IO, Double](
+          boundaries,
+          filter,
+          contextLookup
+        )
+
+      val timeWindow =
+        TimeWindow(100.millis, 200.millis)
+
+      def expected(values: List[Double]) = {
+        val stats = makeStats(values)
+        val counts = makeCounts(values, boundaries)
+
+        val exemplars =
+          makeExemplarValues(values, boundaries).map { value =>
+            ExemplarData.double(
+              exemplarAttributes,
+              Duration.Zero,
+              Some(traceContext),
+              value
+            )
+          }
+
+        PointData.histogram(
+          timeWindow,
+          attributes,
+          exemplars,
+          stats,
+          boundaries,
+          counts
+        )
+      }
+
+      TestControl.executeEmbed {
+        for {
+          accumulator <- aggregator.createAccumulator
+          _ <- values.traverse_ { value =>
+            accumulator.record(value, exemplarAttributes, ctx)
+          }
+          r1 <- accumulator.aggregate(timeWindow, attributes, reset = false)
+          _ <- values.traverse_ { value =>
+            accumulator.record(value, exemplarAttributes, ctx)
+          }
+          r2 <- accumulator.aggregate(timeWindow, attributes, reset = false)
+        } yield {
+          assertEquals(r1: Option[PointData], Some(expected(values)))
+          assertEquals(r2: Option[PointData], Some(expected(values ++ values)))
+        }
+      }
+    }
+  }
+
+  test("toMetricData") {
+    PropF.forAllF(
+      Gens.bucketBoundaries,
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.instrumentDescriptor,
+      Gen.listOf(Gens.histogramPointData),
+      Gens.aggregationTemporality
+    ) { (boundaries, resource, scope, descriptor, points, temporality) =>
+      type HistogramAggregator = Aggregator.Synchronous[IO, Double] {
+        type Point = PointData.Histogram
+      }
+
+      val aggregator =
+        ExplicitBucketHistogramAggregator[IO, Double](
+          boundaries,
+          filter,
+          contextLookup
+        ).asInstanceOf[HistogramAggregator]
+
+      val expected =
+        MetricData(
+          resource = resource,
+          scope = scope,
+          name = descriptor.name.toString,
+          description = descriptor.description,
+          unit = descriptor.unit,
+          data = MetricPoints.histogram(points.toVector, temporality)
+        )
+
+      for {
+        metricData <- aggregator.toMetricData(
+          resource,
+          scope,
+          MetricDescriptor(None, descriptor),
+          points.toVector,
+          temporality
+        )
+      } yield assertEquals(metricData, expected)
+    }
+  }
+
+  private def makeStats(values: List[Double]): Option[Histogram.Stats] =
+    Option.when(values.nonEmpty)(
+      PointData.Histogram.Stats(
+        sum = values.sum,
+        min = values.min,
+        max = values.max,
+        count = values.size.toLong
+      )
+    )
+
+  private def makeCounts(
+      values: List[Double],
+      boundaries: BucketBoundaries
+  ): Vector[Long] =
+    values.foldLeft(Vector.fill(boundaries.length + 1)(0L)) {
+      case (acc, value) =>
+        val i = boundaries.boundaries.indexWhere(b => value <= b)
+        val idx = if (i == -1) boundaries.length else i
+
+        acc.updated(idx, acc(idx) + 1L)
+    }
+
+  // retains last exemplar for each bucket
+  private def makeExemplarValues(
+      values: List[Double],
+      boundaries: BucketBoundaries
+  ): Vector[Double] =
+    values
+      .foldLeft(
+        Vector.fill(boundaries.length + 1)(Option.empty[Double])
+      ) { case (acc, value) =>
+        val i = boundaries.boundaries.indexWhere(b => value <= b)
+        val idx = if (i == -1) boundaries.length else i
+
+        acc.updated(idx, Some(value))
+      }
+      .collect { case Some(value) => value }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(30)
+      .withMaxSize(30)
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation |
| Java implementation | [ExplicitBucketHistogramAggregation.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ExplicitBucketHistogramAggregation.java)  |