### PR TITLE
sdk-metrics: use `ExemplarReservoirs` when they are really needed

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterProvider.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterProvider.scala
@@ -35,6 +35,7 @@ import org.typelevel.otel4s.sdk.context.AskContext
 import org.typelevel.otel4s.sdk.internal.ComponentRegistry
 import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.Reservoirs
 import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
 import org.typelevel.otel4s.sdk.metrics.exporter.MetricProducer
 import org.typelevel.otel4s.sdk.metrics.exporter.MetricReader
@@ -235,13 +236,14 @@ object SdkMeterProvider {
           ExemplarFilter.traceBased(traceContextLookup)
         )
 
+        val reservoirs = Reservoirs(filter, traceContextLookup)
+
         for {
           state <- MeterSharedState.create(
             resource,
             scope,
             startTimestamp,
-            filter,
-            traceContextLookup,
+            reservoirs,
             viewRegistry,
             readers
           )

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoir.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/ExemplarReservoir.scala
@@ -128,6 +128,17 @@ private[metrics] object ExemplarReservoir {
         original.collectAndReset(attributes)
     }
 
+  /** Creates a reservoir that does not record measurements.
+    */
+  def noop[F[_]: Applicative, A]: ExemplarReservoir[F, A] =
+    new ExemplarReservoir[F, A] {
+      def offer(value: A, attributes: Attributes, context: Context): F[Unit] =
+        Applicative[F].unit
+
+      def collectAndReset(attributes: Attributes): F[Vector[Exemplar[A]]] =
+        Applicative[F].pure(Vector.empty)
+    }
+
   private def create[F[_]: Temporal, A](
       size: Int,
       cellSelector: CellSelector[F, A],

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/Reservoirs.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exemplar/Reservoirs.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.exemplar
+
+import cats.Applicative
+import cats.effect.Temporal
+import cats.effect.std.Random
+import cats.syntax.functor._
+import org.typelevel.otel4s.metrics.BucketBoundaries
+import org.typelevel.otel4s.metrics.MeasurementValue
+
+private[metrics] sealed trait Reservoirs[F[_]] {
+
+  /** Creates a reservoir with fixed size that stores the given number of
+    * exemplars.
+    *
+    * @param size
+    *   the maximum number of exemplars to preserve
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def fixedSize[A: MeasurementValue](size: Int): F[ExemplarReservoir[F, A]]
+
+  /** Creates a reservoir that preserves the latest seen measurement per
+    * histogram bucket.
+    *
+    * @param boundaries
+    *   the bucket boundaries of the histogram
+    *
+    * @tparam A
+    *   the type of the values to record
+    */
+  def histogramBucket[A: MeasurementValue: Numeric](
+      boundaries: BucketBoundaries
+  ): F[ExemplarReservoir[F, A]]
+
+}
+
+private[metrics] object Reservoirs {
+
+  /** Creates [[Reservoirs]] according to the given `filter`.
+    *
+    * @param filter
+    *   used by the exemplar reservoir to filter the offered values
+    *
+    * @param lookup
+    *   used by the exemplar reservoir to extract tracing information from the
+    *   context
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def apply[F[_]: Temporal: Random](
+      filter: ExemplarFilter,
+      lookup: TraceContextLookup
+  ): Reservoirs[F] = {
+    def isAlwaysOn =
+      filter == ExemplarFilter.alwaysOn
+
+    def isAlwaysOff =
+      filter == ExemplarFilter.alwaysOff || lookup == TraceContextLookup.noop
+
+    if (isAlwaysOn) alwaysOn[F](lookup)
+    else if (isAlwaysOff) alwaysOff[F]
+    else filtered(filter, lookup)
+  }
+
+  /** Creates [[Reservoirs]] that returns 'always-on' reservoirs.
+    *
+    * @param lookup
+    *   used by the exemplar reservoir to extract tracing information from the
+    *   context
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def alwaysOn[F[_]: Temporal: Random](
+      lookup: TraceContextLookup
+  ): Reservoirs[F] =
+    new AlwaysOn[F](lookup)
+
+  /** Creates [[Reservoirs]] that returns no-op reservoirs.
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def alwaysOff[F[_]: Applicative]: Reservoirs[F] =
+    new AlwaysOff[F]
+
+  /** Creates [[Reservoirs]] that returns filtered reservoirs.
+    *
+    * @param lookup
+    *   used by the exemplar reservoir to extract tracing information from the
+    *   context
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def filtered[F[_]: Temporal: Random](
+      filter: ExemplarFilter,
+      lookup: TraceContextLookup
+  ): Reservoirs[F] =
+    new Filtered[F](filter, lookup)
+
+  private final class AlwaysOn[F[_]: Temporal: Random](
+      lookup: TraceContextLookup
+  ) extends Reservoirs[F] {
+    def fixedSize[A: MeasurementValue](
+        size: Int
+    ): F[ExemplarReservoir[F, A]] =
+      ExemplarReservoir.fixedSize[F, A](size, lookup)
+
+    def histogramBucket[A: MeasurementValue: Numeric](
+        boundaries: BucketBoundaries
+    ): F[ExemplarReservoir[F, A]] =
+      ExemplarReservoir.histogramBucket[F, A](boundaries, lookup)
+  }
+
+  private final class AlwaysOff[F[_]: Applicative] extends Reservoirs[F] {
+    def fixedSize[A: MeasurementValue](size: Int): F[ExemplarReservoir[F, A]] =
+      Applicative[F].pure(ExemplarReservoir.noop[F, A])
+
+    def histogramBucket[A: MeasurementValue: Numeric](
+        boundaries: BucketBoundaries
+    ): F[ExemplarReservoir[F, A]] =
+      Applicative[F].pure(ExemplarReservoir.noop[F, A])
+  }
+
+  private final class Filtered[F[_]: Temporal: Random](
+      filter: ExemplarFilter,
+      lookup: TraceContextLookup
+  ) extends Reservoirs[F] {
+    def fixedSize[A: MeasurementValue](
+        size: Int
+    ): F[ExemplarReservoir[F, A]] =
+      ExemplarReservoir
+        .fixedSize[F, A](size, lookup)
+        .map(r => ExemplarReservoir.filtered(filter, r))
+
+    def histogramBucket[A: MeasurementValue: Numeric](
+        boundaries: BucketBoundaries
+    ): F[ExemplarReservoir[F, A]] =
+      ExemplarReservoir
+        .histogramBucket[F, A](boundaries, lookup)
+        .map(r => ExemplarReservoir.filtered(filter, r))
+  }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/storage/AsynchronousStorage.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/storage/AsynchronousStorage.scala
@@ -20,7 +20,6 @@ import cats.Monad
 import cats.data.NonEmptyVector
 import cats.effect.Concurrent
 import cats.effect.Ref
-import cats.effect.Temporal
 import cats.effect.std.Console
 import cats.mtl.Ask
 import cats.syntax.flatMap._
@@ -145,7 +144,7 @@ private object AsynchronousStorage {
     *   the type of the values to store
     */
   def create[
-      F[_]: Temporal: Console: AskContext,
+      F[_]: Concurrent: Console: AskContext,
       A: MeasurementValue: Numeric
   ](
       reader: RegisteredReader[F],

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/AggregatorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/AggregatorSuite.scala
@@ -33,7 +33,7 @@ import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
 import org.typelevel.otel4s.sdk.metrics.data.PointData
 import org.typelevel.otel4s.sdk.metrics.data.TimeWindow
-import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
+import org.typelevel.otel4s.sdk.metrics.exemplar.Reservoirs
 import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
 import org.typelevel.otel4s.sdk.metrics.internal.MetricDescriptor
 import org.typelevel.otel4s.sdk.metrics.scalacheck.Gens
@@ -75,10 +75,9 @@ class AggregatorSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
         val aggregator = Aggregator
           .synchronous[IO, Long](
+            Reservoirs.alwaysOn(TraceContextLookup.noop),
             aggregation,
-            descriptor,
-            ExemplarFilter.alwaysOn,
-            TraceContextLookup.noop
+            descriptor
           )
           .asInstanceOf[SynchronousAggregator[IO, Long]]
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
@@ -19,7 +19,6 @@ package org.typelevel.otel4s.sdk.metrics.internal
 import cats.data.NonEmptyList
 import cats.data.NonEmptyVector
 import cats.effect.IO
-import cats.effect.std.Random
 import cats.mtl.Ask
 import munit.CatsEffectSuite
 import munit.ScalaCheckEffectSuite
@@ -34,8 +33,7 @@ import org.typelevel.otel4s.sdk.metrics.InstrumentType
 import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
 import org.typelevel.otel4s.sdk.metrics.data.MetricData
 import org.typelevel.otel4s.sdk.metrics.data.MetricPoints
-import org.typelevel.otel4s.sdk.metrics.exemplar.ExemplarFilter
-import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
+import org.typelevel.otel4s.sdk.metrics.exemplar.Reservoirs
 import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
 import org.typelevel.otel4s.sdk.metrics.exporter.InMemoryMetricReader
 import org.typelevel.otel4s.sdk.metrics.exporter.MetricProducer
@@ -214,17 +212,14 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   ): IO[MeterSharedState[IO]] = {
     implicit val askContext: Ask[IO, Context] = Ask.const(Context.root)
 
-    Random.scalaUtilRandom[IO].flatMap { implicit R: Random[IO] =>
-      MeterSharedState.create[IO](
-        resource,
-        scope,
-        start,
-        ExemplarFilter.alwaysOff,
-        TraceContextLookup.noop,
-        ViewRegistry(Vector.empty),
-        Vector(reader)
-      )
-    }
+    MeterSharedState.create[IO](
+      resource,
+      scope,
+      start,
+      Reservoirs.alwaysOff,
+      ViewRegistry(Vector.empty),
+      Vector(reader)
+    )
   }
 
   private def emptyProducer: MetricProducer[IO] =


### PR DESCRIPTION
Closes https://github.com/typelevel/otel4s/issues/664.