### PR TITLE
sdk-exporter: add `ProtocolAutoConfigure`

### DIFF
--- a/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/Protocol.scala
+++ b/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/Protocol.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter.otlp
+
+private[exporter] sealed trait Protocol
+
+private[exporter] object Protocol {
+  final case class Http(encoding: HttpPayloadEncoding) extends Protocol
+}

--- a/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/ProtocolAutoConfigure.scala
+++ b/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/ProtocolAutoConfigure.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter.otlp
+package autoconfigure
+
+import cats.MonadThrow
+import cats.effect.Resource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.autoconfigure.ConfigurationError
+
+/** Autoconfigures OTLP
+  * [[org.typelevel.otel4s.sdk.exporter.otlp.Protocol Protocol]].
+  *
+  * The general configuration options:
+  * {{{
+  * | System property             | Environment variable        | Description                                                                                                 |
+  * |-----------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------|
+  * | otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+  * }}}
+  *
+  * The metrics-specific configuration options:
+  * {{{
+  * | System property                     | Environment variable                | Description                                                                                                 |
+  * |-------------------------------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------|
+  * | otel.exporter.otlp.metrics.protocol | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+  * }}}
+  *
+  * The traces-specific configuration options:
+  * {{{
+  * | System property                    | Environment variable               | Description                                                                                                 |
+  * |------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------|
+  * | otel.exporter.otlp.traces.protocol | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+  * }}}
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol]]
+  */
+private final class ProtocolAutoConfigure[F[_]: MonadThrow](
+    targetSpecificKey: Config.Key[Protocol]
+) extends AutoConfigure.WithHint[F, Protocol](
+      "Protocol",
+      Set(ProtocolAutoConfigure.ConfigKeys.GeneralProtocol, targetSpecificKey)
+    ) {
+
+  import ProtocolAutoConfigure.ConfigKeys
+  import ProtocolAutoConfigure.Defaults
+
+  private val protocols: Map[String, Protocol] =
+    Map(
+      "http/json" -> Protocol.Http(HttpPayloadEncoding.Json),
+      "http/protobuf" -> Protocol.Http(HttpPayloadEncoding.Protobuf)
+    )
+
+  protected def fromConfig(config: Config): Resource[F, Protocol] = {
+    val protocol = config
+      .get(targetSpecificKey)
+      .flatMap {
+        case Some(value) =>
+          Right(value)
+
+        case None =>
+          config.getOrElse(ConfigKeys.GeneralProtocol, Defaults.OtlpProtocol)
+      }
+
+    Resource.eval(MonadThrow[F].fromEither(protocol))
+  }
+
+  private implicit val protocolReader: Config.Reader[Protocol] =
+    Config.Reader.decodeWithHint("Protocol") { s =>
+      protocols
+        .get(s.trim.toLowerCase)
+        .toRight(
+          ConfigurationError(
+            s"Unrecognized protocol [$s]. Supported options [${protocols.keys.mkString(", ")}]"
+          )
+        )
+    }
+
+}
+
+private[exporter] object ProtocolAutoConfigure {
+
+  private object ConfigKeys {
+    val GeneralProtocol: Config.Key[Protocol] =
+      Config.Key("otel.exporter.otlp.protocol")
+
+    val MetricsProtocol: Config.Key[Protocol] =
+      Config.Key("otel.exporter.otlp.metrics.protocol")
+
+    val TracesProtocol: Config.Key[Protocol] =
+      Config.Key("otel.exporter.otlp.traces.protocol")
+  }
+
+  private object Defaults {
+    val OtlpProtocol: Protocol = Protocol.Http(HttpPayloadEncoding.Protobuf)
+  }
+
+  /** Autoconfigures OTLP
+    * [[org.typelevel.otel4s.sdk.exporter.otlp.Protocol Protocol]].
+    *
+    * The general configuration options:
+    * {{{
+    * | System property             | Environment variable        | Description                                                                                                 |
+    * |-----------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------|
+    * | otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+    * }}}
+    *
+    * The metrics-specific configuration options:
+    * {{{
+    * | System property                     | Environment variable                | Description                                                                                                 |
+    * |-------------------------------------|-------------------------------------|-------------------------------------------------------------------------------------------------------------|
+    * | otel.exporter.otlp.metrics.protocol | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+    * }}}
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol]]
+    */
+  def metrics[F[_]: MonadThrow]: AutoConfigure[F, Protocol] =
+    new ProtocolAutoConfigure[F](ConfigKeys.MetricsProtocol)
+
+  /** Autoconfigures OTLP
+    * [[org.typelevel.otel4s.sdk.exporter.otlp.Protocol Protocol]].
+    *
+    * The general configuration options:
+    * {{{
+    * | System property             | Environment variable        | Description                                                                                                 |
+    * |-----------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------|
+    * | otel.exporter.otlp.protocol | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+    * }}}
+    *
+    * The traces-specific configuration options:
+    * {{{
+    * | System property                    | Environment variable               | Description                                                                                                 |
+    * |------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------|
+    * | otel.exporter.otlp.traces.protocol | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use. Options include `http/protobuf` and `http/json`. Default is `http/protobuf`. |
+    * }}}
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol]]
+    */
+  def traces[F[_]: MonadThrow]: AutoConfigure[F, Protocol] =
+    new ProtocolAutoConfigure[F](ConfigKeys.TracesProtocol)
+}

