### PR TITLE
sdk-common: add `ProcessRuntimeDetector`

### DIFF
--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -50,7 +50,7 @@ If not specified, SDK defaults the service name to `unknown_service:scala`.
 | otel.resource.attributes                 | OTEL\\_RESOURCE\\_ATTRIBUTES                     | Specify resource attributes in the following format: `key1=val1,key2=val2,key3=val3`.                       |
 | otel.service.name                        | OTEL\\_SERVICE\\_NAME                            | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes`. |
 | otel.experimental.resource.disabled-keys | OTEL\\_EXPERIMENTAL\\_RESOURCE\\_DISABLED\\_KEYS | Specify resource attribute keys that are filtered.                                                          |
-| otel.otel4s.resource.detectors           | OTEL\\_OTEL4S\\_RESOURCE\\_DETECTORS             | Specify resource detectors to use. Defaults to `host,os`.                                                   | 
+| otel.otel4s.resource.detectors           | OTEL\\_OTEL4S\\_RESOURCE\\_DETECTORS             | Specify resource detectors to use. Defaults to `host,os,process_runtime`.                                   | 
 
 ## Metrics
 

--- a/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
+++ b/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
@@ -198,6 +198,8 @@ object OpenTelemetrySdk {
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
         *   - os: `os.type`, `os.description`
+        *   - process_runtime: `process.runtime.name`,
+        *     `process.runtime.version`, `process.runtime.description`
         *
         * @param detector
         *   the detector to add

--- a/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/Process.scala
+++ b/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/Process.scala
@@ -19,27 +19,20 @@ package org.typelevel.otel4s.sdk.resource
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
-/** A mapping of the Node.js OS API.
+/** A mapping of the Node.js process API.
   *
   * @see
-  *   [[https://nodejs.org/api/os.html]]
+  *   [[https://nodejs.org/api/process.html]]
   */
-private object OS {
+private object Process {
 
   @js.native
-  @JSImport("os", "arch")
-  def arch(): String = js.native
+  @JSImport("process", "versions")
+  def versions: Versions = js.native
 
   @js.native
-  @JSImport("os", "hostname")
-  def hostname(): String = js.native
-
-  @js.native
-  @JSImport("os", "platform")
-  def platform(): String = js.native
-
-  @js.native
-  @JSImport("os", "release")
-  def release(): String = js.native
+  trait Versions extends js.Object {
+    def node: String = js.native
+  }
 
 }

--- a/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
+++ b/sdk/common/js/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+private[resource] trait ProcessRuntimeDetectorPlatform {
+  self: ProcessRuntimeDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] = Sync[F].delay {
+      val attributes = Attributes(
+        Keys.Name("nodejs"),
+        Keys.Version(Process.versions.node),
+        Keys.Description("Node.js")
+      )
+
+      Some(TelemetryResource(attributes, Some(SchemaUrls.Current)))
+    }
+  }
+
+}

--- a/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
+++ b/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+private[resource] trait ProcessRuntimeDetectorPlatform {
+  self: ProcessRuntimeDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] =
+      for {
+        runtimeName <- Sync[F].delay(sys.props.get("java.runtime.name"))
+        runtimeVersion <- Sync[F].delay(sys.props.get("java.runtime.version"))
+        vmVendor <- Sync[F].delay(sys.props.get("java.vm.vendor"))
+        vmName <- Sync[F].delay(sys.props.get("java.vm.name"))
+        vmVersion <- Sync[F].delay(sys.props.get("java.vm.version"))
+      } yield {
+        val attributes = Attributes.newBuilder
+
+        runtimeName.foreach(name => attributes.addOne(Keys.Name(name)))
+        runtimeVersion.foreach(name => attributes.addOne(Keys.Version(name)))
+        (vmVendor, vmName, vmVersion).mapN { (vendor, name, version) =>
+          attributes.addOne(Keys.Description(s"$vendor $name $version"))
+        }
+
+        Some(TelemetryResource(attributes.result(), Some(SchemaUrls.Current)))
+      }
+  }
+
+}

--- a/sdk/common/native/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
+++ b/sdk/common/native/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.resource
+
+import cats.effect.Sync
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.TelemetryResource
+import org.typelevel.otel4s.semconv.SchemaUrls
+
+private[resource] trait ProcessRuntimeDetectorPlatform {
+  self: ProcessRuntimeDetector.type =>
+
+  def apply[F[_]: Sync]: TelemetryResourceDetector[F] =
+    new Detector[F]
+
+  private class Detector[F[_]: Sync] extends TelemetryResourceDetector[F] {
+    def name: String = Const.Name
+
+    def detect: F[Option[TelemetryResource]] =
+      Sync[F].delay {
+        val attributes = Attributes(
+          Keys.Name("scalanative"),
+          // Keys.Version(""), not available yet
+          Keys.Description("Scala Native")
+        )
+
+        Some(TelemetryResource(attributes, Some(SchemaUrls.Current)))
+      }
+  }
+
+}

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -40,7 +40,7 @@ import java.nio.charset.StandardCharsets
   * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
   * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
   * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
-  * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os`.                                                  |
+  * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os,process_runtime`.                                  |
   * }}}
   *
   * @see
@@ -205,7 +205,8 @@ private[sdk] object TelemetryResourceAutoConfigure {
   private object Defaults {
     val Detectors: Set[String] = Set(
       HostDetector.Const.Name,
-      OSDetector.Const.Name
+      OSDetector.Const.Name,
+      ProcessRuntimeDetector.Const.Name
     )
   }
 
@@ -218,7 +219,7 @@ private[sdk] object TelemetryResourceAutoConfigure {
     * | otel.resource.attributes                 | OTEL_RESOURCE_ATTRIBUTES                 | Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3                         |
     * | otel.service.name                        | OTEL_SERVICE_NAME                        | Specify logical service name. Takes precedence over `service.name` defined with `otel.resource.attributes` |
     * | otel.experimental.resource.disabled-keys | OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | Specify resource attribute keys that are filtered.                                                         |
-    * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os`.                                                  |
+    * | otel.otel4s.resource.detectors           | OTEL_OTEL4S_RESOURCE_DETECTORS           | Specify resource detectors to use. Defaults to `host,os,process_runtime`.                                  |
     * }}}
     *
     * @see

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetector.scala
@@ -16,30 +16,28 @@
 
 package org.typelevel.otel4s.sdk.resource
 
