### PR TITLE
sdk-exporter-metrics: add `OtlpHttpMetricExporter`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -368,7 +368,7 @@ lazy val `sdk-exporter-metrics` =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("sdk-exporter/metrics"))
-    .enablePlugins(NoPublishPlugin)
+    .enablePlugins(NoPublishPlugin, DockerComposeEnvPlugin)
     .dependsOn(
       `sdk-exporter-common` % "compile->compile;test->test",
       `sdk-metrics` % "compile->compile;test->test"
@@ -376,6 +376,7 @@ lazy val `sdk-exporter-metrics` =
     .settings(
       name := "otel4s-sdk-exporter-metrics",
       startYear := Some(2024),
+      dockerComposeEnvFile := crossProjectBaseDirectory.value / "docker" / "docker-compose.yml"
     )
     .jsSettings(scalaJSLinkerSettings)
     .nativeEnablePlugins(ScalaNativeBrewedConfigPlugin)

--- a/sdk-exporter/metrics/docker/config/otel-collector-config.yaml
+++ b/sdk-exporter/metrics/docker/config/otel-collector-config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols: # enable OpenTelemetry Protocol receiver, both gRPC and HTTP
+      grpc:
+        endpoint: 0.0.0.0:44317
+      http:
+        endpoint: 0.0.0.0:44318
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:9464"
+
+processors:
+  batch:
+    timeout: 0 # send data immediately
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]

--- a/sdk-exporter/metrics/docker/config/prometheus.yaml
+++ b/sdk-exporter/metrics/docker/config/prometheus.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 1s # Default is every 1 minute.
+
+scrape_configs:
+  - job_name: 'collector'
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+    static_configs:
+      - targets: ['collector:9464']

--- a/sdk-exporter/metrics/docker/docker-compose.yml
+++ b/sdk-exporter/metrics/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+services:
+  collector: # receives application metrics and traces via gRPC or HTTP protocol
+    image: otel/opentelemetry-collector-contrib:0.91.0
+    command: [ --config=/etc/otel-collector-config.yaml ]
+    volumes:
+      - "./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
+    ports:
+      - "44317:44317" # OTLP gRPC receiver
+      - "44318:44318" # OTLP http receiver
+      - "49464:9464" # OTLP /metrics endpoint for Prometheus
+    depends_on:
+      prometheus:
+        condition: service_healthy
+
+  prometheus: # stores metrics received from the OpenTelemetry Collector
+    image: prom/prometheus:v2.51.2
+    command: --config.file=/etc/prometheus/prometheus.yml --log.level=debug
+    volumes:
+      - "./config/prometheus.yaml:/etc/prometheus/prometheus.yml"
+    ports:
+      - "49090:9090"
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "-S", "http://localhost:9090/" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3

