### PR TITLE
sdk-metrics: add `ConsoleMetricExporter `

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/ConsoleMetricExporter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/ConsoleMetricExporter.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import cats.Applicative
+import cats.Foldable
+import cats.Monad
+import cats.effect.std.Console
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+
+/** A metric exporter that logs every metric using [[cats.effect.std.Console]].
+  *
+  * @note
+  *   use this exporter for debugging purposes because it may affect the
+  *   performance
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+private final class ConsoleMetricExporter[F[_]: Monad: Console](
+    val aggregationTemporalitySelector: AggregationTemporalitySelector
+) extends MetricExporter[F] {
+
+  val name: String = "ConsoleMetricExporter"
+
+  def defaultAggregationSelector: AggregationSelector =
+    AggregationSelector.default
+
+  def defaultCardinalityLimitSelector: CardinalityLimitSelector =
+    CardinalityLimitSelector.default
+
+  def exportMetrics[G[_]: Foldable](metrics: G[MetricData]): F[Unit] = {
+    def doExport: F[Unit] =
+      for {
+        _ <- Console[F].println(
+          s"ConsoleMetricExporter: received a collection of [${metrics.size}] metrics for export."
+        )
+        _ <- metrics.traverse_ { metric =>
+          Console[F].println(s"ConsoleMetricExporter: $metric")
+        }
+      } yield ()
+
+    doExport.whenA(metrics.nonEmpty)
+  }
+
+  def flush: F[Unit] = Applicative[F].unit
+}
+
+object ConsoleMetricExporter {
+
+  /** Creates a metric exporter that logs every metric using
+    * [[cats.effect.std.Console]].
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def apply[F[_]: Monad: Console]: MetricExporter[F] =
+    apply(AggregationTemporalitySelector.alwaysCumulative)
+
+  /** Creates a metric exporter that logs every metric using
+    * [[cats.effect.std.Console]].
+    *
+    * @param aggregationTemporalitySelector
+    *   the aggregation temporality selector to use
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def apply[F[_]: Monad: Console](
+      aggregationTemporalitySelector: AggregationTemporalitySelector
+  ): MetricExporter[F] =
+    new ConsoleMetricExporter[F](aggregationTemporalitySelector)
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/ConsoleMetricExporterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/ConsoleMetricExporterSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exporter
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Gen
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
+import org.typelevel.otel4s.sdk.test.InMemoryConsole
+import org.typelevel.otel4s.sdk.test.InMemoryConsole._
+
+class ConsoleMetricExporterSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite {
+
+  test("print metrics to the console") {
+    PropF.forAllF(Gen.listOf(Gens.metricData)) { metrics =>
+      InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
+        val exporter = ConsoleMetricExporter[IO]
+
+        val expected =
+          if (metrics.isEmpty) Nil
+          else {
+            val first = Entry(
+              Op.Println,
+              s"ConsoleMetricExporter: received a collection of [${metrics.size}] metrics for export."
+            )
+
+            val rest = metrics.map { metric =>
+              Entry(Op.Println, s"ConsoleMetricExporter: $metric")
+            }
+
+            first :: rest
+          }
+
+        for {
+          _ <- exporter.exportMetrics(metrics)
+          entries <- C.entries
+        } yield assertEquals(entries, expected)
+      }
+    }
+  }
+
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20)
+      .withMaxSize(20)
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Java implementation | [LoggingMetricExporter.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/logging/src/main/java/io/opentelemetry/exporter/logging/LoggingMetricExporter.java) |
