### PR TITLE
added OtTracePropagator

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
@@ -141,6 +141,7 @@ private[sdk] object ContextPropagatorsAutoConfigure {
     *   - [[B3Propagator.singleHeader b3]]
     *   - [[B3Propagator.multipleHeaders b3multi]]
     *   - [[JaegerPropagator jaeger]]
+   *    - [[OtTracePropagator ottrace]]
     *
     * @see
     *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#propagator]]

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
@@ -141,7 +141,7 @@ private[sdk] object ContextPropagatorsAutoConfigure {
     *   - [[B3Propagator.singleHeader b3]]
     *   - [[B3Propagator.multipleHeaders b3multi]]
     *   - [[JaegerPropagator jaeger]]
-   *    - [[OtTracePropagator ottrace]]
+    *   - [[OtTracePropagator ottrace]]
     *
     * @see
     *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#propagator]]

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
@@ -27,6 +27,7 @@ import org.typelevel.otel4s.sdk.autoconfigure.ConfigurationError
 import org.typelevel.otel4s.sdk.context.Context
 import org.typelevel.otel4s.sdk.trace.context.propagation.B3Propagator
 import org.typelevel.otel4s.sdk.trace.context.propagation.JaegerPropagator
+import org.typelevel.otel4s.sdk.trace.context.propagation.OtTracePropagator
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CBaggagePropagator
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropagator
 
@@ -63,7 +64,8 @@ private final class ContextPropagatorsAutoConfigure[F[_]: MonadThrow](
       AutoConfigure.Named.const("baggage", W3CBaggagePropagator.default),
       AutoConfigure.Named.const("b3", B3Propagator.singleHeader),
       AutoConfigure.Named.const("b3multi", B3Propagator.multipleHeaders),
-      AutoConfigure.Named.const("jaeger", JaegerPropagator.default)
+      AutoConfigure.Named.const("jaeger", JaegerPropagator.default),
+      AutoConfigure.Named.const("ottrace", OtTracePropagator.default)
     )
 
     default ++ extra

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagator.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagator.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.otel4s.sdk.trace.context.propagation
 
 import org.typelevel.otel4s.baggage.Baggage

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagator.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagator.scala
@@ -1,0 +1,134 @@
+package org.typelevel.otel4s.sdk.trace.context.propagation
+
+import org.typelevel.otel4s.baggage.Baggage
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.context.propagation.TextMapUpdater
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.SdkContextKeys
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.SpanContext.SpanId
+import org.typelevel.otel4s.trace.SpanContext.TraceId
+import org.typelevel.otel4s.trace.TraceFlags
+import org.typelevel.otel4s.trace.TraceState
+import scodec.bits.ByteVector
+
+import java.util.Locale
+
+private final class OtTracePropagator extends TextMapPropagator[Context] {
+
+  import OtTracePropagator.Headers
+  import OtTracePropagator.Const
+
+  override def fields: List[String] = List(
+    Headers.TraceId,
+    Headers.SpanId,
+    Headers.Sampled
+  )
+
+  override def extract[A: TextMapGetter](ctx: Context, carrier: A): Context = {
+    val spanContext = for {
+      traceIdHex <- TextMapGetter[A].get(carrier, Headers.TraceId)
+      traceId <- ByteVector.fromHex(traceIdHex) if isValidTraceId(traceId)
+
+      spanHexId <- TextMapGetter[A].get(carrier, Headers.SpanId)
+      spanId <- ByteVector.fromHex(spanHexId) if isValidSpanId(spanId)
+
+      sampled <- TextMapGetter[A]
+        .get(carrier, Headers.Sampled)
+        .flatMap(_.toBooleanOption)
+
+    } yield SpanContext(
+      traceId = traceId,
+      spanId = spanId,
+      traceFlags = if (sampled) TraceFlags.Sampled else TraceFlags.Default,
+      traceState = TraceState.empty,
+      remote = true
+    )
+    // Baggage is only extracted if there is a valid SpanContext
+    spanContext match {
+      case Some(spanContext) =>
+        ctx
+          .updated(SdkContextKeys.SpanContextKey, spanContext)
+          .updated(SdkContextKeys.BaggageKey, decodeBaggage(carrier))
+      case None => ctx
+    }
+  }
+
+  override def inject[A: TextMapUpdater](ctx: Context, carrier: A): A = {
+
+    ctx.get(SdkContextKeys.SpanContextKey).filter(_.isValid) match {
+      case Some(spanContext) =>
+        val sampled =
+          if (spanContext.isSampled) Const.IsSampled else Const.NotSampled
+
+        val headers = Map(
+          Headers.TraceId -> spanContext.traceIdHex,
+          Headers.SpanId -> spanContext.spanIdHex,
+          Headers.Sampled -> sampled
+        ) ++ encodeBaggage(
+          ctx
+        ) // Baggage is only injected if there is a valid SpanContext
+
+        headers.foldLeft(carrier) { case (carrier, (key, value)) =>
+          TextMapUpdater[A].updated(carrier, key, value)
+        }
+
+      case None => carrier
+    }
+
+  }
+
+  override def toString: String = "OtTracePropagator"
+
+  private def encodeBaggage(ctx: Context) =
+    ctx
+      .get(SdkContextKeys.BaggageKey)
+      .map(_.asMap.map { case (key, entry) =>
+        Const.BaggagePrefix + key -> entry.value
+      })
+      .getOrElse(Map.empty)
+
+  private def decodeBaggage[A: TextMapGetter](carrier: A) = {
+    val keys = TextMapGetter[A].keys(carrier)
+    val prefixLength = Const.BaggagePrefix.length
+
+    keys.foldLeft(Baggage.empty) {
+      case (baggage, key)
+          if key.toLowerCase(Locale.ROOT).startsWith(Const.BaggagePrefix) =>
+        TextMapGetter[A]
+          .get(carrier, key)
+          .fold(baggage)(v => baggage.updated(key.drop(prefixLength), v))
+
+      case (baggage, _) => baggage
+    }
+  }
+
+  private def isValidTraceId(value: ByteVector): Boolean =
+    TraceId.isValid(value.padLeft(TraceId.Bytes.toLong))
+
+  private def isValidSpanId(value: ByteVector): Boolean =
+    SpanId.isValid(value)
+}
+
+object OtTracePropagator {
+
+  private val Default = new OtTracePropagator
+
+  private object Headers {
+    val TraceId = "ot-tracer-traceid"
+    val SpanId = "ot-tracer-spanid"
+    val Sampled = "ot-tracer-sampled"
+
+  }
+
+  private object Const {
+    val IsSampled = "true"
+    val NotSampled = "false"
+    val BaggagePrefix = "ot-baggage-"
+  }
+
+  /** Returns an instance of the OtTracePropagator.
+    */
+  def default: TextMapPropagator[Context] = Default
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigureSuite.scala
@@ -125,7 +125,7 @@ class ContextPropagatorsAutoConfigureSuite extends CatsEffectSuite {
       .map(_.leftMap(_.getMessage))
       .assertEquals(
         Left("""Cannot autoconfigure [ContextPropagators].
-            |Cause: Unrecognized value for [otel.propagators]: aws-xray. Supported options [b3, jaeger, b3multi, none, tracecontext, baggage].
+            |Cause: Unrecognized value for [otel.propagators]: aws-xray. Supported options [b3, ottrace, jaeger, b3multi, none, tracecontext, baggage].
             |Config:
             |1) `otel.propagators` - aws-xray""".stripMargin)
       )

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.otel4s.sdk.trace.context.propagation
 
 import munit.ScalaCheckSuite

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
@@ -22,8 +22,10 @@ import org.typelevel.otel4s.baggage.Baggage
 import org.typelevel.otel4s.sdk.context.Context
 import org.typelevel.otel4s.sdk.trace.SdkContextKeys
 import org.typelevel.otel4s.sdk.trace.scalacheck.Gens
+import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.SpanContext.TraceId
-import org.typelevel.otel4s.trace.{SpanContext, TraceFlags, TraceState}
+import org.typelevel.otel4s.trace.TraceFlags
+import org.typelevel.otel4s.trace.TraceState
 import scodec.bits.ByteVector
 
 class OtTracePropagatorSuite extends ScalaCheckSuite {

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/OtTracePropagatorSuite.scala
@@ -1,0 +1,214 @@
+package org.typelevel.otel4s.sdk.trace.context.propagation
+
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop
+import org.typelevel.otel4s.baggage.Baggage
+import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.trace.SdkContextKeys
+import org.typelevel.otel4s.sdk.trace.scalacheck.Gens
+import org.typelevel.otel4s.trace.SpanContext
+
+class OtTracePropagatorSuite extends ScalaCheckSuite {
+
+  private val propagator = OtTracePropagator.default
+
+  test("fields") {
+    assertEquals(
+      propagator.fields.toList,
+      List("ot-tracer-traceid", "ot-tracer-spanid", "ot-tracer-sampled")
+    )
+  }
+
+  test("toString") {
+    assertEquals(propagator.toString, "OtTracePropagator")
+  }
+
+  test("inject nothing when context is empty") {
+    val result = propagator.inject(Context.root, Map.empty[String, String])
+    assertEquals(result.size, 0)
+  }
+
+  test("inject - invalid context - do nothing") {
+    val ctx = SpanContext.invalid
+    val context = Context.root.updated(SdkContextKeys.SpanContextKey, ctx)
+
+    assertEquals(
+      propagator.inject(context, Map.empty[String, String]),
+      Map.empty[String, String]
+    )
+  }
+
+  test("inject - valid context") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val context = Context.root.updated(SdkContextKeys.SpanContextKey, ctx)
+
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      assertEquals(result.get("ot-tracer-traceid"), Some(ctx.traceIdHex))
+      assertEquals(result.get("ot-tracer-spanid"), Some(ctx.spanIdHex))
+      assertEquals(
+        result.get("ot-tracer-sampled"),
+        Some(String.valueOf(ctx.isSampled))
+      )
+
+    }
+  }
+
+  test("inject - valid context with baggage") {
+    Prop.forAll(Gens.spanContext, Gens.baggage) { (ctx, baggage) =>
+      val context = Context.root
+        .updated(SdkContextKeys.SpanContextKey, ctx)
+        .updated(SdkContextKeys.BaggageKey, baggage)
+
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      assertEquals(result.get("ot-tracer-traceid"), Some(ctx.traceIdHex))
+      assertEquals(result.get("ot-tracer-spanid"), Some(ctx.spanIdHex))
+      assertEquals(
+        result.get("ot-tracer-sampled"),
+        Some(String.valueOf(ctx.isSampled))
+      )
+      baggage.asMap.foreach { case (key, entry) =>
+        assertEquals(result.get(s"ot-baggage-$key"), Some(entry.value))
+      }
+
+    }
+  }
+
+  test("inject - baggage only injected if there is a valid SpanContext") {
+    Prop.forAll(Gens.baggage) { baggage =>
+      val context = Context.root.updated(SdkContextKeys.BaggageKey, baggage)
+
+      val result = propagator.inject(context, Map.empty[String, String])
+
+      assert(result.isEmpty)
+
+    }
+  }
+
+  test("extract - empty context") {
+    val ctx = propagator.extract(Context.root, Map.empty[String, String])
+    assertEquals(getSpanContext(ctx), None)
+  }
+
+  test("extract - all headers is missing") {
+    val ctx = propagator.extract(Context.root, Map("key" -> "value"))
+    assertEquals(getSpanContext(ctx), None)
+  }
+
+  test("extract - 'ot-tracer-traceid' header is missing") {
+    Prop.forAll(Gens.spanContext) { spanCtx =>
+      val carrier = Map(
+        "ot-tracer-spanid" -> spanCtx.spanIdHex,
+        "ot-tracer-sampled" -> String.valueOf(spanCtx.isSampled)
+      )
+
+      val ctx = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(ctx), None)
+    }
+  }
+  test("extract - 'ot-tracer-spanid' header is missing") {
+    Prop.forAll(Gens.spanContext) { spanCtx =>
+      val carrier = Map(
+        "ot-tracer-traceid" -> spanCtx.traceIdHex,
+        "ot-tracer-sampled" -> String.valueOf(spanCtx.isSampled)
+      )
+
+      val ctx = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(ctx), None)
+    }
+  }
+
+  test("extract - 'ot-tracer-sampled' header is missing") {
+    Prop.forAll(Gens.spanContext) { spanCtx =>
+      val carrier = Map(
+        "ot-tracer-spanid" -> spanCtx.spanIdHex,
+        "ot-tracer-traceid" -> spanCtx.traceIdHex
+      )
+
+      val ctx = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(ctx), None)
+    }
+  }
+
+  test("extract - valid headers") {
+    Prop.forAll(Gens.spanContext) { ctx =>
+      val carrier = Map(
+        "ot-tracer-traceid" -> ctx.traceIdHex,
+        "ot-tracer-spanid" -> ctx.spanIdHex,
+        "ot-tracer-sampled" -> String.valueOf(ctx.isSampled)
+      )
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getSpanContext(result), Some(asRemote(ctx)))
+    }
+  }
+
+  test("extract - baggage capitalized headers") {
+    Prop.forAll(Gens.spanContext, Gens.baggage) { case (ctx, baggage) =>
+      val carrier = Map(
+        "ot-tracer-traceid" -> ctx.traceIdHex,
+        "ot-tracer-spanid" -> ctx.spanIdHex,
+        "ot-tracer-sampled" -> String.valueOf(ctx.isSampled)
+      ) ++ toBaggageHeaders("OT-baggage-", baggage)
+
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+
+    }
+  }
+
+  test("extract - baggage full capitalized headers") {
+    Prop.forAll(Gens.spanContext, Gens.baggage) { case (ctx, baggage) =>
+      val carrier = Map(
+        "ot-tracer-traceid" -> ctx.traceIdHex,
+        "ot-tracer-spanid" -> ctx.spanIdHex,
+        "ot-tracer-sampled" -> String.valueOf(ctx.isSampled)
+      ) ++ toBaggageHeaders("ot-baggage-".capitalize, baggage)
+
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), Some(baggage))
+
+    }
+  }
+
+  test("extract - baggage is only extracted if there is a valid SpanContext") {
+    Prop.forAll(Gens.baggage) { case (baggage) =>
+      val carrier = toBaggageHeaders("ot-baggage-".capitalize, baggage)
+
+      val result = propagator.extract(Context.root, carrier)
+
+      assertEquals(getBaggage(result), None)
+
+    }
+  }
+
+  private def toBaggageHeaders(
+      prefix: String,
+      baggage: Baggage
+  ): Map[String, String] =
+    baggage.asMap.map { case (key, entry) =>
+      (prefix + key, entry.value)
+    }
+
+  private def getSpanContext(ctx: Context): Option[SpanContext] =
+    ctx.get(SdkContextKeys.SpanContextKey)
+
+  private def getBaggage(ctx: Context): Option[Baggage] =
+    ctx.get(SdkContextKeys.BaggageKey)
+
+  private def asRemote(ctx: SpanContext): SpanContext =
+    SpanContext(
+      traceId = ctx.traceId,
+      spanId = ctx.spanId,
+      traceFlags = ctx.traceFlags,
+      traceState = ctx.traceState,
+      remote = true
+    )
+
+}


### PR DESCRIPTION
Resovles part of https://github.com/typelevel/otel4s/issues/616
Fully inspired by [JaegerPropagator ](https://github.com/typelevel/otel4s/blob/main/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagator.scala), [JaegerPropagatorSuite ](https://github.com/typelevel/otel4s/blob/main/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/context/propagation/JaegerPropagatorSuite.scala) and [OtTracePropagator](https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java)