### PR TITLE
sdk-metrics: add `SdkMetrics`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Applicative
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.effect.std.Random
+import cats.mtl.Ask
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.CommonConfigKeys
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.autoconfigure.TelemetryResourceAutoConfigure
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.autoconfigure.MeterProviderAutoConfigure
+import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
+
+/** The configured metrics module.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+sealed trait SdkMetrics[F[_]] {
+
+  /** The [[org.typelevel.otel4s.metrics.MeterProvider MeterProvider]].
+    */
+  def meterProvider: MeterProvider[F]
+}
+
+object SdkMetrics {
+
+  /** Autoconfigures [[SdkMetrics]] using [[AutoConfigured.Builder]].
+    *
+    * @note
+    *   the external components (e.g. OTLP exporter) must be registered
+    *   manually. Add the `otel4s-sdk-exporter` dependency to the build file:
+    *   {{{
+    * libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
+    *   }}}
+    *   and register the configurer manually:
+    *   {{{
+    * import org.typelevel.otel4s.sdk.metrics.SdkMetrics
+    * import org.typelevel.otel4s.sdk.exporter.otlp.metrics.autoconfigure.OtlpMetricExporterAutoConfigure
+    *
+    * SdkMetrics.autoConfigured[IO](_.addExporterConfigurer(OtlpMetricExporterAutoConfigure[IO]))
+    *   }}}
+    *
+    * @param customize
+    *   a function for customizing the auto-configured SDK builder
+    */
+  def autoConfigured[F[_]: Async: Console](
+      customize: AutoConfigured.Builder[F] => AutoConfigured.Builder[F] =
+        (a: AutoConfigured.Builder[F]) => a
+  ): Resource[F, SdkMetrics[F]] =
+    customize(AutoConfigured.builder[F]).build
+
+  def noop[F[_]: Applicative]: SdkMetrics[F] =
+    new Impl(MeterProvider.noop)
+
+  object AutoConfigured {
+
+    type Customizer[A] = (A, Config) => A
+
+    /** A builder of [[SdkMetrics]].
+      */
+    sealed trait Builder[F[_]] {
+
+      /** Sets the given config to use when resolving properties.
+        *
+        * @note
+        *   [[addPropertiesLoader]] and [[addPropertiesCustomizer]] will have no
+        *   effect if the custom config is provided.
+        *
+        * @param config
+        *   the config to use
+        */
+      def withConfig(config: Config): Builder[F]
+
+      /** Adds the properties loader. Multiple loaders will be added. The loaded
+        * properties will be merged with the default config. Loaded properties
+        * take precedence over the default ones.
+        *
+        * @param loader
+        *   the additional loader to add
+        */
+      def addPropertiesLoader(loader: F[Map[String, String]]): Builder[F]
+
+      /** Adds the properties customizer. Multiple customizers can be added, and
+        * they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addPropertiesCustomizer(
+          customizer: Config => Map[String, String]
+      ): Builder[F]
+
+      /** Adds the meter provider builder customizer. Multiple customizers can
+        * be added, and they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addMeterProviderCustomizer(
+          customizer: Customizer[SdkMeterProvider.Builder[F]]
+      ): Builder[F]
+
+      /** Adds the telemetry resource customizer. Multiple customizers can be
+        * added, and they will be applied in the order they were added.
+        *
+        * @param customizer
+        *   the customizer to add
+        */
+      def addResourceCustomizer(
+          customizer: Customizer[TelemetryResource]
+      ): Builder[F]
+
+      /** Adds the exporter configurer. Can be used to register exporters that
+        * aren't included in the SDK.
+        *
+        * @example
+        *   Add the `otel4s-sdk-exporter` dependency to the build file:
+        *   {{{
+        * libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
+        *   }}}
+        *   and register the configurer manually:
+        *   {{{
+        * import org.typelevel.otel4s.sdk.metrics.SdkMetrics
+        * import org.typelevel.otel4s.sdk.exporter.otlp.metric.autoconfigure.OtlpMetricExporterAutoConfigure
+        *
+        * SdkMetrics.autoConfigured[IO](_.addExporterConfigurer(OtlpMetricExporterAutoConfigure[IO]))
+        *   }}}
+        *
+        * @param configurer
+        *   the configurer to add
+        */
+      def addExporterConfigurer(
+          configurer: AutoConfigure.Named[F, MetricExporter[F]]
+      ): Builder[F]
+
+      /** Creates [[SdkMetrics]] using the configuration of this builder.
+        */
+      def build: Resource[F, SdkMetrics[F]]
+    }
+
+    /** Creates a [[Builder]].
+      */
+    def builder[F[_]: Async: Console]: Builder[F] =
+      BuilderImpl(
+        customConfig = None,
+        propertiesLoader = Async[F].pure(Map.empty),
+        propertiesCustomizers = Nil,
+        resourceCustomizer = (a, _) => a,
+        meterProviderCustomizer = (a: SdkMeterProvider.Builder[F], _) => a,
+        exporterConfigurers = Set.empty
+      )
+
+    private final case class BuilderImpl[F[_]: Async: Console](
+        customConfig: Option[Config],
+        propertiesLoader: F[Map[String, String]],
+        propertiesCustomizers: List[Config => Map[String, String]],
+        resourceCustomizer: Customizer[TelemetryResource],
+        meterProviderCustomizer: Customizer[SdkMeterProvider.Builder[F]],
+        exporterConfigurers: Set[AutoConfigure.Named[F, MetricExporter[F]]]
+    ) extends Builder[F] {
+
+      def withConfig(config: Config): Builder[F] =
+        copy(customConfig = Some(config))
+
+      def addPropertiesLoader(
+          loader: F[Map[String, String]]
+      ): Builder[F] =
+        copy(propertiesLoader = (this.propertiesLoader, loader).mapN(_ ++ _))
+
+      def addPropertiesCustomizer(
+          customizer: Config => Map[String, String]
+      ): Builder[F] =
+        copy(propertiesCustomizers = this.propertiesCustomizers :+ customizer)
+
+      def addResourceCustomizer(
+          customizer: Customizer[TelemetryResource]
+      ): Builder[F] =
+        copy(resourceCustomizer = merge(this.resourceCustomizer, customizer))
+
+      def addMeterProviderCustomizer(
+          customizer: Customizer[SdkMeterProvider.Builder[F]]
+      ): Builder[F] =
+        copy(meterProviderCustomizer =
+          merge(this.meterProviderCustomizer, customizer)
+        )
+
+      def addExporterConfigurer(
+          configurer: AutoConfigure.Named[F, MetricExporter[F]]
+      ): Builder[F] =
+        copy(exporterConfigurers = exporterConfigurers + configurer)
+
+      def build: Resource[F, SdkMetrics[F]] = {
+        def loadConfig: F[Config] =
+          for {
+            props <- propertiesLoader
+            config <- Config.load(props)
+          } yield propertiesCustomizers.foldLeft(config)((cfg, c) =>
+            cfg.withOverrides(c(cfg))
+          )
+
+        def loadNoop: Resource[F, SdkMetrics[F]] =
+          Resource.eval(
+            Console[F]
+              .println(
+                s"SdkMetrics: the '${CommonConfigKeys.SdkDisabled}' set to 'true'. Using no-op implementation"
+              )
+              .as(SdkMetrics.noop[F])
+          )
+
+        def loadMetrics(
+            config: Config,
+            resource: TelemetryResource
+        ): Resource[F, SdkMetrics[F]] =
+          Resource.eval(Random.scalaUtilRandom).flatMap { implicit random =>
+            implicit val askContext: Ask[F, Context] = Ask.const(Context.root)
+
+            val meterProviderConfigure =
+              MeterProviderAutoConfigure[F](
+                resource,
+                TraceContextLookup.noop,
+                meterProviderCustomizer,
+                exporterConfigurers
+              )
+
+            for {
+              meterProvider <- meterProviderConfigure.configure(config)
+            } yield new Impl[F](meterProvider)
+          }
+
+        for {
+          config <- Resource.eval(customConfig.fold(loadConfig)(Async[F].pure))
+
+          resource <- TelemetryResourceAutoConfigure[F]
+            .configure(config)
+            .map(resourceCustomizer(_, config))
+
+          isDisabled <- Resource.eval(
+            Async[F].fromEither(
+              config.getOrElse(CommonConfigKeys.SdkDisabled, false)
+            )
+          )
+
+          metrics <- if (isDisabled) loadNoop else loadMetrics(config, resource)
+        } yield metrics
+      }
+
+      private def merge[A](
+          first: Customizer[A],
+          second: Customizer[A]
+      ): Customizer[A] =
+        (a, config) => second(first(a, config), config)
+
+    }
+  }
+
+  private final class Impl[F[_]](
+      val meterProvider: MeterProvider[F]
+  ) extends SdkMetrics[F] {
+    override def toString: String =
+      s"SdkMetrics{meterProvider=$meterProvider}"
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMetricsSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMetricsSuite.scala
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Foldable
+import cats.effect.IO
+import cats.effect.std.Console
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+import org.typelevel.otel4s.sdk.metrics.exporter.CardinalityLimitSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
+import org.typelevel.otel4s.sdk.metrics.view.InstrumentSelector
+import org.typelevel.otel4s.sdk.metrics.view.View
+import org.typelevel.otel4s.sdk.test.NoopConsole
+
+class SdkMetricsSuite extends CatsEffectSuite {
+
+  private implicit val noopConsole: Console[IO] = new NoopConsole[IO]
+
+  private val DefaultMetrics =
+    metricsToString(TelemetryResource.default)
+
+  private val NoopMetrics =
+    "SdkMetrics{meterProvider=MeterProvider.Noop}"
+
+  test("withConfig - use the given config") {
+    val config = Config.ofProps(Map("otel.metrics.exporter" -> "console"))
+
+    SdkMetrics
+      .autoConfigured[IO](_.withConfig(config))
+      .use(metrics => IO(assertEquals(metrics.toString, DefaultMetrics)))
+  }
+
+  test("load noop instance when 'otel.sdk.disabled=true'") {
+    val config = Config.ofProps(Map("otel.sdk.disabled" -> "true"))
+
+    SdkMetrics
+      .autoConfigured[IO](_.withConfig(config))
+      .use(metrics => IO(assertEquals(metrics.toString, NoopMetrics)))
+  }
+
+  test(
+    "withConfig - ignore 'addPropertiesCustomizer' and 'addPropertiesLoader'"
+  ) {
+    val config = Config.ofProps(Map("otel.sdk.disabled" -> "true"))
+
+    SdkMetrics
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "false"))
+          .addPropertiesLoader(IO.pure(Map("otel.sdk.disabled" -> "false")))
+      )
+      .use(metrics => IO(assertEquals(metrics.toString, NoopMetrics)))
+  }
+
+  // the latter loader should prevail
+  test("addPropertiesLoader - use the loaded properties") {
+    SdkMetrics
+      .autoConfigured[IO](
+        _.addPropertiesLoader(IO.pure(Map("otel.sdk.disabled" -> "false")))
+          .addPropertiesLoader(IO.delay(Map("otel.sdk.disabled" -> "true")))
+      )
+      .use(metrics => IO(assertEquals(metrics.toString, NoopMetrics)))
+  }
+
+  // the latter customizer should prevail
+  test("addPropertiesCustomizer - customize properties") {
+    SdkMetrics
+      .autoConfigured[IO](
+        _.addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "false"))
+          .addPropertiesCustomizer(_ => Map("otel.sdk.disabled" -> "true"))
+      )
+      .use(metrics => IO(assertEquals(metrics.toString, NoopMetrics)))
+  }
+
+  test("addMeterProviderCustomizer - customize meter provider") {
+    val config = Config.ofProps(Map("otel.metrics.exporter" -> "console"))
+
+    val selector = InstrumentSelector.builder.withInstrumentName("*").build
+    val view = View.builder.build
+    val resource = TelemetryResource.default
+
+    SdkMetrics
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addMeterProviderCustomizer((t, _) => t.registerView(selector, view))
+          .addMeterProviderCustomizer((t, _) => t.withResource(resource))
+      )
+      .use { metrics =>
+        IO(
+          assertEquals(
+            metrics.toString,
+            metricsToString(
+              resource,
+              "RegisteredView{selector=InstrumentSelector{instrumentName=*}, view=View{}}"
+            )
+          )
+        )
+      }
+  }
+
+  test("addResourceCustomizer - customize a resource") {
+    val config = Config.ofProps(Map("otel.metrics.exporter" -> "console"))
+
+    val default = TelemetryResource.default
+    val withAttributes =
+      TelemetryResource(Attributes(Attribute("key", "value")))
+    val withSchema = TelemetryResource(Attributes.empty, Some("schema"))
+    val result = default.mergeUnsafe(withAttributes).mergeUnsafe(withSchema)
+
+    SdkMetrics
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(default))
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(withAttributes))
+          .addResourceCustomizer((r, _) => r.mergeUnsafe(withSchema))
+      )
+      .use { metrics =>
+        IO(
+          assertEquals(metrics.toString, metricsToString(result))
+        )
+      }
+  }
+
+  test("addExporterConfigurer - support external configurers") {
+    val config = Config.ofProps(
+      Map("otel.metrics.exporter" -> "custom-1,custom-2")
+    )
+
+    val exporter1: MetricExporter[IO] = customExporter("CustomExporter1")
+    val exporter2: MetricExporter[IO] = customExporter("CustomExporter2")
+
+    SdkMetrics
+      .autoConfigured[IO](
+        _.withConfig(config)
+          .addExporterConfigurer(
+            AutoConfigure.Named.const("custom-1", exporter1)
+          )
+          .addExporterConfigurer(
+            AutoConfigure.Named.const("custom-2", exporter2)
+          )
+      )
+      .use { metrics =>
+        IO(
+          assertEquals(
+            metrics.toString,
+            metricsToString(
+              exporters = List("CustomExporter1", "CustomExporter2")
+            )
+          )
+        )
+      }
+  }
+
+  private def customExporter(exporterName: String): MetricExporter.Push[IO] =
+    new MetricExporter.Push[IO] {
+      def name: String =
+        exporterName
+
+      def aggregationTemporalitySelector: AggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative
+
+      def defaultAggregationSelector: AggregationSelector =
+        AggregationSelector.default
+
+      def defaultCardinalityLimitSelector: CardinalityLimitSelector =
+        CardinalityLimitSelector.default
+
+      def exportMetrics[G[_]: Foldable](spans: G[MetricData]): IO[Unit] =
+        IO.unit
+
+      def flush: IO[Unit] =
+        IO.unit
+    }
+
+  private def metricsToString(
+      resource: TelemetryResource = TelemetryResource.default,
+      view: String = "",
+      exporters: List[String] = List("ConsoleMetricExporter")
+  ) =
+    "SdkMetrics{meterProvider=" +
+      s"SdkMeterProvider{resource=$resource, " +
+      s"metricReaders=[${exporters.map(e => s"PeriodicMetricReader{exporter=$e, interval=1 minute, timeout=30 seconds}").mkString(", ")}], " +
+      s"metricProducers=[], views=[$view]}}"
+}


### PR DESCRIPTION
A user-friendly way to configure only the metrics module.