### PR TITLE
sdk-trace: rename `LoggingSpanExporter` to `ConsoleSpanExporter`

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
@@ -26,7 +26,7 @@ import cats.syntax.functor._
 import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
 import org.typelevel.otel4s.sdk.autoconfigure.Config
 import org.typelevel.otel4s.sdk.autoconfigure.ConfigurationError
-import org.typelevel.otel4s.sdk.trace.exporter.LoggingSpanExporter
+import org.typelevel.otel4s.sdk.trace.exporter.ConsoleSpanExporter
 import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
 
 /** Autoconfigures [[SpanExporter]]s.
@@ -54,7 +54,7 @@ private final class SpanExportersAutoConfigure[F[_]: MonadThrow: Console](
   private val configurers = {
     val default: Set[AutoConfigure.Named[F, SpanExporter[F]]] = Set(
       AutoConfigure.Named.const(Const.NoneExporter, SpanExporter.noop[F]),
-      AutoConfigure.Named.const(Const.LoggingExporter, LoggingSpanExporter[F])
+      AutoConfigure.Named.const(Const.ConsoleExporter, ConsoleSpanExporter[F])
     )
 
     default ++ extra
@@ -139,7 +139,7 @@ private[sdk] object SpanExportersAutoConfigure {
   private[trace] object Const {
     val OtlpExporter = "otlp"
     val NoneExporter = "none"
-    val LoggingExporter = "logging"
+    val ConsoleExporter = "console"
   }
 
   /** Autoconfigures [[SpanExporter]]s.

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
@@ -81,21 +81,21 @@ private final class TracerProviderAutoConfigure[
       config: Config,
       exporters: Map[String, SpanExporter[F]]
   ): Resource[F, List[SpanProcessor[F]]] = {
-    val loggingExporter = SpanExportersAutoConfigure.Const.LoggingExporter
+    val consoleExporter = SpanExportersAutoConfigure.Const.ConsoleExporter
 
-    val logging = exporters.get(loggingExporter) match {
-      case Some(logging) => List(SimpleSpanProcessor(logging))
+    val console = exporters.get(consoleExporter) match {
+      case Some(console) => List(SimpleSpanProcessor(console))
       case None          => Nil
     }
 
-    val others = exporters.removed(loggingExporter)
+    val others = exporters.removed(consoleExporter)
     if (others.nonEmpty) {
       val exporter = others.values.toList.combineAll
       BatchSpanProcessorAutoConfigure[F](exporter)
         .configure(config)
-        .map(processor => logging :+ processor)
+        .map(processor => console :+ processor)
     } else {
-      Resource.pure(logging)
+      Resource.pure(console)
     }
   }
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/exporter/ConsoleSpanExporter.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/exporter/ConsoleSpanExporter.scala
@@ -29,10 +29,10 @@ import org.typelevel.otel4s.sdk.trace.data.SpanData
   *   use this exporter for debugging purposes because it may affect the
   *   performance
   */
-private final class LoggingSpanExporter[F[_]: Applicative: Console]
+private final class ConsoleSpanExporter[F[_]: Applicative: Console]
     extends SpanExporter[F] {
 
-  val name: String = "LoggingSpanExporter"
+  val name: String = "ConsoleSpanExporter"
 
   def exportSpans[G[_]: Foldable](spans: G[SpanData]): F[Unit] = {
     def log(span: SpanData): F[Unit] = {
@@ -43,7 +43,7 @@ private final class LoggingSpanExporter[F[_]: Applicative: Console]
         s"[tracer: ${scope.name}:${scope.version.getOrElse("")}] " +
         s"${span.attributes}"
 
-      Console[F].println(s"LoggingSpanExporter: $content")
+      Console[F].println(s"ConsoleSpanExporter: $content")
     }
 
     spans.traverse_(span => log(span))
@@ -53,9 +53,9 @@ private final class LoggingSpanExporter[F[_]: Applicative: Console]
 
 }
 
-object LoggingSpanExporter {
+object ConsoleSpanExporter {
 
   def apply[F[_]: Applicative: Console]: SpanExporter[F] =
-    new LoggingSpanExporter[F]
+    new ConsoleSpanExporter[F]
 
 }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigureSuite.scala
@@ -117,7 +117,7 @@ class SpanExportersAutoConfigureSuite extends CatsEffectSuite {
       .map(_.leftMap(_.getMessage))
       .assertEquals(
         Left("""Cannot autoconfigure [SpanExporters].
-            |Cause: Unrecognized value for [otel.traces.exporter]: aws-xray. Supported options [none, logging, otlp].
+            |Cause: Unrecognized value for [otel.traces.exporter]: aws-xray. Supported options [none, console, otlp].
             |Config:
             |1) `otel.traces.exporter` - aws-xray""".stripMargin)
       )

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
@@ -161,19 +161,17 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
     }
   }
 
-  test("logging exporter should use a dedicated SimpleSpanProcessor") {
+  test("console exporter should use a dedicated SimpleSpanProcessor") {
     val config = Config.ofProps(
       Map(
-        "otel.traces.exporter" -> "logging,custom",
+        "otel.traces.exporter" -> "console,custom",
         "otel.traces.sampler" -> "always_off"
       )
     )
 
-    val logging: SpanExporter[IO] = customExporter("LoggingExporter")
     val custom: SpanExporter[IO] = customExporter("CustomExporter")
 
     val configurers: Set[AutoConfigure.Named[IO, SpanExporter[IO]]] = Set(
-      AutoConfigure.Named.const("logging", logging),
       AutoConfigure.Named.const("custom", custom)
     )
 
@@ -182,7 +180,7 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
         s"resource=${TelemetryResource.empty}, " +
         s"sampler=${Sampler.AlwaysOff}, " +
         "spanProcessor=SpanProcessor.Multi(" +
-        "SimpleSpanProcessor{exporter=LoggingSpanExporter, exportOnlySampled=true}, " +
+        "SimpleSpanProcessor{exporter=ConsoleSpanExporter, exportOnlySampled=true}, " +
         "BatchSpanProcessor{exporter=CustomExporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
         "SpanStorage)}"
 


### PR DESCRIPTION
The `logging` exporter **name** has been deprecated since `v1.28.0 (2023-12-07)`. The actual [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.32.0/specification/configuration/sdk-environment-variables.md?plain=1#L251-L253):

> "logging" - It is a deprecated value left for backwards compatibility. It SHOULD
NOT be supported by new implementations.

The `sdk-metrics` module already uses a correct [name](https://github.com/typelevel/otel4s/blob/main/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/ConsoleMetricExporter.scala).

Making the `sdk-trace` module up to date too.

