### PR TITLE
core-trace: make `Backend#end` public

### DIFF
--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -154,8 +154,8 @@ object Span {
     def setStatus(status: StatusCode): F[Unit]
     def setStatus(status: StatusCode, description: String): F[Unit]
 
-    private[otel4s] def end: F[Unit]
-    private[otel4s] def end(timestamp: FiniteDuration): F[Unit]
+    def end: F[Unit]
+    def end(timestamp: FiniteDuration): F[Unit]
 
     /** Modify the context `F` using the transformation `f`. */
     def mapK[G[_]](f: F ~> G): Backend[G] = new Backend.MappedK(this)(f)
@@ -224,8 +224,8 @@ object Span {
         def setStatus(status: StatusCode): F[Unit] = unit
         def setStatus(status: StatusCode, description: String): F[Unit] = unit
 
-        private[otel4s] def end: F[Unit] = unit
-        private[otel4s] def end(timestamp: FiniteDuration): F[Unit] = unit
+        def end: F[Unit] = unit
+        def end(timestamp: FiniteDuration): F[Unit] = unit
       }
 
     /** Implementation for [[Backend.mapK]]. */
@@ -263,8 +263,8 @@ object Span {
         f(backend.setStatus(status))
       def setStatus(status: StatusCode, description: String): G[Unit] =
         f(backend.setStatus(status, description))
-      private[otel4s] def end: G[Unit] = f(backend.end)
-      private[otel4s] def end(timestamp: FiniteDuration): G[Unit] =
+      def end: G[Unit] = f(backend.end)
+      def end(timestamp: FiniteDuration): G[Unit] =
         f(backend.end(timestamp))
     }
   }

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
@@ -111,10 +111,10 @@ private[oteljava] class SpanBackendImpl[F[_]: Sync](
       ()
     }
 
-  private[otel4s] def end: F[Unit] =
+  def end: F[Unit] =
     Sync[F].realTime.flatMap(now => end(now))
 
-  private[otel4s] def end(timestamp: FiniteDuration): F[Unit] =
+  def end(timestamp: FiniteDuration): F[Unit] =
     Sync[F].delay(jSpan.end(timestamp.length, timestamp.unit))
 
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -140,18 +140,17 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
       s.copy(status = StatusData(status, description))
     }.void
 
-  private[otel4s] def end: F[Unit] =
+  def end: F[Unit] =
     for {
       now <- Clock[F].realTime
       _ <- end(now)
     } yield ()
 
-  private[otel4s] def end(timestamp: FiniteDuration): F[Unit] = {
+  def end(timestamp: FiniteDuration): F[Unit] =
     for {
       updated <- updateState("end")(s => s.copy(endTimestamp = Some(timestamp)))
       _ <- toSpanData.flatMap(span => spanProcessor.onEnd(span)).whenA(updated)
     } yield ()
-  }
 
   private def addTimedEvent(event: EventData): F[Unit] =
     updateState("addEvent")(s => s.copy(events = s.events :+ event)).void

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
@@ -187,10 +187,10 @@ class SimpleSpanProcessorSuite
       def setStatus(status: StatusCode, description: String): IO[Unit] =
         noopBackend.setStatus(status, description)
 
-      private[otel4s] def end: IO[Unit] =
+      def end: IO[Unit] =
         noopBackend.end
 
-      private[otel4s] def end(timestamp: FiniteDuration): IO[Unit] =
+      def end(timestamp: FiniteDuration): IO[Unit] =
         noopBackend.end(timestamp)
     }
   }


### PR DESCRIPTION
Closes #204.

A few points:
1) How many people need to implement their own `Backend`? It's less relevant since we have an `sdk-trace` module.
2) Initially, `Span` had no public `end` API. The lifecycle has been managed automatically. So the `Backend#end` was private to prevent a user from ending a span by calling `backend.end`. Currently, `Span` has a public `end` API, so I don't think we should keep `Backend#end` private too. 