--- a/sdk-exporter/metrics/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/OtlpHttpMetricExporter.scala
+++ b/sdk-exporter/metrics/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/OtlpHttpMetricExporter.scala
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter
+package otlp
+package metrics
+
+import cats.Applicative
+import cats.Foldable
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Console
+import fs2.compression.Compression
+import fs2.io.net.Network
+import fs2.io.net.tls.TLSContext
+import org.http4s.Headers
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.syntax.literals._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+import org.typelevel.otel4s.sdk.metrics.exporter.CardinalityLimitSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
+
+import scala.concurrent.duration._
+
+/** Exports metrics via HTTP. Support `json` and `protobuf` encoding.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/protocol/exporter/]]
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/]]
+  */
+private final class OtlpHttpMetricExporter[F[_]: Applicative] private (
+    client: OtlpHttpClient[F, MetricData],
+    val aggregationTemporalitySelector: AggregationTemporalitySelector,
+    val defaultAggregationSelector: AggregationSelector,
+    val defaultCardinalityLimitSelector: CardinalityLimitSelector
+) extends MetricExporter.Push[F] {
+  val name: String = s"OtlpHttpMetricExporter{client=$client}"
+
+  def exportMetrics[G[_]: Foldable](metrics: G[MetricData]): F[Unit] =
+    client.doExport(metrics)
+
+  def flush: F[Unit] = Applicative[F].unit
+}
+
+object OtlpHttpMetricExporter {
+
+  private[otlp] object Defaults {
+    val Endpoint: Uri = uri"http://localhost:4318/v1/metrics"
+    val Timeout: FiniteDuration = 10.seconds
+    val GzipCompression: Boolean = false
+  }
+
+  /** A builder of [[OtlpHttpMetricExporter]] */
+  sealed trait Builder[F[_]] {
+
+    /** Sets the OTLP endpoint to connect to.
+      *
+      * The endpoint must start with either `http://` or `https://`, and include
+      * the full HTTP path.
+      *
+      * Default value is `http://localhost:4318/v1/metrics`.
+      */
+    def withEndpoint(endpoint: Uri): Builder[F]
+
+    /** Sets the maximum time to wait for the collector to process an exported
+      * batch of spans.
+      *
+      * Default value is `10 seconds`.
+      */
+    def withTimeout(timeout: FiniteDuration): Builder[F]
+
+    /** Enables Gzip compression.
+      *
+      * The compression is disabled by default.
+      */
+    def withGzip: Builder[F]
+
+    /** Disables Gzip compression. */
+    def withoutGzip: Builder[F]
+
+    /** Adds headers to requests. */
+    def addHeaders(headers: Headers): Builder[F]
+
+    /** Sets the explicit TLS context the HTTP client should use.
+      */
+    def withTLSContext(context: TLSContext[F]): Builder[F]
+
+    /** Sets the retry policy to use.
+      *
+      * Default retry policy is [[RetryPolicy.default]].
+      */
+    def withRetryPolicy(policy: RetryPolicy): Builder[F]
+
+    /** Configures the exporter to use the given encoding.
+      *
+      * Default encoding is `Protobuf`.
+      */
+    def withEncoding(encoding: HttpPayloadEncoding): Builder[F]
+
+    /** Sets the aggregation temporality selector to use.
+      *
+      * Default selector is
+      * [[org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector.alwaysCumulative AggregationTemporalitySelector.alwaysCumulative]].
+      */
+    def withAggregationTemporalitySelector(
+        selector: AggregationTemporalitySelector
+    ): Builder[F]
+
+    /** Sets the default aggregation selector to use.
+      *
+      * If no views are configured for a metric instrument, an aggregation
+      * provided by the selector will be used.
+      *
+      * Default selector is
+      * [[org.typelevel.otel4s.sdk.metrics.exporter.AggregationSelector.default AggregationSelector.default]].
+      */
+    def withDefaultAggregationSelector(
+        selector: AggregationSelector
+    ): Builder[F]
+
+    /** Sets the default cardinality limit selector to use.
+      *
+      * If no views are configured for a metric instrument, a limit provided by
+      * the selector will be used.
+      *
+      * Default selector is
+      * [[org.typelevel.otel4s.sdk.metrics.exporter.CardinalityLimitSelector.default CardinalityLimitSelector.default]].
+      */
+    def withDefaultCardinalityLimitSelector(
+        selector: CardinalityLimitSelector
+    ): Builder[F]
+
+    /** Configures the exporter to use the given client.
+      *
+      * @note
+      *   the 'timeout' and 'tlsContext' settings will be ignored. You must
+      *   preconfigure the client manually.
+      *
+      * @param client
+      *   the custom http4s client to use
+      */
+    def withClient(client: Client[F]): Builder[F]
+
+    /** Creates a [[OtlpHttpMetricExporter]] using the configuration of this
+      * builder.
+      */
+    def build: Resource[F, MetricExporter.Push[F]]
+  }
+
+  /** Creates a [[Builder]] of [[OtlpHttpMetricExporter]] with the default
+    * configuration:
+    *   - encoding: `Protobuf`
+    *   - endpoint: `http://localhost:4318/v1/metrics`
+    *   - timeout: `10 seconds`
+    *   - retry policy: 5 exponential attempts, initial backoff is `1 second`,
+    *     max backoff is `5 seconds`
+    */
+  def builder[F[_]: Async: Network: Compression: Console]: Builder[F] =
+    BuilderImpl(
+      encoding = HttpPayloadEncoding.Protobuf,
+      endpoint = Defaults.Endpoint,
+      gzipCompression = Defaults.GzipCompression,
+      timeout = Defaults.Timeout,
+      headers = Headers.empty,
+      retryPolicy = RetryPolicy.default,
+      aggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative,
+      defaultAggregationSelector = AggregationSelector.default,
+      defaultCardinalityLimitSelector = CardinalityLimitSelector.default,
+      tlsContext = None,
+      client = None
+    )
+
+  private final case class BuilderImpl[
+      F[_]: Async: Network: Compression: Console
+  ](
+      encoding: HttpPayloadEncoding,
+      endpoint: Uri,
+      gzipCompression: Boolean,
+      timeout: FiniteDuration,
+      headers: Headers,
+      retryPolicy: RetryPolicy,
+      aggregationTemporalitySelector: AggregationTemporalitySelector,
+      defaultAggregationSelector: AggregationSelector,
+      defaultCardinalityLimitSelector: CardinalityLimitSelector,
+      tlsContext: Option[TLSContext[F]],
+      client: Option[Client[F]]
+  ) extends Builder[F] {
+
+    def withTimeout(timeout: FiniteDuration): Builder[F] =
+      copy(timeout = timeout)
+
+    def withEndpoint(endpoint: Uri): Builder[F] =
+      copy(endpoint = endpoint)
+
+    def addHeaders(headers: Headers): Builder[F] =
+      copy(headers = this.headers ++ headers)
+
+    def withGzip: Builder[F] =
+      copy(gzipCompression = true)
+
+    def withoutGzip: Builder[F] =
+      copy(gzipCompression = false)
+
+    def withTLSContext(context: TLSContext[F]): Builder[F] =
+      copy(tlsContext = Some(context))
+
+    def withRetryPolicy(policy: RetryPolicy): Builder[F] =
+      copy(retryPolicy = policy)
+
+    def withEncoding(encoding: HttpPayloadEncoding): Builder[F] =
+      copy(encoding = encoding)
+
+    def withAggregationTemporalitySelector(
+        selector: AggregationTemporalitySelector
+    ): Builder[F] =
+      copy(aggregationTemporalitySelector = selector)
+
+    def withDefaultAggregationSelector(
+        selector: AggregationSelector
+    ): Builder[F] =
+      copy(defaultAggregationSelector = selector)
+
+    def withDefaultCardinalityLimitSelector(
+        selector: CardinalityLimitSelector
+    ): Builder[F] =
+      copy(defaultCardinalityLimitSelector = selector)
+
+    def withClient(client: Client[F]): Builder[F] =
+      copy(client = Some(client))
+
+    def build: Resource[F, MetricExporter.Push[F]] = {
+      import MetricsProtoEncoder.exportMetricsRequest
+      import MetricsProtoEncoder.jsonPrinter
+
+      for {
+        client <- OtlpHttpClient.create[F, MetricData](
+          encoding,
+          endpoint,
+          timeout,
+          headers,
+          gzipCompression,
+          retryPolicy,
+          tlsContext,
+          client
+        )
+      } yield new OtlpHttpMetricExporter[F](
+        client,
+        aggregationTemporalitySelector,
+        defaultAggregationSelector,
+        defaultCardinalityLimitSelector
+      )
+    }
+  }
+
+}

