### PR TITLE
sdk-metrics: add `Advice`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
@@ -96,6 +96,7 @@ private object SdkCounter {
         name = CIString(name),
         description = description,
         unit = unit,
+        advice = None,
         instrumentType = InstrumentType.Counter
       )
 

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -31,6 +31,7 @@ import org.typelevel.otel4s.metrics.Histogram
 import org.typelevel.otel4s.metrics.MeasurementValue
 import org.typelevel.otel4s.sdk.context.AskContext
 import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.internal.Advice
 import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
 import org.typelevel.otel4s.sdk.metrics.internal.MeterSharedState
 import org.typelevel.otel4s.sdk.metrics.internal.storage.MetricStorage
@@ -120,6 +121,7 @@ private object SdkHistogram {
         name = CIString(name),
         description = description,
         unit = unit,
+        advice = boundaries.map(b => Advice(Some(b))),
         instrumentType = InstrumentType.Histogram
       )
 

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -92,6 +92,7 @@ private object SdkUpDownCounter {
         name = CIString(name),
         description = description,
         unit = unit,
+        advice = None,
         instrumentType = InstrumentType.UpDownCounter
       )
 

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/aggregation/Aggregator.scala
@@ -240,7 +240,11 @@ private[metrics] object Aggregator {
           case InstrumentType.Counter       => sum
           case InstrumentType.UpDownCounter => sum
           case InstrumentType.Histogram =>
-            histogram(Aggregation.Defaults.Boundaries)
+            val boundaries = descriptor.advice
+              .flatMap(_.explicitBucketBoundaries)
+              .getOrElse(Aggregation.Defaults.Boundaries)
+
+            histogram(boundaries)
         }
 
       case Aggregation.Sum       => sum

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/Advice.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/Advice.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics.internal
+
+import cats.Hash
+import cats.Show
+import cats.syntax.foldable._
+import org.typelevel.otel4s.metrics.BucketBoundaries
+
+/** Advisory options influencing aggregation configuration parameters.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-advisory-parameters]]
+  */
+private[metrics] sealed trait Advice {
+
+  /** The recommended set of bucket boundaries to use if the selected
+    * aggregation is `ExplicitBucketHistogram`.
+    */
+  def explicitBucketBoundaries: Option[BucketBoundaries]
+
+  override final def hashCode(): Int =
+    Hash[Advice].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: Advice => Hash[Advice].eqv(this, other)
+      case _             => false
+    }
+
+  override final def toString: String =
+    Show[Advice].show(this)
+}
+
+private[metrics] object Advice {
+
+  /** Creates an [[Advice]] with the given values.
+    *
+    * @param bucketBoundaries
+    *   the recommended set of bucket boundaries to use if the selected
+    *   aggregation is `explicit bucket histogram`
+    */
+  def apply(bucketBoundaries: Option[BucketBoundaries]): Advice =
+    Impl(bucketBoundaries)
+
+  implicit val adviceHash: Hash[Advice] =
+    Hash.by(_.explicitBucketBoundaries)
+
+  implicit val adviceShow: Show[Advice] =
+    Show.show { advice =>
+      val boundaries = advice.explicitBucketBoundaries.foldMap { b =>
+        s"explicitBucketBoundaries=$b"
+      }
+      s"Advice{$boundaries}"
+    }
+
+  private final case class Impl(
+      explicitBucketBoundaries: Option[BucketBoundaries]
+  ) extends Advice
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/InstrumentDescriptor.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/InstrumentDescriptor.scala
@@ -41,6 +41,10 @@ private[metrics] sealed trait InstrumentDescriptor {
     */
   def unit: Option[String]
 
+  /** The advisory options influencing aggregation configuration parameters.
+    */
+  def advice: Option[Advice]
+
   /** The type of the instrument.
     */
   def instrumentType: InstrumentType
@@ -75,9 +79,10 @@ private[metrics] object InstrumentDescriptor {
       name: CIString,
       description: Option[String],
       unit: Option[String],
-      instrumentType: InstrumentType.Synchronous
+      advice: Option[Advice],
+      instrumentType: InstrumentType.Synchronous,
   ): InstrumentDescriptor.Synchronous =
-    SynchronousImpl(name, description, unit, instrumentType)
+    SynchronousImpl(name, description, unit, advice, instrumentType)
 
   /** Creates an [[InstrumentDescriptor]] for a asynchronous instrument.
     */
@@ -87,7 +92,7 @@ private[metrics] object InstrumentDescriptor {
       unit: Option[String],
       instrumentType: InstrumentType.Asynchronous
   ): InstrumentDescriptor.Asynchronous =
-    AsynchronousImpl(name, description, unit, instrumentType)
+    AsynchronousImpl(name, description, unit, None, instrumentType)
 
   implicit val instrumentDescriptorHash: Hash[InstrumentDescriptor] =
     Hash.by { descriptor =>
@@ -95,6 +100,7 @@ private[metrics] object InstrumentDescriptor {
         descriptor.name,
         descriptor.description,
         descriptor.unit,
+        descriptor.advice,
         descriptor.instrumentType
       )
     }
@@ -103,13 +109,15 @@ private[metrics] object InstrumentDescriptor {
     Show.show { descriptor =>
       val description = descriptor.description.foldMap(d => s"description=$d, ")
       val unit = descriptor.unit.foldMap(d => s"unit=$d, ")
-      s"InstrumentDescriptor{name=${descriptor.name}, $description${unit}type=${descriptor.instrumentType}}"
+      val advice = descriptor.advice.foldMap(a => s"advice=$a, ")
+      s"InstrumentDescriptor{name=${descriptor.name}, $description$unit${advice}type=${descriptor.instrumentType}}"
     }
 
   private final case class SynchronousImpl(
       name: CIString,
       description: Option[String],
       unit: Option[String],
+      advice: Option[Advice],
       instrumentType: InstrumentType.Synchronous
   ) extends InstrumentDescriptor.Synchronous
 
@@ -117,6 +125,7 @@ private[metrics] object InstrumentDescriptor {
       name: CIString,
       description: Option[String],
       unit: Option[String],
+      advice: Option[Advice],
       instrumentType: InstrumentType.Asynchronous
   ) extends InstrumentDescriptor.Asynchronous
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/scalacheck/Gens.scala
@@ -68,7 +68,7 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens {
       name <- Gens.ciString
       description <- Gen.option(Gen.alphaNumStr)
       unit <- Gen.option(Gen.alphaNumStr)
-    } yield InstrumentDescriptor.synchronous(name, description, unit, tpe)
+    } yield InstrumentDescriptor.synchronous(name, description, unit, None, tpe)
 
   val asynchronousInstrumentDescriptor: Gen[InstrumentDescriptor.Asynchronous] =
     for {


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-advisory-parameters |
| Java implementation | [Advice.java](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/descriptor/Advice.java)  |
