### PR TITLE
Trace SDK: introduce span limits support

### DIFF
--- a/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/scalacheck/Gens.scala
@@ -81,6 +81,11 @@ trait Gens {
       attributes <- Gen.listOf(attribute)
     } yield attributes.to(Attributes)
 
+  def attributes(n: Int): Gen[Attributes] =
+    for {
+      attributes <- Gen.listOfN(n, attribute)
+    } yield attributes.to(Attributes)
+
 }
 
 object Gens extends Gens

--- a/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansProtoEncoder.scala
+++ b/sdk-exporter/trace/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansProtoEncoder.scala
@@ -99,7 +99,8 @@ private object SpansProtoEncoder {
       SpanProto.Event(
         timeUnixNano = data.timestamp.toNanos,
         name = data.name,
-        attributes = ProtoEncoder.encode(data.attributes)
+        attributes = ProtoEncoder.encode(data.attributes.elements),
+        droppedAttributesCount = data.attributes.dropped
       )
   }
 
@@ -113,7 +114,8 @@ private object SpansProtoEncoder {
         traceId = ByteString.copyFrom(data.spanContext.traceId.toArray),
         spanId = ByteString.copyFrom(data.spanContext.spanId.toArray),
         traceState = traceState,
-        attributes = ProtoEncoder.encode(data.attributes),
+        attributes = ProtoEncoder.encode(data.attributes.elements),
+        droppedAttributesCount = data.attributes.dropped,
         flags = data.spanContext.traceFlags.toByte.toInt
       )
   }
@@ -135,9 +137,12 @@ private object SpansProtoEncoder {
       kind = ProtoEncoder.encode(span.kind),
       startTimeUnixNano = span.startTimestamp.toNanos,
       endTimeUnixNano = span.endTimestamp.map(_.toNanos).getOrElse(0L),
-      attributes = ProtoEncoder.encode(span.attributes),
-      events = span.events.map(event => ProtoEncoder.encode(event)),
-      links = span.links.map(link => ProtoEncoder.encode(link)),
+      attributes = ProtoEncoder.encode(span.attributes.elements),
+      droppedAttributesCount = span.attributes.dropped,
+      events = span.events.elements.map(ProtoEncoder.encode(_)),
+      droppedEventsCount = span.events.dropped,
+      links = span.links.elements.map(ProtoEncoder.encode(_)),
+      droppedLinksCount = span.links.dropped,
       status = Some(ProtoEncoder.encode(span.status))
     )
   }

--- a/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansJsonCodecs.scala
+++ b/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansJsonCodecs.scala
@@ -79,7 +79,8 @@ private object SpansJsonCodecs extends JsonCodecs {
         .obj(
           "timeUnixNano" := eventData.timestamp.toNanos.toString,
           "name" := eventData.name,
-          "attributes" := eventData.attributes
+          "attributes" := eventData.attributes.elements,
+          "droppedAttributesCount" := eventData.attributes.dropped
         )
         .dropEmptyValues
     }
@@ -91,7 +92,8 @@ private object SpansJsonCodecs extends JsonCodecs {
           "traceId" := link.spanContext.traceIdHex,
           "spanId" := link.spanContext.spanIdHex,
           "traceState" := link.spanContext.traceState,
-          "attributes" := link.attributes,
+          "attributes" := link.attributes.elements,
+          "droppedAttributesCount" := link.attributes.dropped,
           "flags" := encodeFlags(link.spanContext.traceFlags)
         )
         .dropNullValues
@@ -111,9 +113,12 @@ private object SpansJsonCodecs extends JsonCodecs {
           "kind" := span.kind,
           "startTimeUnixNano" := span.startTimestamp.toNanos.toString,
           "endTimeUnixNano" := span.endTimestamp.map(_.toNanos.toString),
-          "attributes" := span.attributes,
-          "events" := span.events,
-          "links" := span.links
+          "attributes" := span.attributes.elements,
+          "droppedAttributesCount" := span.attributes.dropped,
+          "events" := span.events.elements,
+          "droppedEventsCount" := span.events.dropped,
+          "links" := span.links.elements,
+          "droppedLinksCount" := span.links.dropped
         )
         .dropNullValues
         .dropEmptyValues

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -37,6 +37,7 @@ import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
 import org.typelevel.otel4s.sdk.metrics.view.InstrumentSelector
 import org.typelevel.otel4s.sdk.metrics.view.View
 import org.typelevel.otel4s.sdk.test.NoopConsole
+import org.typelevel.otel4s.sdk.trace.SpanLimits
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CBaggagePropagator
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropagator
 import org.typelevel.otel4s.sdk.trace.data.LinkData
@@ -55,7 +56,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   private val DefaultSdk =
     sdkToString(
       TelemetryResource.default,
-      Sampler.parentBased(Sampler.AlwaysOn)
+      sampler = Sampler.parentBased(Sampler.AlwaysOn)
     )
 
   private val NoopSdk =