--- a/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/OtlpHttpMetricExporterSuite.scala
+++ b/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/OtlpHttpMetricExporterSuite.scala
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter.otlp.metrics
+
+import cats.data.NonEmptyVector
+import cats.effect.IO
+import cats.syntax.foldable._
+import com.comcast.ip4s.IpAddress
+import io.circe.Decoder
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.http4s.Headers
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers.`X-Forwarded-For`
+import org.http4s.syntax.literals._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.AttributeType
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.exporter.RetryPolicy
+import org.typelevel.otel4s.sdk.exporter.SuiteRuntimePlatform
+import org.typelevel.otel4s.sdk.exporter.otlp.HttpPayloadEncoding
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.data.PointData
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+
+import scala.concurrent.duration._
+
+class OtlpHttpMetricExporterSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with SuiteRuntimePlatform {
+
+  import OtlpHttpMetricExporterSuite._
+
+  private implicit val encodingArbitrary: Arbitrary[HttpPayloadEncoding] =
+    Arbitrary(Gen.oneOf(HttpPayloadEncoding.Protobuf, HttpPayloadEncoding.Json))
+
+  test("represent builder parameters in the name") {
+    PropF.forAllF { (encoding: HttpPayloadEncoding) =>
+      val enc = encoding match {
+        case HttpPayloadEncoding.Json     => "Json"
+        case HttpPayloadEncoding.Protobuf => "Protobuf"
+      }
+
+      val expected =
+        s"OtlpHttpMetricExporter{client=OtlpHttpClient{encoding=$enc, " +
+          "endpoint=https://localhost:4318/api/v1/metrics, " +
+          "timeout=5 seconds, " +
+          "gzipCompression=true, " +
+          "headers={X-Forwarded-For: 127.0.0.1}}}"
+
+      OtlpHttpMetricExporter
+        .builder[IO]
+        .addHeaders(
+          Headers(`X-Forwarded-For`(IpAddress.fromString("127.0.0.1")))
+        )
+        .withEndpoint(uri"https://localhost:4318/api/v1/metrics")
+        .withTimeout(5.seconds)
+        .withGzip
+        .withEncoding(encoding)
+        .build
+        .use { exporter =>
+          IO(assertEquals(exporter.name, expected))
+        }
+    }
+  }
+
+  test("export metrics") {
+    PropF.forAllF { (md: MetricData, encoding: HttpPayloadEncoding) =>
+      val metric = MetricData(
+        md.resource,
+        md.instrumentationScope,
+        md.name,
+        md.description,
+        md.unit,
+        md.data match {
+          case sum: MetricPoints.Sum =>
+            val monotonic = sum.aggregationTemporality match {
+              case AggregationTemporality.Delta      => true
+              case AggregationTemporality.Cumulative => false
+            }
+
+            MetricPoints.sum(
+              adaptNumberPoints(sum.points),
+              monotonic,
+              sum.aggregationTemporality
+            )
+
+          case gauge: MetricPoints.Gauge =>
+            MetricPoints.gauge(adaptNumberPoints(gauge.points))
+
+          case histogram: MetricPoints.Histogram =>
+            MetricPoints.histogram(
+              adaptHistogramPoints(histogram.points),
+              AggregationTemporality.Cumulative
+            )
+        }
+      )
+
+      val expectedSeries: Vector[PrometheusSeries] = {
+        val const = Map(
+          "instance" -> "collector:9464",
+          "job" -> "collector",
+          "__name__" -> metricName(metric)
+        )
+
+        metric.data match {
+          case sum: MetricPoints.Sum =>
+            numberPointsToSeries(const, sum.points)
+
+          case gauge: MetricPoints.Gauge =>
+            numberPointsToSeries(const, gauge.points)
+
+          case histogram: MetricPoints.Histogram =>
+            histogramPointsToSeries(const, histogram.points)
+        }
+      }
+
+      OtlpHttpMetricExporter
+        .builder[IO]
+        .withEncoding(encoding)
+        .withEndpoint(uri"http://localhost:44318/v1/metrics")
+        .withTimeout(20.seconds)
+        .withRetryPolicy(
+          RetryPolicy.builder
+            .withInitialBackoff(2.second)
+            .withMaxBackoff(20.seconds)
+            .build
+        )
+        .build
+        .use(exporter => exporter.exportMetrics(List(metric)))
+        .flatMap { _ =>
+          findMetrics(metric)
+            .delayBy(1.second)
+            .flatMap { series =>
+              val result = series.map(s => s.metric -> s.value).toMap
+              val expected = expectedSeries.map(s => s.metric -> s.value).toMap
+//IO.println(result) >> IO.println("\n\n") >> IO.println(expected)>> IO.println("\n\n") >>
+              IO(assertEquals(result, expected))
+            }
+        }
+    }
+  }
+
+  private def findMetrics(metric: MetricData): IO[Vector[PrometheusSeries]] =
+    EmberClientBuilder.default[IO].build.use { client =>
+      import org.http4s.syntax.literals._
+      import org.http4s.circe.CirceEntityCodec._
+      import io.circe.generic.auto._
+
+      val query = metricName(metric)
+
+      val url = (uri"http://localhost:49090" / "api" / "v1" / "query")
+        .withQueryParam("query", query)
+
+      def loop(attempts: Int): IO[Vector[PrometheusSeries]] =
+        client
+          .expectOr[PrometheusResponse](url) { response =>
+            for {
+              body <- response.as[String]
+              _ <- IO.println(
+                s"Cannot retrieve metrics due. Status ${response.status} body ${body}"
+              )
+            } yield new RuntimeException(
+              s"Cannot retrieve metrics due. Status ${response.status} body ${body}"
+            )
+          }
+          .handleErrorWith { error =>
+            IO.println(s"Cannot retrieve metrics due to ${error.getMessage}")
+              .as(PrometheusResponse("", PrometheusResult("", Vector.empty)))
+          }
+          .flatMap { response =>
+            if (response.data.result.isEmpty && attempts > 0)
+              loop(attempts - 1).delayBy(300.millis)
+            else if (response.data.result.isEmpty)
+              IO.println(
+                s"Couldn't find metrics for [$query] after 10 attempts"
+              ).as(response.data.result)
+            else
+              IO.pure(response.data.result)
+          }
+
+      loop(10)
+    }
+
+  private def metricName(metric: MetricData): String = {
+    val suffix = metric.data match {
+      case _: MetricPoints.Histogram          => "_bucket"
+      case s: MetricPoints.Sum if s.monotonic => "_total"
+      case _                                  => ""
+    }
+
+    val prefix = if (metric.name.headOption.exists(_.isDigit)) "_" else ""
+
+    // prometheus expands these units
+    val unit = metric.unit
+      .map {
+        case "ms"  => "milliseconds"
+        case "s"   => "seconds"
+        case "m"   => "minutes"
+        case "h"   => "hours"
+        case "d"   => "days"
+        case other => other
+      }
+      .foldMap(unit => "_" + unit)
+
+    prefix + metric.name + unit + suffix
+  }
+
+  private def numberPointsToSeries(
+      const: Map[String, String],
+      points: NonEmptyVector[PointData.NumberPoint]
+  ): Vector[PrometheusSeries] =
+    points.toVector
+      .groupBy(_.attributes)
+      .map { case (attributes, points) =>
+        val attrs =
+          attributes.map(a => attributeToPair(a)).toMap
+
+        PrometheusSeries(
+          const ++ attrs,
+          points.head match {
+            case long: PointData.LongNumber =>
+              PrometheusValue(long.value.toString)
+            case double: PointData.DoubleNumber =>
+              PrometheusValue(BigDecimal(double.value).toString)
+          }
+        )
+      }
+      .toVector
+
+  private def histogramPointsToSeries(
+      const: Map[String, String],
+      points: NonEmptyVector[PointData.Histogram]
+  ): Vector[PrometheusSeries] =
+    points.toVector
+      .groupBy(_.attributes)
+      .flatMap { case (attributes, points) =>
+        val attrs =
+          attributes.map(a => attributeToPair(a)).toMap
+
+        points.flatMap { point =>
+          val all = point.boundaries.boundaries.zipWithIndex.map {
+            case (boundary, idx) =>
+              PrometheusSeries(
+                const ++ attrs ++ Map("le" -> boundary.toString),
+                PrometheusValue(point.counts.take(idx + 1).sum.toString)
+              )
+          }
+
+          val inf = PrometheusSeries(
+            const ++ attrs ++ Map("le" -> "+Inf"),
+            PrometheusValue(point.counts.sum.toString)
+          )
+
+          all :+ inf
+        }
+      }
+      .toVector
+
+  private def attributeToPair(attribute: Attribute[_]): (String, String) = {
+    // name
+    val key = attribute.key.name
+    val prefix = if (key.headOption.exists(_.isDigit)) "key_" else ""
+    val name = prefix + key
+
+    // value
+    def primitive: String = attribute.value.toString
+
+    def seq[A](escape: Boolean): String =
+      attribute.value
+        .asInstanceOf[Seq[A]]
+        .map(v => if (escape) "\"" + v + "\"" else v)
+        .mkString("[", ",", "]")
+
+    val value = attribute.key.`type` match {
+      case AttributeType.Boolean    => primitive
+      case AttributeType.Double     => primitive
+      case AttributeType.Long       => primitive
+      case AttributeType.String     => primitive
+      case AttributeType.BooleanSeq => seq[Boolean](escape = false)
+      case AttributeType.DoubleSeq  => seq[Boolean](escape = false)
+      case AttributeType.LongSeq    => seq[Long](escape = false)
+      case AttributeType.StringSeq  => seq[String](escape = true)
+    }
+
+    // result
+    (name, value)
+  }
+
+  // it's hard to deal with big numeric values due to various encoding pitfalls
+  // so we simplify the numbers
+  private def adaptAttributes(attributes: Attributes): Attributes = {
+    val adapted = attributes.map { attribute =>
+      val name = attribute.key.name
+      attribute.key.`type` match {
+        case AttributeType.Double    => Attribute(name, 1.1)
+        case AttributeType.DoubleSeq => Attribute(name, Seq(1.1))
+        case AttributeType.Long      => Attribute(name, 1L)
+        case AttributeType.LongSeq   => Attribute(name, Seq(1L))
+        case _                       => attribute
+      }
+    }
+
+    adapted.to(Attributes)
+  }
+
+  private def adaptNumberPoints(
+      points: NonEmptyVector[PointData.NumberPoint]
+  ): NonEmptyVector[PointData.NumberPoint] =
+    NonEmptyVector.one(
+      points.map {
+        case long: PointData.LongNumber =>
+          PointData.longNumber(
+            long.timeWindow,
+            adaptAttributes(long.attributes),
+            long.exemplars,
+            math.max(math.min(long.value, 100L), -100L)
+          )
+
+        case double: PointData.DoubleNumber =>
+          PointData.doubleNumber(
+            double.timeWindow,
+            adaptAttributes(double.attributes),
+            double.exemplars,
+            math.max(math.min(double.value, 100.0), -100.0)
+          )
+      }.head
+    )
+
+  private def adaptHistogramPoints(
+      points: NonEmptyVector[PointData.Histogram]
+  ): NonEmptyVector[PointData.Histogram] =
+    NonEmptyVector.one(
+      points.map { point =>
+        PointData.histogram(
+          point.timeWindow,
+          adaptAttributes(point.attributes),
+          point.exemplars,
+          point.stats,
+          point.boundaries,
+          point.counts
+        )
+      }.head
+    )
+
+  override def munitIOTimeout: Duration =
+    1.minute
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(10)
+      .withMaxSize(10)
+
+}
+
+object OtlpHttpMetricExporterSuite {
+
+  implicit val prometheusValueDecoder: Decoder[PrometheusValue] =
+    Decoder.instance { cursor =>
+      for {
+        // unixTimestamp <- cursor.downN(0).as[Json] // either Long or Double
+        value <- cursor.downN(1).as[String]
+      } yield PrometheusValue(value)
+    }
+
+  final case class PrometheusValue(value: String)
+
+  final case class PrometheusSeries(
+      metric: Map[String, String],
+      value: PrometheusValue
+  )
+
+  final case class PrometheusResult(
+      resultType: String,
+      result: Vector[PrometheusSeries]
+  )
+
+  final case class PrometheusResponse(
+      status: String,
+      data: PrometheusResult
+  )
+
+}

