### PR TITLE
sdk-common: add `OSDetector`

### DIFF
--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -50,7 +50,7 @@ If not specified, SDK defaults the service name to `unknown_service:scala`.
 | otel.resource.attributes                 | OTEL\\_RESOURCE\\_ATTRIBUTES                     | Specify resource attributes in the following format: `key1=val1,key2=val2,key3=val3`.                       |
 | otel.service.name                        | OTEL\\_SERVICE\\_NAME                            | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes`. |
 | otel.experimental.resource.disabled-keys | OTEL\\_EXPERIMENTAL\\_RESOURCE\\_DISABLED\\_KEYS | Specify resource attribute keys that are filtered.                                                          |
-| otel.otel4s.resource.detectors           | OTEL\\_OTEL4S\\_RESOURCE\\_DETECTORS             | Specify resource detectors to use. Defaults to `host`.                                                      | 
+| otel.otel4s.resource.detectors           | OTEL\\_OTEL4S\\_RESOURCE\\_DETECTORS             | Specify resource detectors to use. Defaults to `host,os`.                                                   | 
 
 ## Metrics
 

--- a/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
+++ b/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
@@ -197,6 +197,7 @@ object OpenTelemetrySdk {
         *
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
+        *   - os: `os.type`, `os.description`
         *
         * @param detector
         *   the detector to add

--- a/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetectorPlatform.scala
+++ b/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetectorPlatform.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+private[resource] trait OSDetectorPlatform { self: OSDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] = Sync[F].delay {
+      val tpe = Keys.Type(normalizeType(OS.platform()))
+      val release = Keys.Description(OS.release())
+
+      Some(
+        TelemetryResource(Attributes(tpe, release), Some(SchemaUrls.Current))
+      )
+    }
+  }
+
+  // transforms https://nodejs.org/api/os.html#osplatform values to match the spec:
+  // https://opentelemetry.io/docs/specs/semconv/resource/os/
+  private def normalizeType(platform: String): String =
+    platform match {
+      case "sunos" => "solaris"
+      case "win32" => "windows"
+      case other   => other
+    }
+
+}

--- a/sdk/common/jvm-native/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetectorPlatform.scala
+++ b/sdk/common/jvm-native/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetectorPlatform.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+import java.util.Locale
+
+private[resource] trait OSDetectorPlatform { self: OSDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] =
+      for {
+        nameOpt <- Sync[F].delay(sys.props.get("os.name"))
+        versionOpt <- Sync[F].delay(sys.props.get("os.version"))
+      } yield {
+        val tpe = nameOpt.flatMap(nameToType).map(Keys.Type(_))
+
+        val description = versionOpt
+          .zip(nameOpt)
+          .map { case (version, name) =>
+            Keys.Description(name + " " + version)
+          }
+          .orElse(nameOpt.map(Keys.Description(_)))
+
+        val attributes = tpe.to(Attributes) ++ description.to(Attributes)
+        Option.when(attributes.nonEmpty)(
+          TelemetryResource(attributes, Some(SchemaUrls.Current))
+        )
+      }
+  }
+
+  // transforms OS names to match the spec:
+  // https://opentelemetry.io/docs/specs/semconv/resource/os/
+  private def nameToType(name: String): Option[String] =
+    name.toLowerCase(Locale.ROOT) match {
+      case os if os.startsWith("windows")      => Some("windows")
+      case os if os.startsWith("linux")        => Some("linux")
+      case os if os.startsWith("mac")          => Some("darwin")
+      case os if os.startsWith("freebsd")      => Some("freebsd")
+      case os if os.startsWith("netbsd")       => Some("netbsd")
+      case os if os.startsWith("openbsd")      => Some("openbsd")
+      case os if os.startsWith("dragonflybsd") => Some("dragonflybsd")
+      case os if os.startsWith("hp-ux")        => Some("hpux")
+      case os if os.startsWith("aix")          => Some("aix")
+      case os if os.startsWith("solaris")      => Some("solaris")
+      case os if os.startsWith("z/os")         => Some("z_os")
+      case _                                   => None
+    }
+
+}

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -40,7 +40,7 @@ import java.nio.charset.StandardCharsets
   * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
   * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
   * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
-  * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host`                                                      |
+  * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os`.                                                  |
   * }}}
   *
   * @see
@@ -204,7 +204,8 @@ private[sdk] object TelemetryResourceAutoConfigure {
 
   private object Defaults {
     val Detectors: Set[String] = Set(
-      HostDetector.Const.Name
+      HostDetector.Const.Name,
+      OSDetector.Const.Name
     )
   }
 
@@ -217,7 +218,7 @@ private[sdk] object TelemetryResourceAutoConfigure {
     * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
     * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
     * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
-    * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host`                                                      |
+    * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os`.                                                  |
     * }}}
     *
     * @see

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/OSDetector.scala
@@ -16,25 +16,25 @@
 
 package org.typelevel.otel4s.sdk.resource
 
-import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
+import org.typelevel.otel4s.AttributeKey
 
-private object OS {
+/** Detects OS type and description.
+  *
+  * @see
+  *   https://opentelemetry.io/docs/specs/semconv/resource/os/
+  */
+object OSDetector extends OSDetectorPlatform {
 
-  @js.native
-  @JSImport("os", "arch")
-  def arch(): String = js.native
+  private[sdk] object Const {
+    val Name = "os"
+  }
 
-  @js.native
-  @JSImport("os", "hostname")
-  def hostname(): String = js.native
+  private[resource] object Keys {
+    val Type: AttributeKey[String] =
+      AttributeKey[String]("os.type")
 
-  @js.native
-  @JSImport("os", "platform")
-  def platform(): String = js.native
-
-  @js.native
-  @JSImport("os", "release")
-  def release(): String = js.native
+    val Description: AttributeKey[String] =
+      AttributeKey[String]("os.description")
+  }
 
 }

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
@@ -53,11 +53,12 @@ object TelemetryResourceDetector {
     *
     * Includes:
     *   - host detector
+    *   - os detector
     *
     * @tparam F
     *   the higher-kinded type of a polymorphic effect
     */
   def default[F[_]: Sync]: Set[TelemetryResourceDetector[F]] =
-    Set(HostDetector[F])
+    Set(HostDetector[F], OSDetector[F])
 
 }

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
@@ -68,6 +68,7 @@ class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
       .use { resource =>
         val service = Set("service.name")
         val host = Set("host.arch", "host.name")
+        val os = Set("os.type", "os.description")
 
         val telemetry = Set(
           "telemetry.sdk.language",
@@ -76,7 +77,7 @@ class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
         )
 
         val all =
-          host ++ service ++ telemetry
+          host ++ os ++ service ++ telemetry
 
         IO(assertEquals(resource.attributes.map(_.key.name).toSet, all))
       }

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetectorSuite.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetectorSuite.scala
@@ -33,9 +33,20 @@ class TelemetryResourceDetectorSuite extends CatsEffectSuite {
     }
   }
 
-  test("default - contain host detector") {
+  test("OSDetector - detect OS type and description") {
+    val keys = Set("os.type", "os.description")
+
+    for {
+      resource <- OSDetector[IO].detect
+    } yield {
+      assertEquals(resource.map(_.attributes.map(_.key.name).toSet), Some(keys))
+      assertEquals(resource.flatMap(_.schemaUrl), Some(SchemaUrls.Current))
+    }
+  }
+
+  test("default - contain host, os detectors") {
     val detectors = TelemetryResourceDetector.default[IO].map(_.name)
-    val expected = Set("host")
+    val expected = Set("host", "os")
 
     assertEquals(detectors.map(_.name), expected)
   }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
@@ -142,6 +142,7 @@ object SdkMetrics {
         *
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
+        *   - os: `os.type`, `os.description`
         *
         * @param detector
         *   the detector to add

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
@@ -163,6 +163,7 @@ object SdkTraces {
         *
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
+        *   - os: `os.type`, `os.description`
         *
         * @param detector
         *   the detector to add


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/semconv/resource/os/ |
| Java implementation | [OsResource.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/OsResource.java) |
| JavaScript implementation | [OSDetectorSync.ts](https://github.com/open-telemetry/opentelemetry-js/blob/v1.25.1/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts) |


