### PR TITLE
sdk-metrics: add `SdkUpDownCounter`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Monad
+import cats.effect.std.Console
+import cats.mtl.Ask
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.meta.InstrumentMeta
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.metrics.UpDownCounter
+import org.typelevel.otel4s.sdk.context.AskContext
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
+import org.typelevel.otel4s.sdk.metrics.internal.MeterSharedState
+import org.typelevel.otel4s.sdk.metrics.internal.storage.MetricStorage
+
+import scala.collection.immutable
+
+/** A synchronous instrument that supports increments and decrements.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter]]
+  */
+private object SdkUpDownCounter {
+
+  private final class Backend[
+      F[_]: Monad: AskContext,
+      A,
+      Primitive: Numeric
+  ](
+      cast: A => Primitive,
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+  ) extends UpDownCounter.Backend[F, A] {
+    def meta: InstrumentMeta[F] = InstrumentMeta.enabled
+
+    def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      record(cast(value), attributes)
+
+    def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      record(Numeric[Primitive].one, attributes)
+
+    def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+      record(Numeric[Primitive].negate(Numeric[Primitive].one), attributes)
+
+    private def record(
+        value: Primitive,
+        attributes: immutable.Iterable[Attribute[_]]
+    ): F[Unit] =
+      for {
+        ctx <- Ask[F, Context].ask
+        _ <- storage.record(value, attributes.to(Attributes), ctx)
+      } yield ()
+  }
+
+  final case class Builder[
+      F[_]: Monad: Console: AskContext,
+      A: MeasurementValue
+  ](
+      name: String,
+      sharedState: MeterSharedState[F],
+      unit: Option[String] = None,
+      description: Option[String] = None
+  ) extends UpDownCounter.Builder[F, A] {
+
+    def withUnit(unit: String): UpDownCounter.Builder[F, A] =
+      copy(unit = Some(unit))
+
+    def withDescription(description: String): UpDownCounter.Builder[F, A] =
+      copy(description = Some(description))
+
+    def create: F[UpDownCounter[F, A]] = {
+      val descriptor = InstrumentDescriptor.synchronous(
+        name = CIString(name),
+        description = description,
+        unit = unit,
+        instrumentType = InstrumentType.UpDownCounter
+      )
+
+      MeasurementValue[A] match {
+        case MeasurementValue.LongMeasurementValue(cast) =>
+          sharedState
+            .registerMetricStorage[Long](descriptor)
+            .map { storage =>
+              UpDownCounter.fromBackend(
+                new Backend[F, A, Long](cast, storage)
+              )
+            }
+
+        case MeasurementValue.DoubleMeasurementValue(cast) =>
+          sharedState
+            .registerMetricStorage[Double](descriptor)
+            .map { storage =>
+              UpDownCounter.fromBackend(
+                new Backend[F, A, Double](cast, storage)
+              )
+            }
+      }
+    }
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounterSuite.scala
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.effect.IO
+import cats.effect.std.Random
+import cats.mtl.Ask
+import cats.syntax.foldable._
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
+import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+import org.typelevel.otel4s.sdk.metrics.exporter.InMemoryMetricReader
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricProducer
+import org.typelevel.otel4s.sdk.metrics.internal.MeterSharedState
+import org.typelevel.otel4s.sdk.metrics.internal.exporter.RegisteredReader
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+import org.typelevel.otel4s.sdk.metrics.test.PointDataUtils
+import org.typelevel.otel4s.sdk.metrics.view.ViewRegistry
+
+import scala.concurrent.duration.FiniteDuration
+
+class SdkUpDownCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+
+  private implicit val askContext: Ask[IO, Context] = Ask.const(Context.root)
+
+  test("increment") {
+    PropF.forAllF(
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.timeWindow,
+      Gens.attributes,
+      Gens.nonEmptyString,
+      Gen.option(Gen.alphaNumStr),
+      Gen.option(Gen.alphaNumStr)
+    ) { (resource, scope, window, attrs, name, unit, description) =>
+      def test[A: MeasurementValue: Numeric]: IO[Unit] = {
+        val expected = MetricData(
+          resource,
+          scope,
+          name,
+          description,
+          unit,
+          MetricPoints.sum(
+            points = PointDataUtils.toNumberPoints(
+              Vector(Numeric[A].one),
+              attrs,
+              window
+            ),
+            monotonic = false,
+            aggregationTemporality = AggregationTemporality.Cumulative
+          )
+        )
+
+        for {
+          reader <- createReader(window.start)
+          state <- createState(resource, scope, reader, window.start)
+          upDownCounter <- SdkUpDownCounter
+            .Builder[IO, A](name, state, unit, description)
+            .create
+          _ <- upDownCounter.inc(attrs)
+          metrics <- state.collectAll(reader, window.end)
+        } yield assertEquals(metrics, Vector(expected))
+      }
+
+      for {
+        _ <- test[Long]
+        _ <- test[Double]
+      } yield ()
+    }
+  }
+
+  test("decrement") {
+    PropF.forAllF(
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.timeWindow,
+      Gens.attributes,
+      Gens.nonEmptyString,
+      Gen.option(Gen.alphaNumStr),
+      Gen.option(Gen.alphaNumStr)
+    ) { (resource, scope, window, attrs, name, unit, description) =>
+      def test[A: MeasurementValue: Numeric]: IO[Unit] = {
+        val expected = MetricData(
+          resource,
+          scope,
+          name,
+          description,
+          unit,
+          MetricPoints.sum(
+            points = PointDataUtils.toNumberPoints(
+              Vector(Numeric[A].negate(Numeric[A].one)),
+              attrs,
+              window
+            ),
+            monotonic = false,
+            aggregationTemporality = AggregationTemporality.Cumulative
+          )
+        )
+
+        for {
+          reader <- createReader(window.start)
+          state <- createState(resource, scope, reader, window.start)
+          upDownCounter <- SdkUpDownCounter
+            .Builder[IO, A](name, state, unit, description)
+            .create
+          _ <- upDownCounter.dec(attrs)
+          metrics <- state.collectAll(reader, window.end)
+        } yield assertEquals(metrics, Vector(expected))
+      }
+
+      for {
+        _ <- test[Long]
+        _ <- test[Double]
+      } yield ()
+    }
+  }
+
+  test("record values") {
+    PropF.forAllF(
+      Gens.telemetryResource,
+      Gens.instrumentationScope,
+      Gens.timeWindow,
+      Gens.attributes,
+      Gens.nonEmptyString,
+      Gen.option(Gen.alphaNumStr),
+      Gen.option(Gen.alphaNumStr),
+      Gen.either(Gen.listOf(Gen.long), Gen.listOf(Gen.double))
+    ) { (resource, scope, window, attrs, name, unit, description, values) =>
+      def test[A: MeasurementValue: Numeric](values: Vector[A]): IO[Unit] = {
+        val expected = Option.when(values.nonEmpty)(
+          MetricData(
+            resource,
+            scope,
+            name,
+            description,
+            unit,
+            MetricPoints.sum(
+              points = PointDataUtils.toNumberPoints(
+                Vector(values.sum),
+                attrs,
+                window
+              ),
+              monotonic = false,
+              aggregationTemporality = AggregationTemporality.Cumulative
+            )
+          )
+        )
+
+        for {
+          reader <- createReader(window.start)
+          state <- createState(resource, scope, reader, window.start)
+          upDownCounter <- SdkUpDownCounter
+            .Builder[IO, A](name, state, unit, description)
+            .create
+          _ <- values.traverse_(value => upDownCounter.add(value, attrs))
+          metrics <- state.collectAll(reader, window.end)
+        } yield assertEquals(metrics, expected.toVector)
+      }
+
+      values match {
+        case Left(longs)    => test[Long](longs.toVector)
+        case Right(doubles) => test[Double](doubles.toVector)
+      }
+    }
+  }
+
+  private def createReader(start: FiniteDuration): IO[RegisteredReader[IO]] = {
+    val inMemory = new InMemoryMetricReader[IO](
+      emptyProducer,
+      AggregationTemporalitySelector.alwaysCumulative
+    )
+
+    RegisteredReader.create(start, inMemory)
+  }
+
+  private def createState(
+      resource: TelemetryResource,
+      scope: InstrumentationScope,
+      reader: RegisteredReader[IO],
+      start: FiniteDuration
+  ): IO[MeterSharedState[IO]] =
+    Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
+      MeterSharedState.create[IO](
+        resource,
+        scope,
+        start,
+        ExemplarFilter.alwaysOff,
+        TraceContextLookup.noop,
+        ViewRegistry(Vector.empty),
+        Vector(reader)
+      )
+    }
+
+  private def emptyProducer: MetricProducer[IO] =
+    new MetricProducer[IO] {
+      def produce: IO[Vector[MetricData]] = IO.pure(Vector.empty)
+    }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter |
| Java implementation | [SdkLongUpDownCounter.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkLongUpDownCounter.java)  |