--- a/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/autoconfigure/ProtocolAutoConfigureSuite.scala
+++ b/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/autoconfigure/ProtocolAutoConfigureSuite.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter.autoconfigure
+
+import cats.effect.IO
+import cats.syntax.either._
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.exporter.otlp.HttpPayloadEncoding
+import org.typelevel.otel4s.sdk.exporter.otlp.Protocol
+import org.typelevel.otel4s.sdk.exporter.otlp.autoconfigure.ProtocolAutoConfigure
+
+class ProtocolAutoConfigureSuite extends CatsEffectSuite {
+
+  test("metrics - load from the config - empty config - load default") {
+    val config = Config.ofProps(Map.empty)
+    val expected = Protocol.Http(HttpPayloadEncoding.Protobuf)
+
+    ProtocolAutoConfigure
+      .metrics[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("metrics - load from the config - empty string - load default") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.protocol" -> "",
+        "otel.exporter.otlp.metrics.protocol" -> ""
+      )
+    )
+
+    val expected = Protocol.Http(HttpPayloadEncoding.Protobuf)
+
+    ProtocolAutoConfigure
+      .metrics[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("metrics - load from the config - prioritize 'metrics' properties") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.protocol" -> "http/protobuf",
+        "otel.exporter.otlp.metrics.protocol" -> "http/json"
+      )
+    )
+
+    val expected = Protocol.Http(HttpPayloadEncoding.Json)
+
+    ProtocolAutoConfigure
+      .metrics[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("metrics - load from the config - unknown protocol - fail") {
+    val config = Config.ofProps(Map("otel.exporter.otlp.protocol" -> "grpc"))
+
+    ProtocolAutoConfigure
+      .metrics[IO]
+      .configure(config)
+      .use_
+      .attempt
+      .map(_.leftMap(_.getMessage))
+      .assertEquals(
+        Left("""Cannot autoconfigure [Protocol].
+               |Cause: Unrecognized protocol [grpc]. Supported options [http/json, http/protobuf].
+               |Config:
+               |1) `otel.exporter.otlp.metrics.protocol` - N/A
+               |2) `otel.exporter.otlp.protocol` - grpc""".stripMargin)
+      )
+  }
+
+  test("traces - load from the config - empty config - load default") {
+    val config = Config.ofProps(Map.empty)
+    val expected = Protocol.Http(HttpPayloadEncoding.Protobuf)
+
+    ProtocolAutoConfigure
+      .traces[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("traces - load from the config - empty string - load default") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.protocol" -> "",
+        "otel.exporter.otlp.traces.protocol" -> ""
+      )
+    )
+
+    val expected = Protocol.Http(HttpPayloadEncoding.Protobuf)
+
+    ProtocolAutoConfigure
+      .traces[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("traces - load from the config - prioritize 'traces' properties") {
+    val config = Config.ofProps(
+      Map(
+        "otel.exporter.otlp.protocol" -> "http/protobuf",
+        "otel.exporter.otlp.traces.protocol" -> "http/json"
+      )
+    )
+
+    val expected = Protocol.Http(HttpPayloadEncoding.Json)
+
+    ProtocolAutoConfigure
+      .traces[IO]
+      .configure(config)
+      .use(protocol => IO(assertEquals(protocol, expected)))
+  }
+
+  test("traces - load from the config - unknown protocol - fail") {
+    val config = Config.ofProps(Map("otel.exporter.otlp.protocol" -> "grpc"))
+
+    ProtocolAutoConfigure
+      .traces[IO]
+      .configure(config)
+      .use_
+      .attempt
+      .map(_.leftMap(_.getMessage))
+      .assertEquals(
+        Left("""Cannot autoconfigure [Protocol].
+               |Cause: Unrecognized protocol [grpc]. Supported options [http/json, http/protobuf].
+               |Config:
+               |1) `otel.exporter.otlp.protocol` - grpc
+               |2) `otel.exporter.otlp.traces.protocol` - N/A""".stripMargin)
+      )
+  }
+
+}

--- a/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigure.scala
+++ b/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigure.scala
@@ -26,28 +26,17 @@ import org.http4s.Headers
 import org.http4s.client.Client
 import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
 import org.typelevel.otel4s.sdk.autoconfigure.Config
-import org.typelevel.otel4s.sdk.autoconfigure.ConfigurationError
-import org.typelevel.otel4s.sdk.exporter.otlp.HttpPayloadEncoding
+import org.typelevel.otel4s.sdk.exporter.otlp.Protocol
 import org.typelevel.otel4s.sdk.exporter.otlp.autoconfigure.OtlpHttpClientAutoConfigure
+import org.typelevel.otel4s.sdk.exporter.otlp.autoconfigure.ProtocolAutoConfigure
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
 
 /** Autoconfigures OTLP
   * [[org.typelevel.otel4s.sdk.trace.exporter.SpanExporter SpanExporter]].
   *
-  * The general configuration options:
-  * {{{
-  * | System property                    | Environment variable        | Description                                                                                                                                      |
-  * |------------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-  * | otel.exporter.otlp.protocol        | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace, metric, and log requests. Options include `http/protobuf`, and `http/json`. Default is `http/json`. |
-  * }}}
-  *
-  * The traces-specific configuration options:
-  * {{{
-  * | System property                    | Environment variable               | Description                                                                                                                        |
-  * |------------------------------------|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-  * | otel.exporter.otlp.traces.protocol | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL |The transport protocol to use on OTLP trace log requests. Options include `http/protobuf`, and `http/json`. Default is `http/json`. |                               |
-  * }}}
+  * @see
+  *   [[ProtocolAutoConfigure]] for OTLP protocol configuration
   *
   * @see
   *   [[OtlpHttpClientAutoConfigure]] for OTLP HTTP client configuration
@@ -60,32 +49,18 @@ private final class OtlpSpanExporterAutoConfigure[
 ](customClient: Option[Client[F]])
     extends AutoConfigure.WithHint[F, SpanExporter[F]](
       "OtlpSpanExporter",
-      OtlpSpanExporterAutoConfigure.ConfigKeys.All
+      Set.empty
     )
     with AutoConfigure.Named[F, SpanExporter[F]] {
 
-  import OtlpSpanExporterAutoConfigure.ConfigKeys
-  import OtlpSpanExporterAutoConfigure.Defaults
-  import OtlpSpanExporterAutoConfigure.Protocol
-
   def name: String = "otlp"
 
-  protected def fromConfig(config: Config): Resource[F, SpanExporter[F]] = {
-    import SpansProtoEncoder.spanDataToRequest
-    import SpansProtoEncoder.jsonPrinter
+  protected def fromConfig(config: Config): Resource[F, SpanExporter[F]] =
+    ProtocolAutoConfigure.traces[F].configure(config).flatMap {
+      case Protocol.Http(encoding) =>
+        import SpansProtoEncoder.spanDataToRequest
+        import SpansProtoEncoder.jsonPrinter
 
-    val protocol = config.get(ConfigKeys.TracesProtocol).flatMap {
-      case Some(value) =>
-        Right(value)
-
-      case None =>
-        config
-          .get(ConfigKeys.GeneralProtocol)
-          .map(_.getOrElse(Defaults.OtlpProtocol))
-    }
-
-    protocol match {
-      case Right(Protocol.Http(encoding)) =>
         val defaults = OtlpHttpClientAutoConfigure.Defaults(
           OtlpHttpSpanExporter.Defaults.Endpoint,
           OtlpHttpSpanExporter.Defaults.Endpoint.path.toString,
@@ -98,55 +73,11 @@ private final class OtlpSpanExporterAutoConfigure[
           .traces[F, SpanData](defaults, customClient)
           .configure(config)
           .map(client => new OtlpHttpSpanExporter[F](client))
-
-      case Left(e) =>
-        Resource.raiseError(e: Throwable)
-    }
-  }
-
-  private implicit val protocolReader: Config.Reader[Protocol] =
-    Config.Reader.decodeWithHint("Protocol") { s =>
-      s.trim.toLowerCase match {
-        case "http/json" =>
-          Right(Protocol.Http(HttpPayloadEncoding.Json))
-
-        case "http/protobuf" =>
-          Right(Protocol.Http(HttpPayloadEncoding.Protobuf))
-
-        case _ =>
-          Left(
-            ConfigurationError(
-              s"Unrecognized protocol [$s]. Supported options [http/json, http/protobuf]"
-            )
-          )
-      }
     }
 
 }
 
 object OtlpSpanExporterAutoConfigure {
-
-  private sealed trait Protocol
-  private object Protocol {
-    final case class Http(encoding: HttpPayloadEncoding) extends Protocol
-  }
-
-  private object ConfigKeys {
-    val GeneralProtocol: Config.Key[Protocol] =
-      Config.Key("otel.exporter.otlp.protocol")
-
-    val TracesProtocol: Config.Key[Protocol] =
-      Config.Key("otel.exporter.otlp.traces.protocol")
-
-    val All: Set[Config.Key[_]] = Set(
-      GeneralProtocol,
-      TracesProtocol
-    )
-  }
-
-  private object Defaults {
-    val OtlpProtocol: Protocol = Protocol.Http(HttpPayloadEncoding.Protobuf)
-  }
 
   /** Autoconfigures OTLP
     * [[org.typelevel.otel4s.sdk.trace.exporter.SpanExporter SpanExporter]].

--- a/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigureSuite.scala
+++ b/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/autoconfigure/OtlpSpanExporterAutoConfigureSuite.scala
@@ -93,7 +93,7 @@ class OtlpSpanExporterAutoConfigureSuite
       .attempt
       .map(_.leftMap(_.getMessage))
       .assertEquals(
-        Left("""Cannot autoconfigure [OtlpSpanExporter].
+        Left("""Cannot autoconfigure [Protocol].
                |Cause: Unrecognized protocol [grpc]. Supported options [http/json, http/protobuf].
                |Config:
                |1) `otel.exporter.otlp.protocol` - grpc


### PR DESCRIPTION
Decoupling `Protocol` configuration to reuse it by the metrics exporter.