### PR TITLE
sdk-metrics: add `PeriodMetricReader`

### DIFF
--- a/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/test/InMemoryConsole.scala
+++ b/sdk/common/src/test/scala/org/typelevel/otel4s/sdk/test/InMemoryConsole.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.sdk.trace.exporter
+package org.typelevel.otel4s.sdk.test
 
 import cats._
 import cats.effect.kernel.Async

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReader.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReader.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+package exporter
+
+import cats.data.NonEmptyVector
+import cats.effect.Ref
+import cats.effect.Resource
+import cats.effect.Temporal
+import cats.effect.std.Console
+import cats.effect.syntax.spawn._
+import cats.effect.syntax.temporal._
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+
+import scala.concurrent.duration.FiniteDuration
+
+/** A metric reader that collects and exports metrics with the given interval.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/sdk/#periodic-exporting-metricreader]]
+  *
+  * @param metricProducers
+  *   the metric producers to collect metrics from
+  *
+  * @param exporter
+  *   the exporter to send the collected metrics to
+  *
+  * @param config
+  *   the interval and timeout configurations
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+private class PeriodicMetricReader[F[_]: Temporal: Console] private (
+    metricProducers: Ref[F, Vector[MetricProducer[F]]],
+    exporter: MetricExporter[F],
+    config: PeriodicMetricReader.Config
+) extends MetricReader[F] {
+
+  def defaultAggregationSelector: AggregationSelector =
+    exporter.defaultAggregationSelector
+
+  def aggregationTemporalitySelector: AggregationTemporalitySelector =
+    exporter.aggregationTemporalitySelector
+
+  def defaultCardinalityLimitSelector: CardinalityLimitSelector =
+    exporter.defaultCardinalityLimitSelector
+
+  def register(producers: NonEmptyVector[MetricProducer[F]]): F[Unit] = {
+    def warn =
+      Console[F].errorln(
+        "MetricProducers are already registered at this periodic metric reader"
+      )
+
+    metricProducers.flatModify { current =>
+      if (current.isEmpty) (producers.toVector, Temporal[F].unit)
+      else (current, warn)
+    }
+  }
+
+  def collectAllMetrics: F[Vector[MetricData]] =
+    metricProducers.get.flatMap {
+      case producers if producers.nonEmpty =>
+        producers.flatTraverse(_.produce)
+
+      case _ =>
+        Console[F]
+          .errorln(
+            "The PeriodicMetricReader is running, but producers aren't configured yet. Nothing to export"
+          )
+          .as(Vector.empty)
+    }
+
+  def forceFlush: F[Unit] =
+    for {
+      _ <- exportMetrics
+      _ <- exporter.flush
+    } yield ()
+
+  override def toString: String =
+    s"PeriodicMetricReader{exporter=$exporter, interval=${config.exportInterval}, timeout=${config.exportTimeout}}"
+
+  private def worker: F[Unit] =
+    exportMetrics.delayBy(config.exportInterval).foreverM[Unit]
+
+  private def exportMetrics: F[Unit] = {
+    val doExport =
+      for {
+        metrics <- collectAllMetrics
+        _ <- exporter.exportMetrics(metrics).whenA(metrics.nonEmpty)
+      } yield ()
+
+    doExport
+      .timeoutTo(
+        config.exportTimeout,
+        Console[F].errorln(
+          s"PeriodicMetricReader: the export attempt has been canceled after [${config.exportTimeout}]"
+        )
+      )
+      .handleErrorWith { e =>
+        Console[F].errorln(
+          s"PeriodicMetricReader: the export has failed: ${e.getMessage}\n${e.getStackTrace.mkString("\n")}\n"
+        )
+      }
+  }
+
+}
+
+private object PeriodicMetricReader {
+
+  private final case class Config(
+      exportInterval: FiniteDuration,
+      exportTimeout: FiniteDuration
+  )
+
+  /** Creates a period metric reader that collects and exports metrics with the
+    * given interval.
+    *
+    * @param exporter
+    *   the exporter to send the collected metrics to
+    *
+    * @param interval
+    *   how often to export the metrics
+    *
+    * @param timeout
+    *   how long the export can run before it is cancelled
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def create[F[_]: Temporal: Console](
+      exporter: MetricExporter[F],
+      interval: FiniteDuration,
+      timeout: FiniteDuration
+  ): Resource[F, MetricReader[F]] =
+    for {
+      metricProducers <- Resource.eval(Ref.empty[F, Vector[MetricProducer[F]]])
+      reader = new PeriodicMetricReader(
+        metricProducers,
+        exporter,
+        Config(interval, timeout)
+      )
+      _ <- reader.worker.background
+    } yield reader
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/InMemoryMetricExporter.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/InMemoryMetricExporter.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import cats.Foldable
+import cats.Monad
+import cats.effect.Concurrent
+import cats.effect.std.Queue
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+
+final class InMemoryMetricExporter[F[_]: Monad] private (
+    queue: Queue[F, MetricData],
+    val aggregationTemporalitySelector: AggregationTemporalitySelector,
+    val defaultAggregationSelector: AggregationSelector,
+    val defaultCardinalityLimitSelector: CardinalityLimitSelector
+) extends MetricExporter[F] {
+
+  def name: String = "InMemoryMetricExporter"
+
+  def exportMetrics[G[_]: Foldable](metrics: G[MetricData]): F[Unit] =
+    metrics.traverse_(metric => queue.offer(metric))
+
+  def flush: F[Unit] =
+    Monad[F].unit
+
+  def exportedMetrics: F[List[MetricData]] =
+    queue.tryTakeN(None)
+
+  def reset: F[Unit] =
+    queue.tryTakeN(None).void
+}
+
+object InMemoryMetricExporter {
+
+  def create[F[_]: Concurrent](
+      capacity: Option[Int],
+      aggregationTemporalitySelector: AggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative,
+      defaultAggregationSelector: AggregationSelector =
+        AggregationSelector.default,
+      defaultCardinalityLimitSelector: CardinalityLimitSelector =
+        CardinalityLimitSelector.default
+  ): F[InMemoryMetricExporter[F]] =
+    for {
+      queue <- capacity.fold(Queue.unbounded[F, MetricData])(Queue.bounded(_))
+    } yield new InMemoryMetricExporter[F](
+      queue,
+      aggregationTemporalitySelector,
+      defaultAggregationSelector,
+      defaultCardinalityLimitSelector
+    )
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReaderSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReaderSuite.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import cats.data.NonEmptyVector
+import cats.effect.IO
+import cats.effect.Ref
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.effect.testkit.TestControl
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Arbitraries._
+import org.typelevel.otel4s.sdk.test.InMemoryConsole
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+class PeriodicMetricReaderSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite {
+
+  test("export metrics with a fixed interval") {
+    PropF.forAllF { (metrics: List[MetricData]) =>
+      val producer = constProducer(metrics)
+
+      TestControl.executeEmbed {
+        for {
+          exporter <- InMemoryMetricExporter.create[IO](None)
+          _ <- makeReader(exporter).use { reader =>
+            for {
+              _ <- reader.register(NonEmptyVector.one(producer))
+
+              // should be empty
+              _ <- exporter.exportedMetrics.assertEquals(Nil)
+
+              // first export
+              _ <- IO.sleep(40.seconds)
+              _ <- exporter.exportedMetrics.assertEquals(metrics)
+
+              // in-between export interval, should export nothing
+              _ <- IO.sleep(10.seconds)
+              _ <- exporter.exportedMetrics.assertEquals(Nil)
+
+              // second exporter
+              _ <- IO.sleep(15.seconds)
+              _ <- exporter.exportedMetrics.assertEquals(metrics)
+            } yield ()
+          }
+
+          // outside of the periodic reader lifecycle, should be empty
+          _ <- IO.sleep(15.seconds)
+          _ <- exporter.exportedMetrics.assertEquals(Nil)
+        } yield ()
+      }
+    }
+  }
+
+  test("accept first register and ignore any subsequent one") {
+    PropF.forAllF { (metrics: List[MetricData]) =>
+      val producer = constProducer(metrics)
+
+      TestControl.executeEmbed {
+        InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
+          val consoleEntries = {
+            import org.typelevel.otel4s.sdk.test.InMemoryConsole._
+
+            List(
+              Entry(
+                Op.Errorln,
+                "MetricProducers are already registered at this periodic metric reader"
+              )
+            )
+          }
+
+          for {
+            exporter <- InMemoryMetricExporter.create[IO](None)
+            _ <- makeReader(exporter).use { reader =>
+              for {
+                _ <- reader.register(NonEmptyVector.one(producer))
+                _ <- reader.register(NonEmptyVector.one(producer))
+
+                _ <- C.entries.assertEquals(consoleEntries)
+
+                // if both producers are registered, there will be 'metrics ++ metrics'
+                _ <- IO.sleep(40.seconds)
+                _ <- exporter.exportedMetrics.assertEquals(metrics)
+              } yield ()
+            }
+          } yield ()
+        }
+      }
+    }
+  }
+
+  test("keep running when a producer fails to produce metrics") {
+    PropF.forAllF { (metrics: List[MetricData]) =>
+      val e = new RuntimeException("Something went wrong") with NoStackTrace
+
+      def producer(throwError: Ref[IO, Boolean]): MetricProducer[IO] =
+        new MetricProducer[IO] {
+          def produce: IO[Vector[MetricData]] =
+            throwError.get.ifM(
+              IO.raiseError(e),
+              IO.pure(metrics.toVector)
+            )
+        }
+
+      TestControl.executeEmbed {
+        InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
+          val consoleEntries = {
+            import org.typelevel.otel4s.sdk.test.InMemoryConsole._
+
+            List(
+              Entry(
+                Op.Errorln,
+                s"PeriodicMetricReader: the export has failed: ${e.getMessage}\n${e.getStackTrace.mkString("\n")}\n"
+              )
+            )
+          }
+
+          for {
+            exporter <- InMemoryMetricExporter.create[IO](None)
+            _ <- makeReader(exporter).use { reader =>
+              for {
+                throwError <- IO.ref(false)
+
+                _ <- reader.register(NonEmptyVector.one(producer(throwError)))
+
+                // first successful export should happen
+                _ <- IO.sleep(31.seconds)
+                _ <- exporter.exportedMetrics.assertEquals(metrics)
+
+                _ <- throwError.set(true)
+
+                // second export will fail
+                _ <- IO.sleep(31.seconds)
+                _ <- exporter.exportedMetrics.assertEquals(Nil)
+                _ <- C.entries.assertEquals(consoleEntries)
+
+                _ <- throwError.set(false)
+
+                // third successful export should happen
+                _ <- IO.sleep(31.seconds)
+                _ <- exporter.exportedMetrics.assertEquals(metrics)
+              } yield ()
+            }
+          } yield ()
+        }
+      }
+    }
+  }
+
+  test("terminate export task by the timeout") {
+    val producer: MetricProducer[IO] =
+      new MetricProducer[IO] {
+        def produce: IO[Vector[MetricData]] =
+          IO.never.as(Vector.empty)
+      }
+
+    TestControl.executeEmbed {
+      InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
+        val consoleEntries = {
+          import org.typelevel.otel4s.sdk.test.InMemoryConsole._
+
+          List(
+            Entry(
+              Op.Errorln,
+              "PeriodicMetricReader: the export attempt has been canceled after [5 seconds]"
+            )
+          )
+        }
+
+        for {
+          exporter <- InMemoryMetricExporter.create[IO](None)
+          _ <- makeReader(exporter).use { reader =>
+            for {
+              _ <- reader.register(NonEmptyVector.one(producer))
+
+              // nothing should be exported
+              _ <- IO.sleep(60.seconds)
+              _ <- exporter.exportedMetrics.assertEquals(Nil)
+              _ <- C.entries.assertEquals(consoleEntries)
+            } yield ()
+          }
+        } yield ()
+      }
+    }
+  }
+
+  private def makeReader(
+      exporter: MetricExporter[IO]
+  )(implicit console: Console[IO]): Resource[IO, MetricReader[IO]] =
+    MetricReader.periodic(exporter, 30.seconds, 5.seconds)
+
+  private def constProducer(metrics: List[MetricData]): MetricProducer[IO] =
+    new MetricProducer[IO] {
+      def produce: IO[Vector[MetricData]] = IO.pure(metrics.toVector)
+    }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/exporter/LoggingSpanExporterSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/exporter/LoggingSpanExporterSuite.scala
@@ -20,8 +20,9 @@ package exporter
 import cats.Applicative
 import cats.effect.IO
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.sdk.test.InMemoryConsole
+import org.typelevel.otel4s.sdk.test.InMemoryConsole._
 import org.typelevel.otel4s.sdk.trace.data.SpanData
-import org.typelevel.otel4s.sdk.trace.exporter.InMemoryConsole._
 import org.typelevel.otel4s.sdk.trace.scalacheck.Gens
 
 class LoggingSpanExporterSuite extends CatsEffectSuite {


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/sdk/#periodic-exporting-metricreader |
| Java implementation | [PeriodicMetricReader.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.java)  |