### PR TITLE
sdk-common: add `TelemetryResourceDetector`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.8"
+ThisBuild / tlBaseVersion := "0.9"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
@@ -221,6 +221,7 @@ lazy val `sdk-common` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+  .jsSettings(scalaJSLinkerSettings)
 
 lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -243,6 +244,7 @@ lazy val `sdk-metrics` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+  .jsSettings(scalaJSLinkerSettings)
 
 lazy val `sdk-metrics-testkit` =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -275,6 +277,7 @@ lazy val `sdk-trace` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+  .jsSettings(scalaJSLinkerSettings)
 
 lazy val `sdk-trace-testkit` =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -313,6 +316,7 @@ lazy val sdk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .settings(munitDependencies)
   .settings(scalafixSettings)
+  .jsSettings(scalaJSLinkerSettings)
 
 //
 // SDK exporter

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -50,6 +50,7 @@ If not specified, SDK defaults the service name to `unknown_service:scala`.
 | otel.resource.attributes                 | OTEL\\_RESOURCE\\_ATTRIBUTES                     | Specify resource attributes in the following format: `key1=val1,key2=val2,key3=val3`.                       |
 | otel.service.name                        | OTEL\\_SERVICE\\_NAME                            | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes`. |
 | otel.experimental.resource.disabled-keys | OTEL\\_EXPERIMENTAL\\_RESOURCE\\_DISABLED\\_KEYS | Specify resource attribute keys that are filtered.                                                          |
+| otel.otel4s.resource.detectors           | OTEL\\_OTEL4S\\_RESOURCE\\_DETECTORS             | Specify resource detectors to use. Defaults to `host`.                                                      | 
 
 ## Metrics
 

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -67,7 +67,11 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
 
   test("withConfig - use the given config") {
     val config = Config.ofProps(
-      Map("otel.traces.exporter" -> "none", "otel.metrics.exporter" -> "none")
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "none",
+        "otel.metrics.exporter" -> "none"
+      )
     )
 
     OpenTelemetrySdk
@@ -119,7 +123,11 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
 
   test("addTracerProviderCustomizer - customize tracer provider") {
     val config = Config.ofProps(
-      Map("otel.traces.exporter" -> "none", "otel.metrics.exporter" -> "none")
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "none",
+        "otel.metrics.exporter" -> "none"
+      )
     )
 
     val sampler = Sampler.AlwaysOff
@@ -137,7 +145,11 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
 
   test("addResourceCustomizer - customize a resource") {
     val config = Config.ofProps(
-      Map("otel.traces.exporter" -> "none", "otel.metrics.exporter" -> "none")
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "none",
+        "otel.metrics.exporter" -> "none"
+      )
     )
 
     val default = TelemetryResource.default
@@ -163,6 +175,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   test("addSpanExporterConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "custom-1,custom-2",
         "otel.metrics.exporter" -> "none"
       )
@@ -203,6 +216,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   test("addSamplerConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.metrics.exporter" -> "none",
         "otel.traces.sampler" -> "custom-sampler",
@@ -237,6 +251,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   test("addTextMapPropagatorConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.metrics.exporter" -> "none",
         "otel.propagators" -> "tracecontext,custom-1,custom-2,baggage",
@@ -281,6 +296,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   test("addMeterProviderCustomizer - customize meter provider") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.metrics.exporter" -> "console"
       )
@@ -314,6 +330,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   test("addMeterExporterConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.metrics.exporter" -> "custom-1,custom-2"
       )

--- a/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
+++ b/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+private[resource] trait HostDetectorPlatform { self: HostDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] = Sync[F].delay {
+      val host = Keys.Host(OS.hostname())
+      val arch = Keys.Arch(normalizeArch(OS.arch()))
+
+      Some(TelemetryResource(Attributes(host, arch), Some(SchemaUrls.Current)))
+    }
+  }
+
+  // transforms https://nodejs.org/api/os.html#osarch values to match the spec:
+  // https://opentelemetry.io/docs/specs/semconv/resource/host/
+  private def normalizeArch(arch: String): String =
+    arch match {
+      case "arm" => "arm32"
+      case "ppc" => "ppc32"
+      case "x64" => "amd64"
+      case other => other
+    }
+}

--- a/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/OS.scala
+++ b/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/OS.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+private object OS {
+
+  @js.native
+  @JSImport("os", "arch")
+  def arch(): String = js.native
+
+  @js.native
+  @JSImport("os", "hostname")
+  def hostname(): String = js.native
+
+}

--- a/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
+++ b/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+import java.net.InetAddress
+
+private[resource] trait HostDetectorPlatform { self: HostDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] =
+      for {
+        hostOpt <- Sync[F]
+          .blocking(InetAddress.getLocalHost.getHostName)
+          .redeem(_ => None, Some(_))
+
+        archOpt <- Sync[F].delay(sys.props.get("os.arch"))
+      } yield {
+        val host = hostOpt.map(Keys.Host(_))
+        val arch = archOpt.map(Keys.Arch(_))
+        val attributes = host.to(Attributes) ++ arch.to(Attributes)
+        Option.when(attributes.nonEmpty)(
+          TelemetryResource(attributes, Some(SchemaUrls.Current))
+        )
+      }
+  }
+
+}

--- a/sdk/common/native/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
+++ b/sdk/common/native/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+import scala.scalanative.posix.unistd._
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+private[resource] trait HostDetectorPlatform { self: HostDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] =
+      for {
+        hostOpt <- Sync[F].delay(detectHost).handleError(_ => None)
+        archOpt <- Sync[F].delay(sys.props.get("os.arch"))
+      } yield {
+        val host = hostOpt.map(Keys.Host(_))
+        val arch = archOpt.map(Keys.Arch(_))
+        val attributes = host.to(Attributes) ++ arch.to(Attributes)
+        Option.when(attributes.nonEmpty)(
+          TelemetryResource(attributes, Some(SchemaUrls.Current))
+        )
+      }
+
+    private def detectHost: Option[String] =
+      Zone { implicit z =>
+        val size = 256.toUInt
+        val hostnameBuffer = alloc[CChar](size)
+        if (gethostname(hostnameBuffer, size) == 0) {
+          val hostname = fromCString(hostnameBuffer)
+          Some(hostname)
+        } else {
+          None
+        }
+      }
+  }
+
+}

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -18,10 +18,14 @@ package org.typelevel.otel4s
 package sdk
 package autoconfigure
 
-import cats.MonadThrow
 import cats.effect.Resource
+import cats.effect.Sync
+import cats.effect.std.Console
+import cats.syntax.applicativeError._
 import cats.syntax.either._
+import cats.syntax.functor._
 import cats.syntax.traverse._
+import org.typelevel.otel4s.sdk.resource._
 import org.typelevel.otel4s.semconv.attributes.ServiceAttributes
 
 import java.net.URLDecoder
@@ -36,20 +40,49 @@ import java.nio.charset.StandardCharsets
   * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
   * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
   * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
+  * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host`                                                      |
   * }}}
   *
   * @see
   *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+  *