@@ -391,6 +392,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
 
   private def sdkToString(
       resource: TelemetryResource = TelemetryResource.default,
+      spanLimits: SpanLimits = SpanLimits.default,
       sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,
@@ -402,7 +404,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
     "OpenTelemetrySdk.AutoConfigured{sdk=" +
       s"OpenTelemetrySdk{meterProvider=$meterProvider, " +
       "tracerProvider=" +
-      s"SdkTracerProvider{resource=$resource, sampler=$sampler, " +
+      s"SdkTracerProvider{resource=$resource, spanLimits=$spanLimits, sampler=$sampler, " +
       "spanProcessor=SpanProcessor.Multi(" +
       s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
       "SpanStorage)}, " +

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -64,7 +64,7 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
       .getOrElseF(Tracer.raiseNoCurrentSpan)
 
   def spanBuilder(name: String): SpanBuilder[F] =
-    new SdkSpanBuilder[F](name, scopeInfo, sharedState, traceScope)
+    SdkSpanBuilder[F](name, scopeInfo, sharedState, traceScope)
 
   def childScope[A](parent: SpanContext)(fa: F[A]): F[A] =
     traceScope.childScope(parent).flatMap(trace => trace(fa))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanLimits.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SpanLimits.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.Hash
+import cats.Show
+
+/** Holds the limits enforced during recording of a span.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits]]
+  */
+sealed trait SpanLimits {
+
+  /** The max number of attributes per span. */
+  def maxNumberOfAttributes: Int
+
+  /** The max number of events per span. */
+  def maxNumberOfEvents: Int
+
+  /** The max number of links per span. */
+  def maxNumberOfLinks: Int
+
+  /** The max number of attributes per event. */
+  def maxNumberOfAttributesPerEvent: Int
+
+  /** The max number of attributes per link. */
+  def maxNumberOfAttributesPerLink: Int
+
+  /** The max number of characters for string attribute values. For string array
+    * attribute values, applies to each entry individually.
+    */
+  def maxAttributeValueLength: Int
+
+  override final def hashCode(): Int =
+    Hash[SpanLimits].hash(this)
+
+  override final def equals(obj: Any): Boolean =
+    obj match {
+      case other: SpanLimits => Hash[SpanLimits].eqv(this, other)
+      case _                 => false
+    }
+
+  override final def toString: String =
+    Show[SpanLimits].show(this)
+}
+
+object SpanLimits {
+
+  private object Defaults {
+    val MaxNumberOfAttributes = 128
+    val MaxNumberOfEvents = 128
+    val MaxNumberOfLinks = 128
+    val MaxNumberOfAttributesPerEvent = 128
+    val MaxNumberOfAttributesPerLink = 128
+    val MaxAttributeValueLength = Int.MaxValue
+  }
+
+  /** Builder for [[SpanLimits]] */
+  sealed trait Builder {
+
+    /** Sets the max number of attributes per span. */
+    def withMaxNumberOfAttributes(value: Int): Builder
+
+    /** Sets the max number of events per span. */
+    def withMaxNumberOfEvents(value: Int): Builder
+
+    /** Sets the max number of links per span. */
+    def withMaxNumberOfLinks(value: Int): Builder
+
+    /** Sets the max number of attributes per event. */
+    def withMaxNumberOfAttributesPerEvent(value: Int): Builder
+
+    /** Sets the max number of attributes per link. */
+    def withMaxNumberOfAttributesPerLink(value: Int): Builder
+
+    /** Sets the max number of characters for string attribute values. For
+      * string array attribute values, applies to each entry individually.
+      */
+    def withMaxAttributeValueLength(value: Int): Builder
+
+    /** Creates a [[SpanLimits]] with the configuration of this builder. */
+    def build: SpanLimits
+  }
+
+  private val Default: SpanLimits =
+    builder.build
+
+  /** Creates a [[Builder]] for [[SpanLimits]] using the default limits.
+    */
+  def builder: Builder =
+    BuilderImpl(
+      maxNumberOfAttributes = Defaults.MaxNumberOfAttributes,
+      maxNumberOfEvents = Defaults.MaxNumberOfEvents,
+      maxNumberOfLinks = Defaults.MaxNumberOfLinks,
+      maxNumberOfAttributesPerEvent = Defaults.MaxNumberOfAttributesPerEvent,
+      maxNumberOfAttributesPerLink = Defaults.MaxNumberOfAttributesPerLink,
+      maxAttributeValueLength = Defaults.MaxAttributeValueLength
+    )
+
+  /** Creates a [[SpanLimits]] using the given limits. */
+  def apply(
+      maxNumberOfAttributes: Int,
+      maxNumberOfEvents: Int,
+      maxNumberOfLinks: Int,
+      maxNumberOfAttributesPerEvent: Int,
+      maxNumberOfAttributesPerLink: Int,
+      maxAttributeValueLength: Int
+  ): SpanLimits =
+    SpanLimitsImpl(
+      maxNumberOfAttributes = maxNumberOfAttributes,
+      maxNumberOfEvents = maxNumberOfEvents,
+      maxNumberOfLinks = maxNumberOfLinks,
+      maxNumberOfAttributesPerEvent = maxNumberOfAttributesPerEvent,
+      maxNumberOfAttributesPerLink = maxNumberOfAttributesPerLink,
+      maxAttributeValueLength = maxAttributeValueLength
+    )
+
+  def default: SpanLimits = Default
+
+  implicit val spanLimitsHash: Hash[SpanLimits] =
+    Hash.by { s =>
+      (
+        s.maxNumberOfAttributes,
+        s.maxNumberOfEvents,
+        s.maxNumberOfLinks,
+        s.maxNumberOfAttributesPerEvent,
+        s.maxNumberOfAttributesPerLink,
+        s.maxAttributeValueLength
+      )
+    }
+
+  implicit val spanLimitsShow: Show[SpanLimits] =
+    Show.show { s =>
+      "SpanLimits{" +
+        s"maxNumberOfAttributes=${s.maxNumberOfAttributes}, " +
+        s"maxNumberOfEvents=${s.maxNumberOfEvents}, " +
+        s"maxNumberOfLinks=${s.maxNumberOfLinks}, " +
+        s"maxNumberOfAttributesPerEvent=${s.maxNumberOfAttributesPerEvent}, " +
+        s"maxNumberOfAttributesPerLink=${s.maxNumberOfAttributesPerLink}, " +
+        s"maxAttributeValueLength=${s.maxAttributeValueLength}}"
+    }
+
+  private final case class SpanLimitsImpl(
+      maxNumberOfAttributes: Int,
+      maxNumberOfEvents: Int,
+      maxNumberOfLinks: Int,
+      maxNumberOfAttributesPerEvent: Int,
+      maxNumberOfAttributesPerLink: Int,
+      maxAttributeValueLength: Int,
+  ) extends SpanLimits
+
+  private final case class BuilderImpl(
+      maxNumberOfAttributes: Int,
+      maxNumberOfEvents: Int,
+      maxNumberOfLinks: Int,
+      maxNumberOfAttributesPerEvent: Int,
+      maxNumberOfAttributesPerLink: Int,
+      maxAttributeValueLength: Int,
+  ) extends Builder {
+    def withMaxNumberOfAttributes(value: Int): Builder =
+      copy(maxNumberOfAttributes = value)
+
+    def withMaxNumberOfEvents(value: Int): Builder =
+      copy(maxNumberOfEvents = value)
+
+    def withMaxNumberOfLinks(value: Int): Builder =
+      copy(maxNumberOfLinks = value)
+
+    def withMaxNumberOfAttributesPerEvent(value: Int): Builder =
+      copy(maxNumberOfAttributesPerEvent = value)
+
+    def withMaxNumberOfAttributesPerLink(value: Int): Builder =
+      copy(maxNumberOfAttributesPerLink = value)
+
+    def withMaxAttributeValueLength(value: Int): Builder =
+      copy(maxAttributeValueLength = value)
+
+    def build: SpanLimits =
+      SpanLimitsImpl(
+        maxNumberOfAttributes,
+        maxNumberOfEvents,
+        maxNumberOfLinks,
+        maxNumberOfAttributesPerEvent,
+        maxNumberOfAttributesPerLink,
+        maxAttributeValueLength
+      )
+  }
+
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
@@ -23,6 +23,7 @@ import org.typelevel.otel4s.sdk.trace.samplers.Sampler
 private final case class TracerSharedState[F[_]](
     idGenerator: IdGenerator[F],
     resource: TelemetryResource,
+    spanLimits: SpanLimits,
     sampler: Sampler,
     spanProcessor: SpanProcessor[F]
 )

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanLimitsAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanLimitsAutoConfigure.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.autoconfigure
+
+import cats.MonadThrow
+import cats.effect.Resource
+import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.trace.SpanLimits
+
+/** Autoconfigures [[SpanLimits]].
+  *
+  * The configuration options:
+  * {{{
+  * | System property                          | Environment variable                     | Description                                                           |
+  * |------------------------------------------|------------------------------------------|-----------------------------------------------------------------------|
+  * | otel.span.attribute.count.limit          | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT          | The maximum allowed span attribute count. Default is `128`.           |
+  * | otel.span.event.count.limit              | OTEL_SPAN_EVENT_COUNT_LIMIT              | The maximum allowed span event count. Default is `128`.               |
+  * | otel.span.link.count.limit               | OTEL_SPAN_LINK_COUNT_LIMIT               | The maximum allowed span link count. Default is `128`.                |
+  * | otel.event.attribute.count.limit         | OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT         | The maximum allowed attribute per span event count. Default is `128`. |
+  * | otel.link.attribute.count.limit          | OTEL_LINK_ATTRIBUTE_COUNT_LIMIT          | The maximum allowed attribute per span link count. Default is `128`.  |
+  * | otel.span.attribute.value.length.limit   | OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT   | The maximum allowed attribute value size. No limit by default.        |
+  * }}}
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits]]
+  */
+private final class SpanLimitsAutoConfigure[F[_]: MonadThrow]
+    extends AutoConfigure.WithHint[F, SpanLimits](
+      "SpanLimits",
+      SpanLimitsAutoConfigure.ConfigKeys.All
+    ) {
+
+  import SpanLimitsAutoConfigure.ConfigKeys
+
+  def fromConfig(config: Config): Resource[F, SpanLimits] = {
+    def configure =
+      for {
+        maxNumberOfAttributes <- config.get(ConfigKeys.MaxNumberOfAttributes)
+        maxNumberOfEvents <- config.get(ConfigKeys.MaxNumberOfEvents)
+        maxNumberOfLinks <- config.get(ConfigKeys.MaxNumberOfLinks)
+        maxNumberOfAttributesPerEvent <- config.get(
+          ConfigKeys.MaxNumberOfAttributesPerEvent
+        )
+        maxNumberOfAttributesPerLink <- config.get(
+          ConfigKeys.MaxNumberOfAttributesPerLink
+        )
+        maxAttributeValueLength <- config.get(
+          ConfigKeys.MaxAttributeValueLength
+        )
+      } yield {
+        val builder = SpanLimits.builder
+
+        val withMaxNumberOfAttributes =
+          maxNumberOfAttributes.foldLeft(builder)(
+            _.withMaxNumberOfAttributes(_)
+          )
+
+        val withMaxNumberOfEvents =
+          maxNumberOfEvents.foldLeft(withMaxNumberOfAttributes)(
+            _.withMaxNumberOfEvents(_)
+          )
+
+        val withMaxNumberOfLinks =
+          maxNumberOfLinks.foldLeft(withMaxNumberOfEvents)(
+            _.withMaxNumberOfLinks(_)
+          )
+
+        val withMaxNumberOfAttributesPerEvent =
+          maxNumberOfAttributesPerEvent.foldLeft(withMaxNumberOfLinks)(
+            _.withMaxNumberOfAttributesPerEvent(_)
+          )
+
+        val withMaxNumberOfAttributesPerLink =
+          maxNumberOfAttributesPerLink.foldLeft(
+            withMaxNumberOfAttributesPerEvent
+          )(
+            _.withMaxNumberOfAttributesPerLink(_)
+          )
+
+        val withMaxAttributeValueLength =
+          maxAttributeValueLength.foldLeft(withMaxNumberOfAttributesPerLink)(
+            _.withMaxAttributeValueLength(_)
+          )
+
+        withMaxAttributeValueLength.build
+      }
+
+    Resource.eval(MonadThrow[F].fromEither(configure))
+  }
+}
+
+private[sdk] object SpanLimitsAutoConfigure {
+
+  private object ConfigKeys {
+    val MaxNumberOfAttributes: Config.Key[Int] =
+      Config.Key("otel.span.attribute.count.limit")
+
+    val MaxNumberOfEvents: Config.Key[Int] =
+      Config.Key("otel.span.event.count.limit")
+
+    val MaxNumberOfLinks: Config.Key[Int] =
+      Config.Key("otel.span.link.count.limit")
+
+    val MaxNumberOfAttributesPerEvent: Config.Key[Int] =
+      Config.Key("otel.event.attribute.count.limit")
+
+    val MaxNumberOfAttributesPerLink: Config.Key[Int] =
+      Config.Key("otel.link.attribute.count.limit")
+
+    val MaxAttributeValueLength: Config.Key[Int] =
+      Config.Key("otel.span.attribute.value.length.limit")
+
+    val All: Set[Config.Key[_]] =
+      Set(
+        MaxNumberOfAttributes,
+        MaxNumberOfEvents,
+        MaxNumberOfLinks,
+        MaxNumberOfAttributesPerEvent,
+        MaxNumberOfAttributesPerLink,
+        MaxAttributeValueLength
+      )
+  }
+
+  /** Returns [[AutoConfigure]] that configures the [[SpanLimits]].
+    *
+    * The configuration options:
+    * {{{
+    * | System property                          | Environment variable                     | Description                                                           |
+    * |------------------------------------------|------------------------------------------|-----------------------------------------------------------------------|
+    * | otel.span.attribute.count.limit          | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT          | The maximum allowed span attribute count. Default is `128`.           |
+    * | otel.span.event.count.limit              | OTEL_SPAN_EVENT_COUNT_LIMIT              | The maximum allowed span event count. Default is `128`.               |
+    * | otel.span.link.count.limit               | OTEL_SPAN_LINK_COUNT_LIMIT               | The maximum allowed span link count. Default is `128`.                |
+    * | otel.event.attribute.count.limit         | OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT         | The maximum allowed attribute per span event count. Default is `128`. |
+    * | otel.link.attribute.count.limit          | OTEL_LINK_ATTRIBUTE_COUNT_LIMIT          | The maximum allowed attribute per span link count. Default is `128`.  |
+    * | otel.span.attribute.value.length.limit   | OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT   | The maximum allowed attribute value size. No limit by default.        |
+    * }}}
+    *
+    * @see
+    *   [[https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits]]
+    */
+  def apply[F[_]: MonadThrow]: AutoConfigure[F, SpanLimits] =
+    new SpanLimitsAutoConfigure[F]
+
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
@@ -60,11 +60,13 @@ private final class TracerProviderAutoConfigure[
       sampler <- samplerAutoConfigure.configure(config)
       exporters <- exporterAutoConfigure.configure(config)
       processors <- configureProcessors(config, exporters)
+      spanLimits <- SpanLimitsAutoConfigure[F].configure(config)
 
       tracerProviderBuilder = {
         val builder = SdkTracerProvider
           .builder[F]
           .withResource(resource)
+          .withSpanLimits(spanLimits)
           .withSampler(sampler)
           .addTextMapPropagators(contextPropagators.textMapPropagator)
 

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LimitedData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LimitedData.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.data
+
+import cats.Hash
+import cats.Semigroup
+import cats.syntax.semigroup._
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.AttributeType
+import org.typelevel.otel4s.Attributes
+
+import scala.collection.immutable
+
+/** A generic collection container with fixed bounds.
+  *
+  * @tparam A
+  *   the type of container elements
+  *
+  * @tparam S
+  *   the type of underlying container collection
+  */
+sealed trait LimitedData[A, S <: immutable.Iterable[A]] {
+
+  /** The limit for container elements.
+    */
+  def sizeLimit: Int
+
+  /** The number of dropped elements.
+    */
+  def dropped: Int
+
+  /** The container elements.
+    */
+  def elements: S
+
+  /** Appends an element to the container if the number of container elements
+    * has not reached the limit, otherwise drops the element.
+    *
+    * @param a
+    *   the element to append
+    */
+  def append(a: A): LimitedData[A, S]
+
+  /** Appends all given elements to the container up to the limit and drops the
+    * rest elements.
+    *
+    * @param as
+    *   the collection of elements to append
+    */
+  def appendAll(as: S): LimitedData[A, S]
+
+  /** Prepends all given elements to the container up to the limit and drops all
+    * elements that exceeds the limit (even if they already existed before).
+    *
+    * @param as
+    *   the collection of elements to prepend
+    */
+  def prependAll(as: S): LimitedData[A, S]
+
+  /** Maps the container elements by applying the passed function.
+    *
+    * @param f
+    *   the function to apply
+    */
+  def map(f: S => S): LimitedData[A, S]
+}
+
+object LimitedData {
+
+  implicit def limitedDataHash[A, S <: immutable.Iterable[A]: Hash]
+      : Hash[LimitedData[A, S]] =
+    Hash.by(events => (events.sizeLimit, events.dropped, events.elements))
+
+  /** Created [[LimitedData]] with the collection of [[Attribute]] inside.
+    *
+    * @param sizeLimit
+    *   The limit for container elements
+    *
+    * @param valueLengthLimit
+    *   The limit for attribute's value
+    */
+  def attributes(
+      sizeLimit: Int,
+      valueLengthLimit: Int
+  ): LimitedData[Attribute[_], Attributes] = {
+    def limitValueLength(a: Attribute[_]) =
+      a.key.`type` match {
+        case AttributeType.String =>
+          Attribute(
+            a.key.name,
+            a.value.asInstanceOf[String].take(valueLengthLimit)
+          )
+        case AttributeType.BooleanSeq =>
+          Attribute(
+            a.key.name,
+            a.value.asInstanceOf[Seq[Boolean]].take(valueLengthLimit)
+          )
+        case AttributeType.DoubleSeq =>
+          Attribute(
+            a.key.name,
+            a.value.asInstanceOf[Seq[Double]].take(valueLengthLimit)
+          )
+        case AttributeType.StringSeq =>
+          Attribute(
+            a.key.name,
+            a.value.asInstanceOf[Seq[String]].take(valueLengthLimit)
+          )
+        case AttributeType.LongSeq =>
+          Attribute(
+            a.key.name,
+            a.value.asInstanceOf[Seq[Long]].take(valueLengthLimit)
+          )
+        case _ =>
+          a
+      }
+
+    Impl[Attribute[_], Attributes](
+      sizeLimit,
+      Attributes.empty,
+      _ splitAt _,
+      Attributes(_),
+      _.map(limitValueLength).to(Attributes)
+    )
+  }
+
+  /** Created [[LimitedData]] with the vector of [[LinkData]] inside.
+    *
+    * @param sizeLimit
+    *   The limit for container elements
+    */
+  def links(sizeLimit: Int): LimitedData[LinkData, Vector[LinkData]] =
+    Impl[LinkData, Vector[LinkData]](
+      sizeLimit,
+      Vector.empty,
+      _ splitAt _,
+      Vector(_)
+    )
+
+  /** Created [[LimitedData]] with the vector of [[EventData]] inside.
+    *
+    * @param sizeLimit
+    *   The limit for container elements
+    */
+  def events(sizeLimit: Int): LimitedData[EventData, Vector[EventData]] =
+    Impl[EventData, Vector[EventData]](
+      sizeLimit,
+      Vector.empty,
+      _ splitAt _,
+      Vector(_)
+    )
+
+  private final case class Impl[A, S <: immutable.Iterable[A]: Semigroup](
+      sizeLimit: Int,
+      elements: S,
+      splitAt: (S, Int) => (S, S),
+      pure: A => S,
+      refine: S => S = identity[S],
+      dropped: Int = 0
+  ) extends LimitedData[A, S] {
+    def append(a: A): LimitedData[A, S] = {
+      if (elements.size < sizeLimit) {
+        copy(elements = elements |+| refine(pure(a)))
+      } else {
+        copy(dropped = dropped + 1)
+      }
+    }
+
+    def appendAll(as: S): LimitedData[A, S] =
+      if (elements.size + as.size <= sizeLimit) {
+        copy(elements = elements |+| refine(as))
+      } else {
+        val (toAdd, toDrop) = splitAt(as, sizeLimit - elements.size)
+        copy(
+          elements = elements |+| refine(toAdd),
+          dropped = dropped + toDrop.size
+        )
+      }
+
+    def prependAll(as: S): LimitedData[A, S] = {
+      val allElements = as |+| elements
+      val (toKeep, toDrop) = splitAt(allElements, sizeLimit)
+      copy(elements = refine(toKeep), dropped = dropped + toDrop.size)
+    }
+
+    def map(f: S => S): LimitedData[A, S] =
+      copy(elements = f(elements))
+  }
+}

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LinkData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LinkData.scala
@@ -40,7 +40,7 @@ sealed trait LinkData {
 
   /** The [[Attributes]] associated with this link.
     */
-  def attributes: Attributes
+  def attributes: LimitedData[Attribute[_], Attributes]
 
   override final def hashCode(): Int =
     Hash[LinkData].hash(this)
@@ -62,15 +62,10 @@ object LinkData {
     * @param context
     *   the context of the span the link refers to
     */
-  def apply(context: SpanContext): LinkData =
-    Impl(context, Attributes.empty)
-
-  /** Creates a [[LinkData]] with the given `context`.
-    *
-    * @param context
-    *   the context of the span the link refers to
-    */
-  def apply(context: SpanContext, attributes: Attributes): LinkData =
+  def apply(
+      context: SpanContext,
+      attributes: LimitedData[Attribute[_], Attributes]
+  ): LinkData =
     Impl(context, attributes)
 
   implicit val linkDataHash: Hash[LinkData] =
@@ -78,12 +73,12 @@ object LinkData {
 
   implicit val linkDataShow: Show[LinkData] =
     Show.show { data =>
-      show"LinkData{spanContext=${data.spanContext}, attributes=${data.attributes}}"
+      show"LinkData{spanContext=${data.spanContext}, attributes=${data.attributes.elements}}"
     }
 
   private final case class Impl(
       spanContext: SpanContext,
-      attributes: Attributes
+      attributes: LimitedData[Attribute[_], Attributes]
   ) extends LinkData
 
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
@@ -67,15 +67,15 @@ sealed trait SpanData {
 
   /** The attributes associated with the span.
     */
-  def attributes: Attributes
+  def attributes: LimitedData[Attribute[_], Attributes]
 
   /** The events associated with the span.
     */
-  def events: Vector[EventData]
+  def events: LimitedData[EventData, Vector[EventData]]
 
   /** The links associated with the span.
     */
-  def links: Vector[LinkData]
+  def links: LimitedData[LinkData, Vector[LinkData]]
 
   /** The instrumentation scope associated with the span.
     */
@@ -151,9 +151,9 @@ object SpanData {
       startTimestamp: FiniteDuration,
       endTimestamp: Option[FiniteDuration],
       status: StatusData,
-      attributes: Attributes,
-      events: Vector[EventData],
-      links: Vector[LinkData],
+      attributes: LimitedData[Attribute[_], Attributes],
+      events: LimitedData[EventData, Vector[EventData]],
+      links: LimitedData[LinkData, Vector[LinkData]],
       instrumentationScope: InstrumentationScope,
       resource: TelemetryResource
   ): SpanData =
@@ -204,9 +204,9 @@ object SpanData {
         endTimestamp +
         show"hasEnded=${data.hasEnded}, " +
         show"status=${data.status}, " +
-        show"attributes=${data.attributes}, " +
-        show"events=${data.events}, " +
-        show"links=${data.links}, " +
+        show"attributes=${data.attributes.elements}, " +
+        show"events=${data.events.elements}, " +
+        show"links=${data.links.elements}, " +
         show"instrumentationScope=${data.instrumentationScope}, " +
         show"resource=${data.resource}}"
     }
@@ -219,9 +219,9 @@ object SpanData {
       startTimestamp: FiniteDuration,
       endTimestamp: Option[FiniteDuration],
       status: StatusData,
-      attributes: Attributes,
-      events: Vector[EventData],
-      links: Vector[LinkData],
+      attributes: LimitedData[Attribute[_], Attributes],
+      events: LimitedData[EventData, Vector[EventData]],
+      links: LimitedData[LinkData, Vector[LinkData]],
       instrumentationScope: InstrumentationScope,
       resource: TelemetryResource
   ) extends SpanData

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -49,6 +49,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   private val DefaultTraces =
     tracesToString(
       TelemetryResource.default,
+      SpanLimits.default,
       Sampler.parentBased(Sampler.AlwaysOn)
     )
 
@@ -115,6 +116,7 @@ class SdkTracesSuite extends CatsEffectSuite {
 
     val sampler = Sampler.AlwaysOff
     val resource = TelemetryResource.default
+    val spanLimits = SpanLimits.default
 
     SdkTraces
       .autoConfigured[IO](
@@ -123,7 +125,12 @@ class SdkTracesSuite extends CatsEffectSuite {
           .addTracerProviderCustomizer((t, _) => t.withResource(resource))
       )
       .use { traces =>
-        IO(assertEquals(traces.toString, tracesToString(resource, sampler)))
+        IO(
+          assertEquals(
+            traces.toString,
+            tracesToString(resource, spanLimits, sampler)
+          )
+        )
       }
   }
 
@@ -275,6 +282,7 @@ class SdkTracesSuite extends CatsEffectSuite {
 
   private def tracesToString(
       resource: TelemetryResource = TelemetryResource.default,
+      spanLimits: SpanLimits = SpanLimits.default,
       sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,
@@ -283,7 +291,7 @@ class SdkTracesSuite extends CatsEffectSuite {
       exporter: String = "SpanExporter.Noop"
   ) =
     "SdkTraces{tracerProvider=" +
-      s"SdkTracerProvider{resource=$resource, sampler=$sampler, " +
+      s"SdkTracerProvider{resource=$resource, spanLimits=$spanLimits, sampler=$sampler, " +
       "spanProcessor=SpanProcessor.Multi(" +
       s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
       "SpanStorage)}, " +

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanLimitsSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SpanLimitsSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.Show
+import cats.kernel.laws.discipline.HashTests
+import cats.syntax.show._
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+
+class SpanLimitsSuite extends DisciplineSuite {
+
+  private val spanLimitsGen: Gen[SpanLimits] =
+    for {
+      maxAttributes <- Gen.choose(0, 100)
+      maxEvents <- Gen.choose(0, 100)
+      maxLinks <- Gen.choose(0, 100)
+      maxAttributesPerEvent <- Gen.choose(0, 100)
+      maxAttributesPerLink <- Gen.choose(0, 100)
+      maxAttributeLength <- Gen.choose(0, 100)
+    } yield SpanLimits.builder
+      .withMaxNumberOfAttributes(maxAttributes)
+      .withMaxNumberOfEvents(maxEvents)
+      .withMaxNumberOfLinks(maxLinks)
+      .withMaxNumberOfAttributesPerEvent(maxAttributesPerEvent)
+      .withMaxNumberOfAttributesPerLink(maxAttributesPerLink)
+      .withMaxAttributeValueLength(maxAttributeLength)
+      .build
+
+  private implicit val spanLimitsArbitrary: Arbitrary[SpanLimits] =
+    Arbitrary(spanLimitsGen)
+
+  private implicit val spanLimitsCogen: Cogen[SpanLimits] =
+    Cogen[(Int, Int, Int, Int, Int, Int)].contramap { s =>
+      (
+        s.maxNumberOfAttributes,
+        s.maxNumberOfEvents,
+        s.maxNumberOfLinks,
+        s.maxNumberOfAttributesPerEvent,
+        s.maxNumberOfAttributesPerLink,
+        s.maxAttributeValueLength
+      )
+    }
+
+  checkAll("SpanLimits.HashLaws", HashTests[SpanLimits].hash)
+
+  property("Show[SpanLimits]") {
+    Prop.forAll(spanLimitsGen) { s =>
+      val expected = "SpanLimits{" +
+        show"maxNumberOfAttributes=${s.maxNumberOfAttributes}, " +
+        show"maxNumberOfEvents=${s.maxNumberOfEvents}, " +
+        show"maxNumberOfLinks=${s.maxNumberOfLinks}, " +
+        show"maxNumberOfAttributesPerEvent=${s.maxNumberOfAttributesPerEvent}, " +
+        show"maxNumberOfAttributesPerLink=${s.maxNumberOfAttributesPerLink}, " +
+        show"maxAttributeValueLength=${s.maxAttributeValueLength}}"
+
+      assertEquals(Show[SpanLimits].show(s), expected)
+    }
+  }
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanLimitsAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanLimitsAutoConfigureSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.autoconfigure
+
+import cats.effect.IO
+import cats.syntax.either._
+import cats.syntax.show._
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.sdk.autoconfigure.Config
+import org.typelevel.otel4s.sdk.trace.SpanLimits
+
+class SpanLimitsAutoConfigureSuite extends CatsEffectSuite {
+
+  test("load from an empty config - load default") {
+    val config = Config(Map.empty, Map.empty, Map.empty)
+
+    SpanLimitsAutoConfigure[IO]
+      .configure(config)
+      .use { limits =>
+        IO(assertEquals(limits, SpanLimits.default))
+      }
+  }
+
+  test("load from the config (empty string) - load default") {
+    val props = Map(
+      "otel.span.attribute.count.limit" -> "",
+      "otel.span.event.count.limit" -> "",
+      "otel.span.link.count.limit" -> "",
+      "otel.event.attribute.count.limit" -> "",
+      "otel.link.attribute.count.limit" -> "",
+      "otel.span.attribute.value.length.limit" -> "",
+    )
+
+    val config = Config.ofProps(props)
+
+    SpanLimitsAutoConfigure[IO]
+      .configure(config)
+      .use { limits =>
+        IO(assertEquals(limits, SpanLimits.default))
+      }
+  }
+
+  test("load from the config - use given value") {
+    val props = Map(
+      "otel.span.attribute.count.limit" -> "100",
+      "otel.span.event.count.limit" -> "101",
+      "otel.span.link.count.limit" -> "102",
+      "otel.event.attribute.count.limit" -> "103",
+      "otel.link.attribute.count.limit" -> "104",
+      "otel.span.attribute.value.length.limit" -> "105",
+    )
+
+    val config = Config.ofProps(props)
+
+    val expected =
+      "SpanLimits{" +
+        "maxNumberOfAttributes=100, " +
+        "maxNumberOfEvents=101, " +
+        "maxNumberOfLinks=102, " +
+        "maxNumberOfAttributesPerEvent=103, " +
+        "maxNumberOfAttributesPerLink=104, " +
+        "maxAttributeValueLength=105}"
+
+    SpanLimitsAutoConfigure[IO]
+      .configure(config)
+      .use { limits =>
+        IO(assertEquals(limits.show, expected))
+      }
+  }
+
+  test("invalid config value - fail") {
+    val config =
+      Config.ofProps(Map("otel.span.attribute.count.limit" -> "not int"))
+    val error =
+      "Invalid value for property otel.span.attribute.count.limit=not int. Must be [Int]"
+
+    SpanLimitsAutoConfigure[IO]
+      .configure(config)
+      .evalMap(IO.println)
+      .use_
+      .attempt
+      .map(_.leftMap(_.getMessage))
+      .assertEquals(
+        Left(
+          s"""Cannot autoconfigure [SpanLimits].
+             |Cause: $error.
+             |Config:
+             |1) `otel.event.attribute.count.limit` - N/A
+             |2) `otel.link.attribute.count.limit` - N/A
+             |3) `otel.span.attribute.count.limit` - not int
+             |4) `otel.span.attribute.value.length.limit` - N/A
+             |5) `otel.span.event.count.limit` - N/A
+             |6) `otel.span.link.count.limit` - N/A""".stripMargin
+        )
+      )
+  }
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
@@ -32,6 +32,7 @@ import org.typelevel.otel4s.sdk.autoconfigure.AutoConfigure
 import org.typelevel.otel4s.sdk.autoconfigure.Config
 import org.typelevel.otel4s.sdk.context.Context
 import org.typelevel.otel4s.sdk.trace.SdkTracerProvider
+import org.typelevel.otel4s.sdk.trace.SpanLimits
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CBaggagePropagator
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropagator
 import org.typelevel.otel4s.sdk.trace.data.LinkData
@@ -50,6 +51,7 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
   private val DefaultProvider =
     providerToString(
       TelemetryResource.empty,
+      SpanLimits.default,
       Sampler.parentBased(Sampler.AlwaysOn)
     )
 
@@ -178,6 +180,7 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
     val expected =
       "SdkTracerProvider{" +
         s"resource=${TelemetryResource.empty}, " +
+        s"spanLimits=${SpanLimits.default}, " +
         s"sampler=${Sampler.AlwaysOff}, " +
         "spanProcessor=SpanProcessor.Multi(" +
         "SimpleSpanProcessor{exporter=ConsoleSpanExporter, exportOnlySampled=true}, " +
@@ -221,11 +224,13 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
 
   private def providerToString(
       resource: TelemetryResource = TelemetryResource.empty,
+      spanLimits: SpanLimits = SpanLimits.default,
       sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
       exporter: String = "SpanExporter.Noop"
   ) =
     "SdkTracerProvider{" +
       s"resource=$resource, " +
+      s"spanLimits=$spanLimits, " +
       s"sampler=$sampler, " +
       "spanProcessor=SpanProcessor.Multi(" +
       s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
@@ -42,7 +42,7 @@ class EventDataSuite extends DisciplineSuite {
   test("Show[EventData]") {
     Prop.forAll(Gens.eventData) { data =>
       val expected =
-        show"EventData{name=${data.name}, timestamp=${data.timestamp}, attributes=${data.attributes}}"
+        show"EventData{name=${data.name}, timestamp=${data.timestamp}, attributes=${data.attributes.elements}}"
 
       assertEquals(Show[EventData].show(data), expected)
     }
@@ -70,11 +70,21 @@ class EventDataSuite extends DisciplineSuite {
       ) |+| attributes
 
       val data =
-        EventData.fromException(ts, exception, attributes, escaped = true)
+        EventData.fromException(
+          ts,
+          exception,
+          LimitedData
+            .attributes(
+              SpanLimits.default.maxNumberOfAttributesPerEvent,
+              SpanLimits.default.maxAttributeValueLength
+            )
+            .appendAll(attributes),
+          escaped = true
+        )
 
       assertEquals(data.name, "exception")
       assertEquals(data.timestamp, ts)
-      assertEquals(data.attributes, expectedAttributes)
+      assertEquals(data.attributes.elements, expectedAttributes)
     }
   }
 
@@ -92,11 +102,21 @@ class EventDataSuite extends DisciplineSuite {
       ) |+| attributes
 
       val data =
-        EventData.fromException(ts, exception, attributes, escaped = false)
+        EventData.fromException(
+          ts,
+          exception,
+          LimitedData
+            .attributes(
+              SpanLimits.default.maxNumberOfAttributesPerEvent,
+              SpanLimits.default.maxAttributeValueLength
+            )
+            .appendAll(attributes),
+          escaped = false
+        )
 
       assertEquals(data.name, "exception")
       assertEquals(data.timestamp, ts)
-      assertEquals(data.attributes, expectedAttributes)
+      assertEquals(data.attributes.elements, expectedAttributes)
     }
   }
 }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LimitedDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LimitedDataSuite.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace.data
+
+import munit.ScalaCheckSuite
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.AttributeKey
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.trace.scalacheck.Gens
+
+class LimitedDataSuite extends ScalaCheckSuite {
+
+  test("drop extra elements when appending one by one") {
+    Prop.forAll(
+      Gens.attributes(100),
+      Gens.attributes(200)
+    ) { (attributes, extraAttributes) =>
+      val data = LimitedData
+        .attributes(150, Int.MaxValue)
+        .appendAll(attributes)
+      val dataWithDropped = extraAttributes.foldLeft(data) {
+        (data, attribute) =>
+          data.append(attribute)
+      }
+
+      assertEquals(dataWithDropped.dropped, 150)
+    }
+  }
+
+  test("drop extra elements when appending all at once") {
+    Prop.forAll(
+      Gens.attributes(100),
+      Gens.attributes(200)
+    ) { (attributes, extraAttributes) =>
+      val data = LimitedData
+        .attributes(150, Int.MaxValue)
+        .appendAll(attributes)
+      val dataWithDropped = data.appendAll(extraAttributes)
+
+      assertEquals(dataWithDropped.dropped, 150)
+    }
+  }
+
+  test("drop extra elements when prepending all at once") {
+    Prop.forAll(
+      Gens.attributes(100),
+      Gens.attributes(200)
+    ) { (attributes, extraAttributes) =>
+      val data = LimitedData
+        .attributes(150, Int.MaxValue)
+        .appendAll(attributes)
+      val dataWithDropped = data.prependAll(extraAttributes)
+
+      assertEquals(dataWithDropped.dropped, 150)
+    }
+  }
+
+  test("limit attribute's values") {
+    val stringKey = AttributeKey.string("stringKey")
+    val booleanSeqKey = AttributeKey.booleanSeq("booleanSeqKey")
+    val doubleSeqKey = AttributeKey.doubleSeq("doubleSeqKey")
+    val stringSeqKey = AttributeKey.stringSeq("stringSeqKey")
+    val longSeqKey = AttributeKey.longSeq("longSeqKey")
+
+    Prop.forAll(
+      Gen.posNum[Int],
+      Gens.nonEmptyString,
+      Gens.nonEmptyVector(Gen.oneOf(true, false)),
+      Gens.nonEmptyVector(Gen.double),
+      Gens.nonEmptyVector(Gens.nonEmptyString),
+      Gens.nonEmptyVector(Gen.long)
+    ) {
+      (
+          valueLengthLimit,
+          stringValue,
+          booleanSeqValue,
+          doubleSeqValue,
+          stringSeqValue,
+          longSeqValue
+      ) =>
+        val data = LimitedData
+          .attributes(Int.MaxValue, valueLengthLimit)
+          .append(Attribute(stringKey, stringValue))
+          .appendAll(
+            Attributes(
+              Attribute(booleanSeqKey, booleanSeqValue.toVector),
+              Attribute(doubleSeqKey, doubleSeqValue.toVector)
+            )
+          )
+          .prependAll(
+            Attributes(
+              Attribute(stringSeqKey, stringSeqValue.toVector),
+              Attribute(longSeqKey, longSeqValue.toVector)
+            )
+          )
+
+        data.elements
+          .get(stringKey)
+          .exists(_.value.length <= valueLengthLimit) &&
+        data.elements
+          .get(booleanSeqKey)
+          .exists(_.value.length <= valueLengthLimit) &&
+        data.elements
+          .get(doubleSeqKey)
+          .exists(_.value.length <= valueLengthLimit) &&
+        data.elements
+          .get(stringSeqKey)
+          .exists(_.value.length <= valueLengthLimit) &&
+        data.elements
+          .get(longSeqKey)
+          .exists(_.value.length <= valueLengthLimit)
+    }
+  }
+
+}

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LinkDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/LinkDataSuite.scala
@@ -35,7 +35,7 @@ class LinkDataSuite extends DisciplineSuite {
   test("Show[LinkData]") {
     Prop.forAll(Gens.linkData) { data =>
       val expected =
-        show"LinkData{spanContext=${data.spanContext}, attributes=${data.attributes}}"
+        show"LinkData{spanContext=${data.spanContext}, attributes=${data.attributes.elements}}"
 
       assertEquals(Show[LinkData].show(data), expected)
     }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/SpanDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/SpanDataSuite.scala
@@ -49,9 +49,9 @@ class SpanDataSuite extends DisciplineSuite {
           endedEpoch +
           show"hasEnded=${data.hasEnded}, " +
           show"status=${data.status}, " +
-          show"attributes=${data.attributes}, " +
-          show"events=${data.events}, " +
-          show"links=${data.links}, " +
+          show"attributes=${data.attributes.elements}, " +
+          show"events=${data.events.elements}, " +
+          show"links=${data.links.elements}, " +
           show"instrumentationScope=${data.instrumentationScope}, " +
           show"resource=${data.resource}}"
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
@@ -139,7 +139,7 @@ class SimpleSpanProcessorSuite
         IO(data.startTimestamp)
 
       def getAttribute[A](key: AttributeKey[A]): IO[Option[A]] =
-        IO(data.attributes.get(key).map(_.value))
+        IO(data.attributes.elements.get(key).map(_.value))
 
       // span.backend
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/scalacheck/Cogens.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/scalacheck/Cogens.scala
@@ -46,12 +46,12 @@ trait Cogens
 
   implicit val eventDataCogen: Cogen[EventData] =
     Cogen[(String, FiniteDuration, Attributes)].contramap { data =>
-      (data.name, data.timestamp, data.attributes)
+      (data.name, data.timestamp, data.attributes.elements)
     }
 
   implicit val linkDataCogen: Cogen[LinkData] =
     Cogen[(SpanContext, Attributes)].contramap { data =>
-      (data.spanContext, data.attributes)
+      (data.spanContext, data.attributes.elements)
     }
 
   implicit val statusDataCogen: Cogen[StatusData] =
@@ -83,9 +83,9 @@ trait Cogens
       spanData.startTimestamp,
       spanData.endTimestamp,
       spanData.status,
-      spanData.attributes,
-      spanData.events,
-      spanData.links,
+      spanData.attributes.elements,
+      spanData.events.elements,
+      spanData.links.elements,
       spanData.instrumentationScope,
       spanData.resource
     )


### PR DESCRIPTION
Resolves #481 

It's a kind of pre-PR. If anyone thinks that something could be better done differently, let's discuss. 
Also need to agree on how exactly to apply `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` - should it be some method of `Attributes` trait or something else.