-import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
+import org.typelevel.otel4s.AttributeKey
 
-/** A mapping of the Node.js OS API.
+/** Detects runtime details such as name, version, and description.
   *
   * @see
-  *   [[https://nodejs.org/api/os.html]]
+  *   https://opentelemetry.io/docs/specs/semconv/resource/process/#process-runtimes
   */
-private object OS {
+object ProcessRuntimeDetector extends ProcessRuntimeDetectorPlatform {
 
-  @js.native
-  @JSImport("os", "arch")
-  def arch(): String = js.native
+  private[sdk] object Const {
+    val Name = "process_runtime"
+  }
 
-  @js.native
-  @JSImport("os", "hostname")
-  def hostname(): String = js.native
+  private[resource] object Keys {
+    val Name: AttributeKey[String] =
+      AttributeKey("process.runtime.name")
 
-  @js.native
-  @JSImport("os", "platform")
-  def platform(): String = js.native
+    val Version: AttributeKey[String] =
+      AttributeKey("process.runtime.version")
 
-  @js.native
-  @JSImport("os", "release")
-  def release(): String = js.native
+    val Description: AttributeKey[String] =
+      AttributeKey("process.runtime.description")
+  }
 
 }

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/resource/TelemetryResourceDetector.scala
@@ -54,11 +54,12 @@ object TelemetryResourceDetector {
     * Includes:
     *   - host detector
     *   - os detector
+    *   - process runtime detector
     *
     * @tparam F
     *   the higher-kinded type of a polymorphic effect
     */
   def default[F[_]: Sync]: Set[TelemetryResourceDetector[F]] =
-    Set(HostDetector[F], OSDetector[F])
+    Set(HostDetector[F], OSDetector[F], ProcessRuntimeDetector[F])
 
 }

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigureSuite.scala
@@ -20,6 +20,7 @@ package autoconfigure
 
 import cats.effect.IO
 import munit.CatsEffectSuite
+import munit.internal.PlatformCompat
 import org.typelevel.otel4s.sdk.resource.TelemetryResourceDetector
 
 class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
@@ -70,6 +71,15 @@ class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
         val host = Set("host.arch", "host.name")
         val os = Set("os.type", "os.description")
 
+        val runtime = {
+          val name = "process.runtime.name"
+          val version = "process.runtime.version"
+          val description = "process.runtime.description"
+
+          if (PlatformCompat.isNative) Set(name, description)
+          else Set(name, version, description)
+        }
+
         val telemetry = Set(
           "telemetry.sdk.language",
           "telemetry.sdk.name",
@@ -77,7 +87,7 @@ class TelemetryResourceAutoConfigureSuite extends CatsEffectSuite {
         )
 
         val all =
-          host ++ os ++ service ++ telemetry
+          host ++ os ++ runtime ++ service ++ telemetry
 
         IO(assertEquals(resource.attributes.map(_.key.name).toSet, all))
       }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMetrics.scala
@@ -143,6 +143,8 @@ object SdkMetrics {
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
         *   - os: `os.type`, `os.description`
+        *   - process_runtime: `process.runtime.name`,
+        *     `process.runtime.version`, `process.runtime.description`
         *
         * @param detector
         *   the detector to add

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
@@ -164,6 +164,8 @@ object SdkTraces {
         * By default, the following detectors are enabled:
         *   - host: `host.arch`, `host.name`
         *   - os: `os.type`, `os.description`
+        *   - process_runtime: `process.runtime.name`,
+        *     `process.runtime.version`, `process.runtime.description`
         *
         * @param detector
         *   the detector to add


### PR DESCRIPTION
| Reference | Link |
|-|-|
| Spec | https://opentelemetry.io/docs/specs/semconv/resource/process/#process-runtimes |
| Java implementation | [ProcessRuntimeResource.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessRuntimeResource.java) |
| JavaScript implementation | [ProcessDetectorSync.ts](https://github.com/open-telemetry/opentelemetry-js/blob/v1.25.1/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts) |


