### PR TITLE
sdk-metrics-testkit: add `MetricsTestkit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s-sdk-metrics_native0.4_2.13 otel4s-sdk-metrics_native0.4_3 otel4s-sdk-exporter-metrics_2.13 otel4s-sdk-exporter-metrics_3 otel4s_2.13 otel4s_3 otel4s-sdk-exporter-metrics_native0.4_2.13 otel4s-sdk-exporter-metrics_native0.4_3 docs_2.13 docs_3 scalafix-output_2.13 scalafix-input_2.13 otel4s-sdk-exporter-metrics_sjs1_2.13 otel4s-sdk-exporter-metrics_sjs1_3 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 otel4s-sdk-metrics_2.13 otel4s-sdk-metrics_3 otel4s-sdk-metrics_sjs1_2.13 otel4s-sdk-metrics_sjs1_3 scalafix-tests_2.12
+          modules-ignore: otel4s-benchmarks_2.13 otel4s-benchmarks_3 otel4s-examples_2.13 otel4s-examples_3 otel4s-sdk-metrics_native0.4_2.13 otel4s-sdk-metrics_native0.4_3 otel4s-sdk-exporter-metrics_2.13 otel4s-sdk-exporter-metrics_3 otel4s_2.13 otel4s_3 otel4s-sdk-exporter-metrics_native0.4_2.13 otel4s-sdk-exporter-metrics_native0.4_3 docs_2.13 docs_3 scalafix-output_2.13 scalafix-input_2.13 otel4s-sdk-exporter-metrics_sjs1_2.13 otel4s-sdk-exporter-metrics_sjs1_3 otel4s-sdk-metrics-testkit_sjs1_2.13 otel4s-sdk-metrics-testkit_sjs1_3 otel4s_2.13 otel4s_3 otel4s_2.13 otel4s_3 otel4s-sdk-metrics-testkit_native0.4_2.13 otel4s-sdk-metrics-testkit_native0.4_3 otel4s-sdk-metrics_2.13 otel4s-sdk-metrics_3 otel4s-sdk-metrics-testkit_2.13 otel4s-sdk-metrics-testkit_3 otel4s-sdk-metrics_sjs1_2.13 otel4s-sdk-metrics_sjs1_3 scalafix-tests_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val root = tlCrossRootProject
     core,
     `sdk-common`,
     `sdk-metrics`,
+    `sdk-metrics-testkit`,
     `sdk-trace`,
     `sdk-trace-testkit`,
     sdk,
@@ -239,6 +240,18 @@ lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+
+lazy val `sdk-metrics-testkit` =
+  crossProject(JVMPlatform, JSPlatform, NativePlatform)
+    .crossType(CrossType.Pure)
+    .enablePlugins(NoPublishPlugin)
+    .in(file("sdk/metrics-testkit"))
+    .dependsOn(`sdk-metrics`)
+    .settings(
+      name := "otel4s-sdk-metrics-testkit",
+      startYear := Some(2024)
+    )
+    .settings(scalafixSettings)
 
 lazy val `sdk-trace` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -658,6 +671,7 @@ lazy val unidocs = project
       core.jvm,
       `sdk-common`.jvm,
       `sdk-metrics`.jvm,
+      `sdk-metrics-testkit`.jvm,
       `sdk-trace`.jvm,
       `sdk-trace-testkit`.jvm,
       sdk.jvm,

--- a/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/InMemoryMetricExporter.scala
+++ b/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/InMemoryMetricExporter.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.testkit.metrics
+
+import cats.Foldable
+import cats.Monad
+import cats.effect.Concurrent
+import cats.effect.std.Queue
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+import org.typelevel.otel4s.sdk.metrics.exporter.CardinalityLimitSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
+
+final class InMemoryMetricExporter[F[_]: Monad] private (
+    queue: Queue[F, MetricData],
+    val aggregationTemporalitySelector: AggregationTemporalitySelector,
+    val defaultAggregationSelector: AggregationSelector,
+    val defaultCardinalityLimitSelector: CardinalityLimitSelector
+) extends MetricExporter.Push[F] {
+
+  def name: String = "InMemoryMetricExporter"
+
+  def exportMetrics[G[_]: Foldable](metrics: G[MetricData]): F[Unit] =
+    metrics.traverse_(metric => queue.offer(metric))
+
+  def flush: F[Unit] =
+    Monad[F].unit
+
+  def exportedMetrics: F[List[MetricData]] =
+    queue.tryTakeN(None)
+
+  def reset: F[Unit] =
+    queue.tryTakeN(None).void
+}
+
+object InMemoryMetricExporter {
+
+  /** Creates a `MetricExporter` that keeps metrics in-memory.
+    *
+    * @param capacity
+    *   the capacity of the internal queue
+    *
+    * @param aggregationTemporalitySelector
+    *   the preferred aggregation for the given instrument type
+    *
+    * @param defaultAggregationSelector
+    *   the preferred aggregation for the given instrument type. If no views are
+    *   configured for a metric instrument, an aggregation provided by the
+    *   selector will be used.
+    *
+    * @param defaultCardinalityLimitSelector
+    *   the preferred cardinality limit for the given instrument type. If no
+    *   views are configured for a metric instrument, an aggregation provided by
+    *   the selector will be used.
+    */
+  def create[F[_]: Concurrent](
+      capacity: Option[Int],
+      aggregationTemporalitySelector: AggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative,
+      defaultAggregationSelector: AggregationSelector =
+        AggregationSelector.default,
+      defaultCardinalityLimitSelector: CardinalityLimitSelector =
+        CardinalityLimitSelector.default
+  ): F[InMemoryMetricExporter[F]] =
+    for {
+      queue <- capacity.fold(Queue.unbounded[F, MetricData])(Queue.bounded(_))
+    } yield new InMemoryMetricExporter[F](
+      queue,
+      aggregationTemporalitySelector,
+      defaultAggregationSelector,
+      defaultCardinalityLimitSelector
+    )
+
+}

--- a/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/InMemoryMetricReader.scala
+++ b/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/InMemoryMetricReader.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.testkit.metrics
+
+import cats.Monad
+import cats.data.NonEmptyVector
+import cats.effect.Concurrent
+import cats.effect.Ref
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.exporter._
+
+final class InMemoryMetricReader[F[_]: Monad](
+    producersRef: Ref[F, Vector[MetricProducer[F]]],
+    val aggregationTemporalitySelector: AggregationTemporalitySelector,
+    val defaultAggregationSelector: AggregationSelector,
+    val defaultCardinalityLimitSelector: CardinalityLimitSelector
+) extends MetricReader[F] {
+
+  def register(producers: NonEmptyVector[MetricProducer[F]]): F[Unit] =
+    producersRef.set(producers.toVector)
+
+  def collectAllMetrics: F[Vector[MetricData]] =
+    for {
+      producers <- producersRef.get
+      metrics <- producers.flatTraverse(_.produce)
+    } yield metrics
+
+  def forceFlush: F[Unit] =
+    Monad[F].unit
+
+  override def toString: String =
+    "InMemoryMetricReader"
+}
+
+object InMemoryMetricReader {
+
+  /** Creates a `MetricReader` that keeps metrics in-memory.
+    *
+    * @param aggregationTemporalitySelector
+    *   the preferred aggregation for the given instrument type
+    *
+    * @param defaultAggregationSelector
+    *   the preferred aggregation for the given instrument type. If no views are
+    *   configured for a metric instrument, an aggregation provided by the
+    *   selector will be used.
+    *
+    * @param defaultCardinalityLimitSelector
+    *   the preferred cardinality limit for the given instrument type. If no
+    *   views are configured for a metric instrument, an aggregation provided by
+    *   the selector will be used.
+    */
+  def create[F[_]: Concurrent](
+      aggregationTemporalitySelector: AggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative,
+      defaultAggregationSelector: AggregationSelector =
+        AggregationSelector.default,
+      defaultCardinalityLimitSelector: CardinalityLimitSelector =
+        CardinalityLimitSelector.default
+  ): F[InMemoryMetricReader[F]] =
+    for {
+      producers <- Ref.empty[F, Vector[MetricProducer[F]]]
+    } yield new InMemoryMetricReader[F](
+      producers,
+      aggregationTemporalitySelector,
+      defaultAggregationSelector,
+      defaultCardinalityLimitSelector
+    )
+
+}

--- a/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/MetricsTestkit.scala
+++ b/sdk/metrics-testkit/src/main/scala/org/typelevel/otel4s/sdk/testkit/metrics/MetricsTestkit.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.testkit.metrics
+
+import cats.FlatMap
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.std.Console
+import cats.effect.std.Random
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.sdk.context.AskContext
+import org.typelevel.otel4s.sdk.metrics.SdkMeterProvider
+import org.typelevel.otel4s.sdk.metrics.data.MetricData
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+import org.typelevel.otel4s.sdk.metrics.exporter.CardinalityLimitSelector
+import org.typelevel.otel4s.sdk.metrics.exporter.MetricReader
+
+trait MetricsTestkit[F[_]] {
+
+  /** The [[org.typelevel.otel4s.metrics.MeterProvider MeterProvider]].
+    */
+  def meterProvider: MeterProvider[F]
+
+  /** Collects and returns metrics.
+    *
+    * @note
+    *   metrics are recollected on each invocation.
+    */
+  def collectMetrics: F[List[MetricData]]
+}
+
+object MetricsTestkit {
+
+  /** Creates [[MetricsTestkit]] that keeps metrics in-memory.
+    *
+    * @param customize
+    *   the customization of the builder
+    *
+    * @param aggregationTemporalitySelector
+    *   the preferred aggregation for the given instrument type
+    *
+    * @param defaultAggregationSelector
+    *   the preferred aggregation for the given instrument type. If no views are
+    *   configured for a metric instrument, an aggregation provided by the
+    *   selector will be used.
+    *
+    * @param defaultCardinalityLimitSelector
+    *   the preferred cardinality limit for the given instrument type. If no
+    *   views are configured for a metric instrument, an aggregation provided by
+    *   the selector will be used.
+    */
+  def inMemory[F[_]: Async: Console: AskContext](
+      customize: SdkMeterProvider.Builder[F] => SdkMeterProvider.Builder[F] =
+        (b: SdkMeterProvider.Builder[F]) => b,
+      aggregationTemporalitySelector: AggregationTemporalitySelector =
+        AggregationTemporalitySelector.alwaysCumulative,
+      defaultAggregationSelector: AggregationSelector =
+        AggregationSelector.default,
+      defaultCardinalityLimitSelector: CardinalityLimitSelector =
+        CardinalityLimitSelector.default
+  ): Resource[F, MetricsTestkit[F]] = {
+    def createMeterProvider(
+        reader: InMemoryMetricReader[F]
+    ): F[MeterProvider[F]] =
+      Random.scalaUtilRandom[F].flatMap { implicit random =>
+        val builder = SdkMeterProvider.builder[F].registerMetricReader(reader)
+        customize(builder).build
+      }
+
+    for {
+      reader <- Resource.eval(
+        InMemoryMetricReader.create[F](
+          aggregationTemporalitySelector,
+          defaultAggregationSelector,
+          defaultCardinalityLimitSelector
+        )
+      )
+      meterProvider <- Resource.eval(createMeterProvider(reader))
+    } yield new Impl(meterProvider, reader)
+  }
+
+  private final class Impl[F[_]: FlatMap](
+      val meterProvider: MeterProvider[F],
+      reader: MetricReader[F]
+  ) extends MetricsTestkit[F] {
+    def collectMetrics: F[List[MetricData]] =
+      reader.collectAllMetrics.map(_.toList)
+  }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterProvider.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterProvider.scala
@@ -117,7 +117,7 @@ object SdkMeterProvider {
       *   [[org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter ExemplarFilter]]
       *   to register
       */
-    private[metrics] def withExemplarFilter(filter: ExemplarFilter): Builder[F]
+    private[sdk] def withExemplarFilter(filter: ExemplarFilter): Builder[F]
 
     /** Sets a
       * [[org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup TraceContextLookup]]
@@ -128,7 +128,7 @@ object SdkMeterProvider {
       *   [[org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup TraceContextLookup]]
       *   to use
       */
-    private[metrics] def withTraceContextLookup(
+    private[sdk] def withTraceContextLookup(
         lookup: TraceContextLookup
     ): Builder[F]
 
@@ -157,9 +157,7 @@ object SdkMeterProvider {
       *   [[org.typelevel.otel4s.sdk.metrics.exporter.MetricReader MetricReader]]
       *   to register
       */
-    private[metrics] def registerMetricReader(
-        reader: MetricReader[F]
-    ): Builder[F]
+    private[sdk] def registerMetricReader(reader: MetricReader[F]): Builder[F]
 
     /** Registers a
       * [[org.typelevel.otel4s.sdk.metrics.exporter.MetricProducer MetricProducer]].


### PR DESCRIPTION
A drop-in replacement for the [oteljava MetricsTestkit](https://github.com/typelevel/otel4s/blob/main/oteljava/metrics-testkit/src/main/scala/org/typelevel/otel4s/oteljava/testkit/metrics/MetricsTestkit.scala).