--- a/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigure.scala
+++ b/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigure.scala
@@ -179,8 +179,8 @@ object OtlpSpanExporterAutoConfigure {
     *   HTTP client
     *
     * @note
-    *   the 'timeout' and 'tlsContext' context settings will be ignored. You
-    *   must preconfigure the client manually.
+    *   the 'timeout' and 'tlsContext' settings will be ignored. You must
+    *   preconfigure the client manually.
     *
     * @example
     *   {{{

--- a/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/MetricsTestkit.scala
+++ b/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/MetricsTestkit.scala
@@ -59,12 +59,12 @@ object MetricsTestkit {
     * @param defaultAggregationSelector
     *   the preferred aggregation for the given instrument type. If no views are
     *   configured for a metric instrument, an aggregation provided by the
-    *   selector will be used.
+    *   selector will be used
     *
     * @param defaultCardinalityLimitSelector
     *   the preferred cardinality limit for the given instrument type. If no
-    *   views are configured for a metric instrument, an aggregation provided by
-    *   the selector will be used.
+    *   views are configured for a metric instrument, a limit provided by the
+    *   selector will be used
     */
   def inMemory[F[_]: Async: Console: AskContext](
       customize: SdkMeterProvider.Builder[F] => SdkMeterProvider.Builder[F] =

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/PointData.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/PointData.scala
@@ -261,14 +261,14 @@ object PointData {
 
         s"PointData.$prefix{" +
           s"timeWindow=${data.timeWindow}, " +
-          s"attribute=${data.attributes}, " +
+          s"attributes=${data.attributes}, " +
           s"exemplars=${data.exemplars}, " +
           s"value=${data.value}}"
 
       case data: Histogram =>
         "PointData.Histogram{" +
           s"timeWindow=${data.timeWindow}, " +
-          s"attribute=${data.attributes}, " +
+          s"attributes=${data.attributes}, " +
           s"exemplars=${data.exemplars}, " +
           s"stats=${data.stats}, " +
           s"boundaries=${data.boundaries}, " +

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/PointDataSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/PointDataSuite.scala
@@ -42,14 +42,14 @@ class PointDataSuite extends DisciplineSuite {
 
           s"PointData.$prefix{" +
             s"timeWindow=${data.timeWindow}, " +
-            s"attribute=${data.attributes}, " +
+            s"attributes=${data.attributes}, " +
             s"exemplars=${data.exemplars}, " +
             s"value=${data.value}}"
 
         case data: PointData.Histogram =>
           "PointData.Histogram{" +
             s"timeWindow=${data.timeWindow}, " +
-            s"attribute=${data.attributes}, " +
+            s"attributes=${data.attributes}, " +
             s"exemplars=${data.exemplars}, " +
             s"stats=${data.stats}, " +
             s"boundaries=${data.boundaries}, " +

--- a/sdk/testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/OpenTelemetrySdkTestkit.scala
+++ b/sdk/testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/OpenTelemetrySdkTestkit.scala
@@ -76,12 +76,12 @@ object OpenTelemetrySdkTestkit {
     * @param defaultAggregationSelector
     *   the preferred aggregation for the given instrument type. If no views are
     *   configured for a metric instrument, an aggregation provided by the
-    *   selector will be used.
+    *   selector will be used
     *
     * @param defaultCardinalityLimitSelector
     *   the preferred cardinality limit for the given instrument type. If no
-    *   views are configured for a metric instrument, an aggregation provided by
-    *   the selector will be used.
+    *   views are configured for a metric instrument, a limit provided by the
+    *   selector will be used
     */
   def inMemory[F[_]: Async: Parallel: Console: LocalContextProvider](
       customizeMeterProviderBuilder: Customizer[SdkMeterProvider.Builder[F]] =


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Java implementation | [OtlpHttpMetricExporter.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporter.java) <br> [OtlpHttpMetricExporterBuilder.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/metrics/OtlpHttpMetricExporterBuilder.java) <br>  |
