### PR TITLE
metrics: support synchronous gauge

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.7"
+ThisBuild / tlBaseVersion := "0.8"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package metrics
+
+import scala.collection.immutable
+
+private[otel4s] trait GaugeMacro[F[_], A] {
+  def backend: Gauge.Backend[F, A]
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def record(value: A, attributes: Attribute[_]*): F[Unit] =
+    macro GaugeMacro.record[A]
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  def record(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
+    macro GaugeMacro.recordColl[A]
+
+}
+
+object GaugeMacro {
+  import scala.reflect.macros.blackbox
+
+  def record[A](c: blackbox.Context)(
+      value: c.Expr[A],
+      attributes: c.Expr[Attribute[_]]*
+  ): c.universe.Tree = {
+    import c.universe._
+    recordColl(c)(value, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+  }
+
+  def recordColl[A](c: blackbox.Context)(
+      value: c.Expr[A],
+      attributes: c.Expr[immutable.Iterable[Attribute[_]]]
+  ): c.universe.Tree = {
+    import c.universe._
+    val backend = q"${c.prefix}.backend"
+    val meta = q"$backend.meta"
+
+    q"if ($meta.isEnabled) $backend.record($value, $attributes) else $meta.unit"
+  }
+
+}

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package metrics
+
+import scala.collection.immutable
+import scala.quoted.*
+
+private[otel4s] trait GaugeMacro[F[_], A] {
+  def backend: Gauge.Backend[F, A]
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def record(
+      inline value: A,
+      inline attributes: Attribute[_]*
+  ): F[Unit] =
+    ${ GaugeMacro.record('backend, 'value, 'attributes) }
+
+  /** Records a value with a set of attributes.
+    *
+    * @param value
+    *   the value to record
+    *
+    * @param attributes
+    *   the set of attributes to associate with the value
+    */
+  inline def record(
+      inline value: A,
+      inline attributes: immutable.Iterable[Attribute[_]]
+  ): F[Unit] =
+    ${ GaugeMacro.record('backend, 'value, 'attributes) }
+
+}
+
+object GaugeMacro {
+
+  def record[F[_], A](
+      backend: Expr[Gauge.Backend[F, A]],
+      value: Expr[A],
+      attributes: Expr[immutable.Iterable[Attribute[_]]]
+  )(using Quotes, Type[F], Type[A]) =
+    '{
+      if ($backend.meta.isEnabled) $backend.record($value, $attributes)
+      else $backend.meta.unit
+    }
+
+}

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Gauge.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Gauge.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package metrics
+
+import cats.Applicative
+import org.typelevel.otel4s.meta.InstrumentMeta
+
+import scala.collection.immutable
+
+/** A `Gauge` instrument that records non-additive values of type `A`.
+  *
+  * @see
+  *   See [[UpDownCounter]] to record additive values
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  *
+  * @tparam A
+  *   the type of the values to record. The type must have an instance of
+  *   [[MeasurementValue]]. [[scala.Long]] and [[scala.Double]] are supported
+  *   out of the box.
+  */
+trait Gauge[F[_], A] extends GaugeMacro[F, A]
+
+object Gauge {
+
+  /** A builder of [[Gauge]].
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    *
+    * @tparam A
+    *   the type of the values to record. The type must have an instance of
+    *   [[MeasurementValue]]. [[scala.Long]] and [[scala.Double]] are supported
+    *   out of the box.
+    */
+  trait Builder[F[_], A] {
+
+    /** Sets the unit of measure for this counter.
+      *
+      * @see
+      *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-unit Instrument Unit]]
+      *
+      * @param unit
+      *   the measurement unit. Must be 63 or fewer ASCII characters.
+      */
+    def withUnit(unit: String): Builder[F, A]
+
+    /** Sets the description for this gauge.
+      *
+      * @see
+      *   [[https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-description Instrument Description]]
+      *
+      * @param description
+      *   the description
+      */
+    def withDescription(description: String): Builder[F, A]
+
+    /** Creates a [[Gauge]] with the given `unit` and `description` (if any).
+      */
+    def create: F[Gauge[F, A]]
+  }
+
+  trait Backend[F[_], A] {
+    def meta: InstrumentMeta[F]
+
+    /** Records a value with a set of attributes.
+      *
+      * @param value
+      *   the value to record
+      *
+      * @param attributes
+      *   the set of attributes to associate with the value
+      */
+    def record(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit]
+
+  }
+
+  def noop[F[_], A](implicit F: Applicative[F]): Gauge[F, A] =
+    new Gauge[F, A] {
+      val backend: Backend[F, A] =
+        new Backend[F, A] {
+          val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+          def record(
+              value: A,
+              attributes: immutable.Iterable[Attribute[_]]
+          ): F[Unit] = meta.unit
+        }
+    }
+
+  private[otel4s] def fromBackend[F[_], A](b: Backend[F, A]): Gauge[F, A] =
+    new Gauge[F, A] {
+      def backend: Backend[F, A] = b
+    }
+
+}

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
@@ -135,6 +135,37 @@ trait Meter[F[_]] {
       name: String
   ): UpDownCounter.Builder[F, A]
 
+  /** Creates a builder of [[Gauge]] instrument that records values of type `A`.
+    *
+    * The [[Gauge]] records non-additive values.
+    *
+    * @note
+    *   the `A` type must be provided explicitly, for example
+    *   `meter.gauge[Long]` or `meter.gauge[Double]`
+    *
+    * @example
+    *   {{{
+    * val meter: Meter[F] = ???
+    *
+    * val doubleGauge: F[Gauge[F, Double]] =
+    *   meter.gauge[Double]("double-gauge").create
+    *
+    * val longGauge: F[Gauge[F, Long]] =
+    *   meter.gauge[Long]("long-gauge").create
+    *   }}}
+    *
+    * @see
+    *   See [[upDownCounter]] to record additive values
+    *
+    * @param name
+    *   the name of the instrument
+    *
+    * @tparam A
+    *   the type of the measurement. [[scala.Long]] and [[scala.Double]] are
+    *   supported out of the box
+    */
+  def gauge[A: MeasurementValue](name: String): Gauge.Builder[F, A]
+
   /** Creates a builder of [[ObservableGauge]] instrument that collects values
     * of type `A` from the given callback.
     *
@@ -324,6 +355,13 @@ object Meter {
               description: String
           ): UpDownCounter.Builder[F, A] = this
           def create: F[UpDownCounter[F, A]] = F.pure(UpDownCounter.noop)
+        }
+
+      def gauge[A: MeasurementValue](name: String): Gauge.Builder[F, A] =
+        new Gauge.Builder[F, A] {
+          def withUnit(unit: String): Gauge.Builder[F, A] = this
+          def withDescription(description: String): Gauge.Builder[F, A] = this
+          def create: F[Gauge[F, A]] = F.pure(Gauge.noop)
         }
 
       def observableGauge[A: MeasurementValue](

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package oteljava
+package metrics
+
+import cats.effect.kernel.Sync
+import io.opentelemetry.api.metrics.{Meter => JMeter}
+import org.typelevel.otel4s.meta.InstrumentMeta
+import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.oteljava.AttributeConverters._
+import org.typelevel.otel4s.oteljava.context.AskContext
+
+import scala.collection.immutable
+
+private[oteljava] case class GaugeBuilderImpl[F[_], A](
+    factory: GaugeBuilderImpl.Factory[F, A],
+    name: String,
+    unit: Option[String] = None,
+    description: Option[String] = None
+) extends Gauge.Builder[F, A] {
+
+  def withUnit(unit: String): Gauge.Builder[F, A] =
+    copy(unit = Option(unit))
+
+  def withDescription(description: String): Gauge.Builder[F, A] =
+    copy(description = Option(description))
+
+  def create: F[Gauge[F, A]] =
+    factory.create(name, unit, description)
+
+}
+
+private[oteljava] object GaugeBuilderImpl {
+
+  def apply[F[_]: Sync: AskContext, A: MeasurementValue](
+      jMeter: JMeter,
+      name: String
+  ): Gauge.Builder[F, A] =
+    MeasurementValue[A] match {
+      case MeasurementValue.LongMeasurementValue(cast) =>
+        GaugeBuilderImpl(longFactory(jMeter, cast), name)
+
+      case MeasurementValue.DoubleMeasurementValue(cast) =>
+        GaugeBuilderImpl(doubleFactory(jMeter, cast), name)
+    }
+
+  private[oteljava] trait Factory[F[_], A] {
+    def create(
+        name: String,
+        unit: Option[String],
+        description: Option[String]
+    ): F[Gauge[F, A]]
+  }
+
+  private def longFactory[F[_]: Sync: AskContext, A](
+      jMeter: JMeter,
+      cast: A => Long
+  ): Factory[F, A] =
+    new Factory[F, A] {
+      def create(
+          name: String,
+          unit: Option[String],
+          description: Option[String]
+      ): F[Gauge[F, A]] =
+        Sync[F].delay {
+          val builder = jMeter.gaugeBuilder(name)
+          unit.foreach(builder.setUnit)
+          description.foreach(builder.setDescription)
+          val gauge = builder.ofLongs().build()
+
+          val backend = new Gauge.Backend[F, A] {
+            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+
+            def record(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
+              ContextUtils.delayWithContext { () =>
+                gauge.set(cast(value), attributes.toJavaAttributes)
+              }
+          }
+
+          Gauge.fromBackend(backend)
+        }
+    }
+
+  private def doubleFactory[F[_]: Sync: AskContext, A](
+      jMeter: JMeter,
+      cast: A => Double
+  ): Factory[F, A] =
+    new Factory[F, A] {
+      def create(
+          name: String,
+          unit: Option[String],
+          description: Option[String]
+      ): F[Gauge[F, A]] =
+        Sync[F].delay {
+          val builder = jMeter.gaugeBuilder(name)
+          unit.foreach(builder.setUnit)
+          description.foreach(builder.setDescription)
+          val gauge = builder.build()
+
+          val backend = new Gauge.Backend[F, A] {
+            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+
+            def record(
+                value: A,
+                attributes: immutable.Iterable[Attribute[_]]
+            ): F[Unit] =
+              ContextUtils.delayWithContext { () =>
+                gauge.set(cast(value), attributes.toJavaAttributes)
+              }
+          }
+
+          Gauge.fromBackend(backend)
+        }
+    }
+
+}

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
@@ -37,6 +37,9 @@ private[oteljava] class MeterImpl[F[_]: Async: AskContext](jMeter: JMeter)
   ): UpDownCounter.Builder[F, A] =
     UpDownCounterBuilderImpl(jMeter, name)
 
+  def gauge[A: MeasurementValue](name: String): Gauge.Builder[F, A] =
+    GaugeBuilderImpl(jMeter, name)
+
   def observableGauge[A: MeasurementValue](
       name: String
   ): ObservableGauge.Builder[F, A] =

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/Aggregation.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/Aggregation.scala
@@ -59,6 +59,7 @@ object Aggregation {
     *   - counter - [[sum]]
     *   - up down counter - [[sum]]
     *   - observable counter - [[sum]]
+    *   - gauge - [[lastValue]]
     *   - observable up down counter - [[sum]]
     *   - histogram - `explicitBucketHistogram`
     *   - observable gauge - [[lastValue]]
@@ -82,6 +83,7 @@ object Aggregation {
     * using the last seen measurement.
     *
     * Compatible instruments:
+    *   - [[org.typelevel.otel4s.metrics.Gauge Gauge]]
     *   - [[org.typelevel.otel4s.metrics.ObservableGauge ObservableGauge]]
     */
   def lastValue: Aggregation = LastValue
@@ -165,7 +167,7 @@ object Aggregation {
     )
 
     val LastValue: Set[InstrumentType] =
-      Set(InstrumentType.ObservableGauge)
+      Set(InstrumentType.Gauge, InstrumentType.ObservableGauge)
 
     val ExplicitBucketHistogram: Set[InstrumentType] =
       Set(InstrumentType.Counter, InstrumentType.Histogram)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/InstrumentType.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/InstrumentType.scala
@@ -62,6 +62,7 @@ object InstrumentType {
   case object Counter extends Synchronous
   case object UpDownCounter extends Synchronous
   case object Histogram extends Synchronous
+  case object Gauge extends Synchronous
   case object ObservableCounter extends Asynchronous
   case object ObservableUpDownCounter extends Asynchronous
   case object ObservableGauge extends Asynchronous
@@ -70,6 +71,7 @@ object InstrumentType {
     Counter,
     UpDownCounter,
     Histogram,
+    Gauge,
     ObservableCounter,
     ObservableUpDownCounter,
     ObservableGauge

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilder.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilder.scala
@@ -22,6 +22,7 @@ import cats.effect.std.Console
 import cats.syntax.functor._
 import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.metrics.Counter
+import org.typelevel.otel4s.metrics.Gauge
 import org.typelevel.otel4s.metrics.Histogram
 import org.typelevel.otel4s.metrics.Measurement
 import org.typelevel.otel4s.metrics.ObservableCounter
@@ -76,6 +77,20 @@ private object NoopInstrumentBuilder {
 
       def create: F[UpDownCounter[F, A]] =
         warn("UpDownCounter", name).as(UpDownCounter.noop)
+    }
+
+  def gauge[F[_]: Applicative: Console, A](
+      name: String
+  ): Gauge.Builder[F, A] =
+    new Gauge.Builder[F, A] {
+      def withUnit(unit: String): Gauge.Builder[F, A] =
+        this
+
+      def withDescription(description: String): Gauge.Builder[F, A] =
+        this
+
+      def create: F[Gauge[F, A]] =
+        warn("Gauge", name).as(Gauge.noop)
     }
 
   def observableGauge[F[_]: Applicative: Console, A](

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.metrics
+
+import cats.Monad
+import cats.effect.std.Console
+import cats.mtl.Ask
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.meta.InstrumentMeta
+import org.typelevel.otel4s.metrics.Gauge
+import org.typelevel.otel4s.metrics.MeasurementValue
+import org.typelevel.otel4s.sdk.context.AskContext
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.metrics.internal.InstrumentDescriptor
+import org.typelevel.otel4s.sdk.metrics.internal.MeterSharedState
+import org.typelevel.otel4s.sdk.metrics.internal.storage.MetricStorage
+
+import scala.collection.immutable
+
+/** A synchronous instrument that records non-additive values.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge]]
+  */
+private object SdkGauge {
+
+  private final class Backend[F[_]: Monad: AskContext, A, Primitive](
+      cast: A => Primitive,
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+  ) extends Gauge.Backend[F, A] {
+    def meta: InstrumentMeta[F] = InstrumentMeta.enabled
+
+    def record(
+        value: A,
+        attributes: immutable.Iterable[Attribute[_]]
+    ): F[Unit] =
+      for {
+        ctx <- Ask[F, Context].ask
+        _ <- storage.record(cast(value), attributes.to(Attributes), ctx)
+      } yield ()
+
+  }
+
+  final case class Builder[
+      F[_]: Monad: Console: AskContext,
+      A: MeasurementValue
+  ](
+      name: String,
+      sharedState: MeterSharedState[F],
+      unit: Option[String] = None,
+      description: Option[String] = None
+  ) extends Gauge.Builder[F, A] {
+
+    def withUnit(unit: String): Gauge.Builder[F, A] =
+      copy(unit = Some(unit))
+
+    def withDescription(description: String): Gauge.Builder[F, A] =
+      copy(description = Some(description))
+
+    def create: F[Gauge[F, A]] = {
+      val descriptor = InstrumentDescriptor.synchronous(
+        name = CIString(name),
+        description = description,
+        unit = unit,
+        advice = None,
+        instrumentType = InstrumentType.Gauge
+      )
+
+      MeasurementValue[A] match {
+        case MeasurementValue.LongMeasurementValue(cast) =>
+          sharedState
+            .registerMetricStorage[Long](descriptor)
+            .map { storage =>
+              Gauge.fromBackend(
+                new Backend[F, A, Long](cast, storage)
+              )
+            }
+
+        case MeasurementValue.DoubleMeasurementValue(cast) =>
+          sharedState
+            .registerMetricStorage[Double](descriptor)
+            .map { storage =>
+              Gauge.fromBackend(
+                new Backend[F, A, Double](cast, storage)
+              )
+            }
+      }
+    }
+  }
+
+}

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeter.scala
@@ -21,6 +21,7 @@ import cats.effect.MonadCancelThrow
 import cats.effect.std.Console
 import org.typelevel.otel4s.metrics.BatchCallback
 import org.typelevel.otel4s.metrics.Counter
+import org.typelevel.otel4s.metrics.Gauge
 import org.typelevel.otel4s.metrics.Histogram
 import org.typelevel.otel4s.metrics.MeasurementValue
 import org.typelevel.otel4s.metrics.Meter
@@ -67,6 +68,12 @@ private class SdkMeter[F[_]: MonadCancelThrow: Clock: Console: AskContext](
       SdkUpDownCounter.Builder(name, sharedState)
     else
       NoopInstrumentBuilder.upDownCounter(name)
+
+  def gauge[A: MeasurementValue](name: String): Gauge.Builder[F, A] =
+    if (SdkMeter.isValidName(name))
+      SdkGauge.Builder(name, sharedState)
+    else
+      NoopInstrumentBuilder.gauge(name)
 
   def observableGauge[A: MeasurementValue](
       name: String

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/AggregationSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/AggregationSuite.scala
@@ -88,6 +88,7 @@ class AggregationSuite extends DisciplineSuite {
 
       case lastValue @ Aggregation.LastValue =>
         val compatible: Set[InstrumentType] = Set(
+          InstrumentType.Gauge,
           InstrumentType.ObservableGauge
         )
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilderSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilderSuite.scala
@@ -56,6 +56,15 @@ class NoopInstrumentBuilderSuite extends CatsEffectSuite {
     }
   }
 
+  test("create a noop Gauge") {
+    InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
+      for {
+        _ <- NoopInstrumentBuilder.gauge[IO, Long](incorrectName).create
+        _ <- C.entries.assertEquals(consoleEntries("Gauge"))
+      } yield ()
+    }
+  }
+
   test("create a noop ObservableCounter") {
     InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
       for {

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/AggregatorSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/aggregation/AggregatorSuite.scala
@@ -102,6 +102,7 @@ class AggregatorSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
               descriptor.instrumentType match {
                 case InstrumentType.Counter       => numberPoints
                 case InstrumentType.UpDownCounter => numberPoints
+                case InstrumentType.Gauge         => numberPoints
                 case InstrumentType.Histogram =>
                   histogramPoints(Aggregation.Defaults.Boundaries)
               }
@@ -140,6 +141,7 @@ class AggregatorSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
               descriptor.instrumentType match {
                 case InstrumentType.Counter       => sum
                 case InstrumentType.UpDownCounter => sum
+                case InstrumentType.Gauge         => lastValue
                 case InstrumentType.Histogram =>
                   histogram(Aggregation.Defaults.Boundaries)
               }

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedStateSuite.scala
@@ -79,6 +79,15 @@ class MeterSharedStateSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
               aggregationTemporality = AggregationTemporality.Cumulative
             )
 
+          case InstrumentType.Gauge =>
+            MetricPoints.gauge(
+              PointDataUtils.toNumberPoints(
+                NonEmptyVector.one(value),
+                attributes,
+                timeWindow
+              )
+            )
+
           case InstrumentType.Histogram =>
             MetricPoints.histogram(
               NonEmptyVector.one(


### PR DESCRIPTION
Synchronous gauge is stable since [1.33.0](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.33.0) - https://github.com/open-telemetry/opentelemetry-specification/pull/4019.

Related changes:
- https://github.com/open-telemetry/opentelemetry-java/pull/6419

~`oteljava` waits for the `1.38.0` release.~


The changeset:
- [x] core-metrics: add `Gauge`, `GaugeMacro`
- [x] sdk-metrics: add `SdkGauge`
- [x] sdk-metrics: make `LastValueAggregator` record exemplars
- [x] oteljava-metrics: add `GaugeBuilderImpl`