### PR TITLE
sdk-exporter-trace: add `OtlpHttpSpanExporter.Builder#withClient`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.6"
+ThisBuild / tlBaseVersion := "0.7"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporter.scala
+++ b/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/OtlpHttpSpanExporter.scala
@@ -109,6 +109,17 @@ object OtlpHttpSpanExporter {
       */
     def withEncoding(encoding: HttpPayloadEncoding): Builder[F]
 
+    /** Configures the exporter to use the given client.
+      *
+      * @note
+      *   the 'timeout' and 'tlsContext' settings will be ignored. You must
+      *   preconfigure the client manually.
+      *
+      * @param client
+      *   the custom http4s client to use
+      */
+    def withClient(client: Client[F]): Builder[F]
+
     /** Creates a [[OtlpHttpSpanExporter]] using the configuration of this
       * builder.
       */


### PR DESCRIPTION
The follow-up to https://github.com/typelevel/otel4s/pull/578.

I added `withClient` to the `BuilderImpl` class but forgot to add it to the `Builder` trait.