### PR TITLE
sdk-metrics: make `MetricPoints` use `NonEmptyVector` for `points`

### DIFF
--- a/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
@@ -17,10 +17,17 @@
 package org.typelevel.otel4s
 package scalacheck
 
+import cats.data.NonEmptyVector
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 
 trait Gens {
+
+  def nonEmptyVector[A](gen: Gen[A]): Gen[NonEmptyVector[A]] =
+    for {
+      head <- gen
+      tail <- Gen.nonEmptyContainerOf[Vector, A](gen)
+    } yield NonEmptyVector(head, tail)
 
   val nonEmptyString: Gen[String] =
     for {

--- a/sdk-exporter/metrics/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsProtoEncoder.scala
+++ b/sdk-exporter/metrics/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsProtoEncoder.scala
@@ -151,7 +151,7 @@ private object MetricsProtoEncoder {
     case sum: MetricPoints.Sum =>
       Proto.Metric.Data.Sum(
         Proto.Sum(
-          sum.points.map(ProtoEncoder.encode(_)),
+          sum.points.toVector.map(ProtoEncoder.encode(_)),
           ProtoEncoder.encode(sum.aggregationTemporality),
           sum.monotonic
         )
@@ -159,13 +159,13 @@ private object MetricsProtoEncoder {
 
     case gauge: MetricPoints.Gauge =>
       Proto.Metric.Data.Gauge(
-        Proto.Gauge(gauge.points.map(ProtoEncoder.encode(_)))
+        Proto.Gauge(gauge.points.toVector.map(ProtoEncoder.encode(_)))
       )
 
     case histogram: MetricPoints.Histogram =>
       Proto.Metric.Data.Histogram(
         Proto.Histogram(
-          histogram.points.map(ProtoEncoder.encode(_)),
+          histogram.points.toVector.map(ProtoEncoder.encode(_)),
           ProtoEncoder.encode(histogram.aggregationTemporality)
         )
       )

--- a/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsJsonCodecs.scala
+++ b/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsJsonCodecs.scala
@@ -19,6 +19,7 @@ package sdk
 package exporter.otlp
 package metrics
 
+import cats.data.NonEmptyVector
 import io.circe.Encoder
 import io.circe.Json
 import io.circe.syntax._
@@ -31,12 +32,6 @@ import org.typelevel.otel4s.sdk.metrics.data.PointData
 // the instances mimic Protobuf encoding
 private object MetricsJsonCodecs extends JsonCodecs {
 
-  implicit val longEncoder: Encoder[Long] =
-    Encoder.instance { a =>
-      if (a > Int.MaxValue || a < Int.MinValue) Json.fromString(a.toString)
-      else Json.fromLong(a)
-    }
-
   implicit val aggregationTemporalityJsonEncoder
       : Encoder[AggregationTemporality] =
     Encoder.instance {
@@ -48,7 +43,7 @@ private object MetricsJsonCodecs extends JsonCodecs {
     Encoder.instance { exemplar =>
       val value = exemplar match {
         case exemplar: ExemplarData.LongExemplar =>
-          Json.obj("asInt" := exemplar.value)
+          Json.obj("asInt" := exemplar.value.toString)
 
         case exemplar: ExemplarData.DoubleExemplar =>
           Json.obj("asDouble" := exemplar.value)
@@ -70,7 +65,7 @@ private object MetricsJsonCodecs extends JsonCodecs {
     Encoder.instance { point =>
       val value = point match {
         case number: PointData.LongNumber =>
-          Json.obj("asInt" := number.value)
+          Json.obj("asInt" := number.value.toString)
 
         case number: PointData.DoubleNumber =>
           Json.obj("asDouble" := number.value)
@@ -114,7 +109,7 @@ private object MetricsJsonCodecs extends JsonCodecs {
 
       Json
         .obj(
-          "dataPoints" := (sum.points: Vector[PointData.NumberPoint]),
+          "dataPoints" := (sum.points: NonEmptyVector[PointData.NumberPoint]),
           "aggregationTemporality" := sum.aggregationTemporality,
           "isMonotonic" := monotonic
         )
@@ -126,7 +121,7 @@ private object MetricsJsonCodecs extends JsonCodecs {
     Encoder.instance { gauge =>
       Json
         .obj(
-          "dataPoints" := (gauge.points: Vector[PointData.NumberPoint])
+          "dataPoints" := (gauge.points: NonEmptyVector[PointData.NumberPoint])
         )
         .dropEmptyValues
     }

--- a/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsProtoEncoderSuite.scala
+++ b/sdk-exporter/metrics/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/metrics/MetricsProtoEncoderSuite.scala
@@ -37,7 +37,7 @@ class MetricsProtoEncoderSuite extends ScalaCheckSuite {
     Prop.forAll(Gens.exemplarData) { exemplar =>
       val value = exemplar match {
         case exemplar: ExemplarData.LongExemplar =>
-          Json.obj("asInt" := exemplar.value)
+          Json.obj("asInt" := exemplar.value.toString)
 
         case exemplar: ExemplarData.DoubleExemplar =>
           Json.obj("asDouble" := exemplar.value)
@@ -62,7 +62,7 @@ class MetricsProtoEncoderSuite extends ScalaCheckSuite {
     Prop.forAll(Gens.pointDataNumber) { point =>
       val value = point match {
         case number: PointData.LongNumber =>
-          Json.obj("asInt" := number.value)
+          Json.obj("asInt" := number.value.toString)
 
         case number: PointData.DoubleNumber =>
           Json.obj("asDouble" := number.value)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk.metrics.aggregation
 
 import cats.Applicative
+import cats.data.NonEmptyVector
 import cats.effect.Temporal
 import cats.effect.std.Random
 import org.typelevel.otel4s.Attributes
@@ -84,7 +85,7 @@ private[metrics] object Aggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        points: Vector[Point],
+        points: NonEmptyVector[Point],
         temporality: AggregationTemporality
     ): F[MetricData]
   }
@@ -137,7 +138,7 @@ private[metrics] object Aggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        measurements: Vector[AsynchronousMeasurement[A]],
+        measurements: NonEmptyVector[AsynchronousMeasurement[A]],
         temporality: AggregationTemporality
     ): F[MetricData]
   }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregator.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk.metrics.aggregation
 
 import cats.FlatMap
+import cats.data.NonEmptyVector
 import cats.effect.Concurrent
 import cats.effect.Ref
 import cats.effect.Temporal
@@ -67,7 +68,7 @@ private final class ExplicitBucketHistogramAggregator[
       resource: TelemetryResource,
       scope: InstrumentationScope,
       descriptor: MetricDescriptor,
-      points: Vector[PointData.Histogram],
+      points: NonEmptyVector[PointData.Histogram],
       temporality: AggregationTemporality
   ): F[MetricData] =
     Concurrent[F].pure(

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/LastValueAggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/LastValueAggregator.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk.metrics.aggregation
 
 import cats.Applicative
+import cats.data.NonEmptyVector
 import cats.effect.Concurrent
 import cats.syntax.functor._
 import org.typelevel.otel4s.Attributes
@@ -86,7 +87,7 @@ private object LastValueAggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        points: Vector[Point],
+        points: NonEmptyVector[Point],
         temporality: AggregationTemporality
     ): F[MetricData] =
       Concurrent[F].pure(
@@ -142,7 +143,7 @@ private object LastValueAggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        measurements: Vector[AsynchronousMeasurement[A]],
+        measurements: NonEmptyVector[AsynchronousMeasurement[A]],
         temporality: AggregationTemporality
     ): F[MetricData] = {
       val points = measurements.map { m =>

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/SumAggregator.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk.metrics.aggregation
 
 import cats.Applicative
+import cats.data.NonEmptyVector
 import cats.effect.Temporal
 import cats.effect.std.Random
 import cats.syntax.flatMap._
@@ -109,7 +110,7 @@ private object SumAggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        points: Vector[Point],
+        points: NonEmptyVector[Point],
         temporality: AggregationTemporality
     ): F[MetricData] =
       Temporal[F].pure(
@@ -184,7 +185,7 @@ private object SumAggregator {
         resource: TelemetryResource,
         scope: InstrumentationScope,
         descriptor: MetricDescriptor,
-        measurements: Vector[AsynchronousMeasurement[A]],
+        measurements: NonEmptyVector[AsynchronousMeasurement[A]],
         temporality: AggregationTemporality
     ): F[MetricData] = {
       val points = measurements.map { m =>

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricData.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/data/MetricData.scala
@@ -59,14 +59,6 @@ sealed trait MetricData {
     */
   def resource: TelemetryResource
 
-  /** Whether the measurements are empty.
-    */
-  final def isEmpty: Boolean = data.points.isEmpty
-
-  /** Whether the measurements are non empty.
-    */
-  final def nonEmpty: Boolean = !isEmpty
-
   override final def hashCode(): Int =
     Hash[MetricData].hash(this)
 

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedState.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedState.scala
@@ -226,7 +226,7 @@ private[metrics] final class MeterSharedState[
           result <- storages.traverse { storage =>
             storage.collect(resource, scope, timeWindow)
           }
-        } yield result.flatten.filter(_.nonEmpty)
+        } yield result.flatten
       }
     }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkBatchCallbackSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkBatchCallbackSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import munit.CatsEffectSuite
@@ -55,7 +56,7 @@ class SdkBatchCallbackSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             ),
@@ -72,7 +73,7 @@ class SdkBatchCallbackSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             ),
@@ -89,7 +90,7 @@ class SdkBatchCallbackSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.gauge(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             )

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkCounterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkCounterSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.foldable._
@@ -106,7 +107,7 @@ class SdkCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(Numeric[A].one),
+              NonEmptyVector.one(Numeric[A].one),
               attrs,
               window
             ),
@@ -159,7 +160,7 @@ class SdkCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
             unit,
             MetricPoints.sum(
               points = PointDataUtils.toNumberPoints(
-                Vector(values.sum),
+                NonEmptyVector.one(values.sum),
                 attrs,
                 window
               ),

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableCounterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableCounterSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import munit.CatsEffectSuite
@@ -58,7 +59,7 @@ class SdkObservableCounterSuite
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             ),

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableGaugeSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableGaugeSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import munit.CatsEffectSuite
@@ -57,7 +58,7 @@ class SdkObservableGaugeSuite
           unit,
           MetricPoints.gauge(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             )

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableUpDownCounterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkObservableUpDownCounterSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import munit.CatsEffectSuite
@@ -58,7 +59,7 @@ class SdkObservableUpDownCounterSuite
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(value),
+              NonEmptyVector.one(value),
               attrs,
               window
             ),

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounterSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import cats.syntax.foldable._
@@ -55,7 +56,7 @@ class SdkUpDownCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(Numeric[A].one),
+              NonEmptyVector.one(Numeric[A].one),
               attrs,
               window
             ),
@@ -106,7 +107,7 @@ class SdkUpDownCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           unit,
           MetricPoints.sum(
             points = PointDataUtils.toNumberPoints(
-              Vector(Numeric[A].negate(Numeric[A].one)),
+              NonEmptyVector.one(Numeric[A].negate(Numeric[A].one)),
               attrs,
               window
             ),
@@ -159,7 +160,7 @@ class SdkUpDownCounterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
             unit,
             MetricPoints.sum(
               points = PointDataUtils.toNumberPoints(
-                Vector(values.sum),
+                NonEmptyVector.one(values.sum),
                 attrs,
                 window
               ),

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregatorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/ExplicitBucketHistogramAggregatorSuite.scala
@@ -200,7 +200,7 @@ class ExplicitBucketHistogramAggregatorSuite
       Gens.telemetryResource,
       Gens.instrumentationScope,
       Gens.instrumentDescriptor,
-      Gen.listOf(Gens.histogramPointData),
+      Gens.nonEmptyVector(Gens.histogramPointData),
       Gens.aggregationTemporality
     ) { (boundaries, resource, scope, descriptor, points, temporality) =>
       type HistogramAggregator = Aggregator.Synchronous[IO, Double] {
@@ -221,7 +221,7 @@ class ExplicitBucketHistogramAggregatorSuite
           name = descriptor.name.toString,
           description = descriptor.description,
           unit = descriptor.unit,
-          data = MetricPoints.histogram(points.toVector, temporality)
+          data = MetricPoints.histogram(points, temporality)
         )
 
       for {
@@ -229,7 +229,7 @@ class ExplicitBucketHistogramAggregatorSuite
           resource,
           scope,
           MetricDescriptor(None, descriptor),
-          points.toVector,
+          points,
           temporality
         )
       } yield assertEquals(metricData, expected)

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPointsSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/data/MetricPointsSuite.scala
@@ -34,16 +34,16 @@ class MetricPointsSuite extends DisciplineSuite {
       val expected = data match {
         case sum: MetricPoints.Sum =>
           "MetricPoints.Sum{" +
-            s"points=${sum.points.mkString("{", ",", "}")}, " +
+            s"points=${sum.points.toVector.mkString("{", ",", "}")}, " +
             s"monotonic=${sum.monotonic}, " +
             s"aggregationTemporality=${sum.aggregationTemporality}}"
 
         case gauge: MetricPoints.Gauge =>
-          s"MetricPoints.Gauge{points=${gauge.points.mkString("{", ",", "}")}}"
+          s"MetricPoints.Gauge{points=${gauge.points.toVector.mkString("{", ",", "}")}}"
 
         case histogram: MetricPoints.Histogram =>
           "MetricPoints.Histogram{" +
-            s"points=${histogram.points.mkString("{", ",", "}")}, " +
+            s"points=${histogram.points.toVector.mkString("{", ",", "}")}, " +
             s"aggregationTemporality=${histogram.aggregationTemporality}}"
       }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk.metrics.internal
 
 import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.effect.std.Random
 import cats.mtl.Ask
@@ -61,7 +62,7 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           case InstrumentType.Counter =>
             MetricPoints.sum(
               points = PointDataUtils.toNumberPoints(
-                Vector(value),
+                NonEmptyVector.one(value),
                 attributes,
                 timeWindow
               ),
@@ -72,7 +73,7 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           case InstrumentType.UpDownCounter =>
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(value),
+                NonEmptyVector.one(value),
                 attributes,
                 timeWindow
               ),
@@ -82,9 +83,9 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
           case InstrumentType.Histogram =>
             MetricPoints.histogram(
-              Vector(
+              NonEmptyVector.one(
                 PointDataUtils.toHistogramPoint(
-                  Vector(value),
+                  NonEmptyVector.one(value),
                   attributes,
                   timeWindow,
                   Aggregation.Defaults.Boundaries
@@ -133,7 +134,7 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           case InstrumentType.ObservableCounter =>
             MetricPoints.sum(
               points = PointDataUtils.toNumberPoints(
-                Vector(value),
+                NonEmptyVector.one(value),
                 attributes,
                 timeWindow
               ),
@@ -144,7 +145,7 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           case InstrumentType.ObservableUpDownCounter =>
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(value),
+                NonEmptyVector.one(value),
                 attributes,
                 timeWindow
               ),
@@ -155,7 +156,7 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           case InstrumentType.ObservableGauge =>
             MetricPoints.gauge(
               PointDataUtils.toNumberPoints(
-                Vector(value),
+                NonEmptyVector.one(value),
                 attributes,
                 timeWindow
               )

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/SdkObservableMeasurementSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/SdkObservableMeasurementSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics.internal
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.mtl.Ask
 import munit.CatsEffectSuite
@@ -111,7 +112,11 @@ class SdkObservableMeasurementSuite
           descriptor.description,
           descriptor.unit,
           MetricPoints.gauge(
-            PointDataUtils.toNumberPoints(Vector(value), attributes, timeWindow)
+            PointDataUtils.toNumberPoints(
+              NonEmptyVector.one(value),
+              attributes,
+              timeWindow
+            )
           )
         )
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/storage/SynchronousStorageSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/storage/SynchronousStorageSuite.scala
@@ -16,6 +16,7 @@
 
 package org.typelevel.otel4s.sdk.metrics.internal.storage
 
+import cats.data.NonEmptyVector
 import cats.effect.IO
 import cats.effect.std.Console
 import cats.effect.std.Random
@@ -87,7 +88,7 @@ class SynchronousStorageSuite
             descriptor.unit,
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(Vector.fill(repeat)(values).flatten.sum),
+                NonEmptyVector.one(Vector.fill(repeat)(values).flatten.sum),
                 attributes,
                 timeWindow
               ),
@@ -140,7 +141,7 @@ class SynchronousStorageSuite
             descriptor.unit,
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(values.sum),
+                NonEmptyVector.one(values.sum),
                 attributes,
                 TimeWindow(Duration.Zero, timeWindow.end)
               ),
@@ -199,7 +200,7 @@ class SynchronousStorageSuite
             descriptor.unit,
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(values.sum),
+                NonEmptyVector.one(values.sum),
                 Attributes.empty,
                 TimeWindow(Duration.Zero, timeWindow.end)
               ),
@@ -266,7 +267,7 @@ class SynchronousStorageSuite
             descriptor.unit,
             MetricPoints.sum(
               PointDataUtils.toNumberPoints(
-                Vector(values.sum),
+                NonEmptyVector.one(values.sum),
                 attrs,
                 TimeWindow(Duration.Zero, timeWindow.end)
               ),

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Cogens.scala
@@ -146,15 +146,15 @@ trait Cogens extends org.typelevel.otel4s.sdk.scalacheck.Cogens {
 
   implicit val sumMetricPointsCogen: Cogen[MetricPoints.Sum] =
     Cogen[(Vector[PointData], Boolean, AggregationTemporality)].contramap { s =>
-      (s.points, s.monotonic, s.aggregationTemporality)
+      (s.points.toVector, s.monotonic, s.aggregationTemporality)
     }
 
   implicit val gaugeMetricPointsCogen: Cogen[MetricPoints.Gauge] =
-    Cogen[Vector[PointData]].contramap(_.points)
+    Cogen[Vector[PointData]].contramap(_.points.toVector)
 
   implicit val histogramMetricPointsCogen: Cogen[MetricPoints.Histogram] =
     Cogen[(Vector[PointData], AggregationTemporality)].contramap { h =>
-      (h.points, h.aggregationTemporality)
+      (h.points.toVector, h.aggregationTemporality)
     }
 
   implicit val metricPointsCogen: Cogen[MetricPoints] =

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/test/PointDataUtils.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/test/PointDataUtils.scala
@@ -16,6 +16,8 @@
 
 package org.typelevel.otel4s.sdk.metrics.test
 
+import cats.data.NonEmptyVector
+import cats.syntax.foldable._
 import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.metrics.MeasurementValue
@@ -25,10 +27,10 @@ import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
 object PointDataUtils {
 
   def toNumberPoints[A: MeasurementValue](
-      values: Vector[A],
+      values: NonEmptyVector[A],
       attributes: Attributes,
       timeWindow: TimeWindow
-  ): Vector[PointData.NumberPoint] =
+  ): NonEmptyVector[PointData.NumberPoint] =
     MeasurementValue[A] match {
       case MeasurementValue.LongMeasurementValue(cast) =>
         values.map { a =>
@@ -52,7 +54,7 @@ object PointDataUtils {
     }
 
   def toHistogramPoint[A](
-      values: Vector[A],
+      values: NonEmptyVector[A],
       attributes: Attributes,
       timeWindow: TimeWindow,
       boundaries: BucketBoundaries
@@ -60,12 +62,12 @@ object PointDataUtils {
     import N.mkNumericOps
 
     val stats: Option[PointData.Histogram.Stats] =
-      Option.when(values.nonEmpty)(
+      Some(
         PointData.Histogram.Stats(
-          sum = values.sum.toDouble,
-          min = values.min.toDouble,
-          max = values.max.toDouble,
-          count = values.size.toLong
+          sum = values.toVector.sum.toDouble,
+          min = values.toVector.min.toDouble,
+          max = values.toVector.max.toDouble,
+          count = values.size
         )
       )
 


### PR DESCRIPTION
`MetricPoints` without actual points is useless. We can tighten up the collection type to `NonEmptyVector`.