+  * @param extraDetectors
+  *   the extra detectors to use
   */
-private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
-    extends AutoConfigure.WithHint[F, TelemetryResource](
+private final class TelemetryResourceAutoConfigure[F[_]: Sync: Console](
+    extraDetectors: Set[TelemetryResourceDetector[F]]
+) extends AutoConfigure.WithHint[F, TelemetryResource](
       "TelemetryResource",
       TelemetryResourceAutoConfigure.ConfigKeys.All
     ) {
 
   import TelemetryResourceAutoConfigure.ConfigKeys
+  import TelemetryResourceAutoConfigure.Const
+  import TelemetryResourceAutoConfigure.Defaults
 
-  def fromConfig(config: Config): Resource[F, TelemetryResource] = {
+  private val detectors: Set[TelemetryResourceDetector[F]] =
+    TelemetryResourceDetector.default ++ extraDetectors
+
+  def fromConfig(config: Config): Resource[F, TelemetryResource] =
+    for {
+      disabledKeys <- Resource.eval(
+        Sync[F].fromEither(
+          config.getOrElse(ConfigKeys.DisabledKeys, Set.empty[String])
+        )
+      )
+
+      envResource <- Resource.eval(
+        Sync[F].fromEither(fromEnv(config, disabledKeys))
+      )
+
+      detectedResource <- fromDetectors(config, disabledKeys)
+    } yield detectedResource.fold(envResource)(_.mergeUnsafe(envResource))
+
+  private def fromEnv(
+      config: Config,
+      disabledKeys: Set[String]
+  ): Either[Throwable, TelemetryResource] = {
+
     def parse(entries: List[(String, String)], disabledKeys: Set[String]) =
       entries
         .filter { case (key, _) => !disabledKeys.contains(key) }
@@ -66,12 +99,11 @@ private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
         }
         .map(_.to(Attributes))
 
-    val attempt = for {
-      disabledKeys <-
-        config.getOrElse(ConfigKeys.DisabledKeys, Set.empty[String])
-
-      entries <-
-        config.getOrElse(ConfigKeys.Attributes, Map.empty[String, String])
+    for {
+      entries <- config.getOrElse(
+        ConfigKeys.Attributes,
+        Map.empty[String, String]
+      )
 
       attributes <- parse(entries.toList, disabledKeys)
     } yield {
@@ -86,8 +118,64 @@ private final class TelemetryResourceAutoConfigure[F[_]: MonadThrow]
 
       default.mergeUnsafe(fromEnv)
     }
+  }
 
-    Resource.eval(MonadThrow[F].fromEither(attempt))
+  private def fromDetectors(
+      config: Config,
+      disabledKeys: Set[String]
+  ): Resource[F, Option[TelemetryResource]] = {
+
+    def removeDisabledAttributes(resource: TelemetryResource) =
+      TelemetryResource(
+        resource.attributes.filterNot(a => disabledKeys.contains(a.key.name)),
+        resource.schemaUrl
+      )
+
+    def detect(name: String): F[Option[TelemetryResource]] =
+      detectors.find(_.name == name) match {
+        case Some(detector) =>
+          detector.detect
+            .map(_.map(removeDisabledAttributes))
+            .handleErrorWith { e =>
+              Console[F]
+                .errorln(
+                  s"Detector [${detector.name}] failed to detect the resource. The detector is ignored. " +
+                    s"${e.getMessage}\n${e.getStackTrace.mkString("\n")}\n"
+                )
+                .as(None)
+            }
+
+        case None =>
+          Sync[F].raiseError(
+            ConfigurationError.unrecognized(
+              ConfigKeys.Detectors.name,
+              name,
+              detectors.map(_.name) + Const.NoneDetector
+            )
+          )
+      }
+
+    config.getOrElse(ConfigKeys.Detectors, Defaults.Detectors) match {
+      case Right(n) if n.contains(Const.NoneDetector) && n.sizeIs > 1 =>
+        Resource.raiseError(
+          ConfigurationError(
+            s"[${ConfigKeys.Detectors}] contains '${Const.NoneDetector}' along with other detectors"
+          ): Throwable
+        )
+
+      case Right(m) if m.contains(Const.NoneDetector) && m.sizeIs == 1 =>
+        Resource.pure(None)
+
+      case Right(names) =>
+        Resource.eval(
+          names.toList
+            .flatTraverse(detector => detect(detector).map(_.toList))
+            .map(resources => resources.reduceOption(_ mergeUnsafe _))
+        )
+
+      case Left(error) =>
+        Resource.raiseError(error: Throwable)
+    }
   }
 
 }
@@ -104,7 +192,20 @@ private[sdk] object TelemetryResourceAutoConfigure {
     val ServiceName: Config.Key[String] =
       Config.Key("otel.service.name")
 
+    val Detectors: Config.Key[Set[String]] =
+      Config.Key("otel.otel4s.resource.detectors")
+
     val All: Set[Config.Key[_]] = Set(DisabledKeys, Attributes, ServiceName)
+  }
+
+  private object Const {
+    val NoneDetector = "none"
+  }
+
+  private object Defaults {
+    val Detectors: Set[String] = Set(
+      HostDetector.Const.Name
+    )
   }
 
   /** Returns [[AutoConfigure]] that configures the [[TelemetryResource]].
@@ -116,12 +217,18 @@ private[sdk] object TelemetryResourceAutoConfigure {
     * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
     * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
     * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
+    * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host`                                                      |
     * }}}
     *
     * @see
     *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+    *
+    * @param extraDetectors
+    *   the extra detectors to use
     */
-  def apply[F[_]: MonadThrow]: AutoConfigure[F, TelemetryResource] =
-    new TelemetryResourceAutoConfigure[F]
+  def apply[F[_]: Sync: Console](
+      extraDetectors: Set[TelemetryResourceDetector[F]]
+  ): AutoConfigure[F, TelemetryResource] =
+    new TelemetryResourceAutoConfigure[F](extraDetectors)
 
 }

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetector.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import org.typelevel.otel4s.AttributeKey
+
+/** Detects host's architecture and name.
+  *
+  * @see
+  *   https://opentelemetry.io/docs/specs/semconv/resource/host/
+  */
+object HostDetector extends HostDetectorPlatform {
+
+  private[sdk] object Const {
+    val Name = "host"
+  }
+
+  private[resource] object Keys {
+    val Arch: AttributeKey[String] = AttributeKey("host.arch")
+    val Host: AttributeKey[String] = AttributeKey("host.name")
+  }
+
+}

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package sdk
+package resource
+
+import cats.effect.Sync
+
+/** A detector creates a resource with environment(platform)-specific
+  * attributes.
+  *
+  * @note
+  *   a detector that populates resource attributes according to OpenTelemetry
+  *   semantic conventions MUST ensure that the resource has a Schema URL set to
+  *   a value that matches the semantic conventions.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment]]
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+trait TelemetryResourceDetector[F[_]] {
+
+  /** The name of the detector.
+    */
+  def name: String
+
+  /** Returns the detected resource, if any.
+    */
+  def detect: F[Option[TelemetryResource]]
+
+  override def toString: String = name
+}
+
+object TelemetryResourceDetector {
+
+  /** Returns the default set of resource detectors.
+    *
+    * Includes:
+    *   - host detector
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def default[F[_]: Sync]: Set[TelemetryResourceDetector[F]] =
+    Set(HostDetector[F])
+
+}

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetectorSuite.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetectorSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+class TelemetryResourceDetectorSuite extends CatsEffectSuite {
+
+  test("HostDetector - detect name and arch") {
+    val keys = Set("host.name", "host.arch")
+
+    for {
+      resource <- HostDetector[IO].detect
+    } yield {
+      assertEquals(resource.map(_.attributes.map(_.key.name).toSet), Some(keys))
+      assertEquals(resource.flatMap(_.schemaUrl), Some(SchemaUrls.Current))
+    }
+  }
+
+  test("default - contain host detector") {
+    val detectors = TelemetryResourceDetector.default[IO].map(_.name)
+    val expected = Set("host")
+
+    assertEquals(detectors.map(_.name), expected)
+  }
+
+}

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMetricsSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMetricsSuite.scala
@@ -45,7 +45,12 @@ class SdkMetricsSuite extends CatsEffectSuite {
     "SdkMetrics{meterProvider=MeterProvider.Noop}"
 
   test("withConfig - use the given config") {
-    val config = Config.ofProps(Map("otel.metrics.exporter" -> "console"))
+    val config = Config.ofProps(
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.metrics.exporter" -> "console"
+      )
+    )
 
     SdkMetrics
       .autoConfigured[IO](_.withConfig(config))
@@ -121,7 +126,12 @@ class SdkMetricsSuite extends CatsEffectSuite {
   }
 
   test("addResourceCustomizer - customize a resource") {
-    val config = Config.ofProps(Map("otel.metrics.exporter" -> "console"))
+    val config = Config.ofProps(
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.metrics.exporter" -> "console"
+      )
+    )
 
     val default = TelemetryResource.default
     val withAttributes =
@@ -145,7 +155,10 @@ class SdkMetricsSuite extends CatsEffectSuite {
 
   test("addExporterConfigurer - support external configurers") {
     val config = Config.ofProps(
-      Map("otel.metrics.exporter" -> "custom-1,custom-2")
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.metrics.exporter" -> "custom-1,custom-2"
+      )
     )
 
     val exporter1: MetricExporter[IO] = customExporter("CustomExporter1")

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -56,7 +56,12 @@ class SdkTracesSuite extends CatsEffectSuite {
     "SdkTraces{tracerProvider=TracerProvider.Noop, propagators=ContextPropagators.Noop}"
 
   test("withConfig - use the given config") {
-    val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
+    val config = Config.ofProps(
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "none"
+      )
+    )
 
     SdkTraces
       .autoConfigured[IO](_.withConfig(config))
@@ -123,7 +128,12 @@ class SdkTracesSuite extends CatsEffectSuite {
   }
 
   test("addResourceCustomizer - customize a resource") {
-    val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
+    val config = Config.ofProps(
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "none"
+      )
+    )
 
     val default = TelemetryResource.default
     val withAttributes =
@@ -147,7 +157,10 @@ class SdkTracesSuite extends CatsEffectSuite {
 
   test("addExporterConfigurer - support external configurers") {
     val config = Config.ofProps(
-      Map("otel.traces.exporter" -> "custom-1,custom-2")
+      Map(
+        "otel.otel4s.resource.detectors" -> "none",
+        "otel.traces.exporter" -> "custom-1,custom-2"
+      )
     )
 
     def customExporter(exporterName: String): SpanExporter[IO] =
@@ -185,6 +198,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   test("addSamplerConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.traces.sampler" -> "custom-sampler",
       )
@@ -218,6 +232,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   test("addTextMapPropagatorConfigurer - support external configurers") {
     val config = Config.ofProps(
       Map(
+        "otel.otel4s.resource.detectors" -> "none",
         "otel.traces.exporter" -> "none",
         "otel.propagators" -> "tracecontext,custom-1,custom-2,baggage",
       )

--- a/semconv/stable/src/main/scala/org/typelevel/otel4s/semconv/SchemaUrls.scala
+++ b/semconv/stable/src/main/scala/org/typelevel/otel4s/semconv/SchemaUrls.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.semconv
+
+object SchemaUrls {
+
+  val V1_26_0: String = "https://opentelemetry.io/schemas/1.26.0"
+
+  private[otel4s] val Current: String = V1_26_0
+
+}

--- a/semconv/stable/src/test/scala/org/typelevel/otel4s/semconv/SchemaUrlsSuite.scala
+++ b/semconv/stable/src/test/scala/org/typelevel/otel4s/semconv/SchemaUrlsSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.semconv
+
+class SchemaUrlsSuite extends munit.FunSuite {
+
+  test("contain the current version") {
+    val version =
+      BuildInfo.openTelemetrySemanticConventionsVersion.stripSuffix("-alpha")
+
+    val expected = s"https://opentelemetry.io/schemas/$version"
+
+    assertEquals(SchemaUrls.Current, expected)
+  }
+
+}


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/semconv/resource/host/ |
| Java implementation | [HostResource.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostResource.java) |
| JavaScript implementation | [HostDetectorSync.ts](https://github.com/open-telemetry/opentelemetry-js/blob/v1.25.1/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts) |

We need `TelemetryResourceDetector` to build environment-aware `TelemetryResource` for our Scala SDK.

Some context: https://github.com/typelevel/otel4s/issues/615.

