### PR TITLE
sdk-exporter: add `MetricReader`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/MetricExporter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/MetricExporter.scala
@@ -36,10 +36,16 @@ trait MetricExporter[F[_]] {
   def aggregationTemporalitySelector: AggregationTemporalitySelector
 
   /** The preferred aggregation for the given instrument.
+    *
+    * If no views are configured for a metric instrument, an aggregation
+    * provided by the selector will be used.
     */
   def defaultAggregationSelector: AggregationSelector
 
   /** The preferred cardinality limit for the given instrument.
+    *
+    * If no views are configured for a metric instrument, a limit provided by
+    * the selector will be used.
     */
   def defaultCardinalityLimitSelector: CardinalityLimitSelector
 

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/MetricReader.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/MetricReader.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package exporter
+
+import cats.data.NonEmptyVector
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+
+/** A reader of metrics that collects metrics from the associated metric
+  * producers.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+trait MetricReader[F[_]] {
+
+  /** The preferred aggregation temporality for the given instrument.
+    */
+  def aggregationTemporalitySelector: AggregationTemporalitySelector
+
+  /** The preferred aggregation for the given instrument.
+    *
+    * If no views are configured for a metric instrument, an aggregation
+    * provided by the selector will be used.
+    */
+  def defaultAggregationSelector: AggregationSelector
+
+  /** The preferred cardinality limit for the given instrument.
+    *
+    * If no views are configured for a metric instrument, a limit provided by
+    * the selector will be used.
+    */
+  def defaultCardinalityLimitSelector: CardinalityLimitSelector
+
+  /** Sets the metric producer to be used by this reader.
+    *
+    * @note
+    *   this should only be called by the SDK and should be considered an
+    *   internal API. The producers can be configured only once.
+    *
+    * @param producers
+    *   the producers to use to collect the metrics
+    */
+  def register(producers: NonEmptyVector[MetricProducer[F]]): F[Unit]
+
+  /** Collects all metrics from the associated metric producers.
+    */
+  def collectAllMetrics: F[Vector[MetricData]]
+
+  /** Collects all metrics and sends them to the exporter. Flushes the exporter
+    * too.
+    */
+  def forceFlush: F[Unit]
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader |
| Java implementation | [MetricReader.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricReader.java)  |