### PR TITLE
core-metrics: remove `Histogram.Meta` in favor of `InstrumentMeta`

### DIFF
--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -137,7 +137,7 @@ object HistogramMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.recordDuration($timeUnit, $attributes) else $meta.resourceUnit"
+    q"if ($meta.isEnabled) $backend.recordDuration($timeUnit, $attributes) else _root_.cats.effect.kernel.Resource.unit"
   }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -126,7 +126,7 @@ object HistogramMacro {
     '{
       if ($backend.meta.isEnabled)
         $backend.recordDuration($timeUnit, $attributes)
-      else $backend.meta.resourceUnit
+      else _root_.cats.effect.kernel.Resource.unit
     }
 
 }

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/HistogramSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/HistogramSuite.scala
@@ -23,6 +23,7 @@ import cats.effect.Resource
 import cats.effect.testkit.TestControl
 import cats.syntax.functor._
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.meta.InstrumentMeta
 
 import java.util.concurrent.TimeUnit
 import scala.collection.immutable
@@ -114,7 +115,7 @@ object HistogramSuite {
 
     val backend: Histogram.Backend[IO, Double] =
       new Histogram.Backend[IO, Double] {
-        val meta: Histogram.Meta[IO] = Histogram.Meta.enabled
+        val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
 
         def record(
             value: Double,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -23,6 +23,7 @@ import cats.effect.kernel.Sync
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import io.opentelemetry.api.metrics.{Meter => JMeter}
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.oteljava.AttributeConverters._
 import org.typelevel.otel4s.oteljava.context.AskContext
@@ -101,7 +102,7 @@ object HistogramBuilderImpl {
           val histogram = builder.ofLongs().build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: Histogram.Meta[F] = Histogram.Meta.enabled
+            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
             def record(
                 value: A,
@@ -161,7 +162,7 @@ object HistogramBuilderImpl {
           val histogram = builder.build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: Histogram.Meta[F] = Histogram.Meta.enabled
+            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
             def record(
                 value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -26,6 +26,7 @@ import cats.syntax.functor._
 import org.typelevel.ci.CIString
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics.BucketBoundaries
 import org.typelevel.otel4s.metrics.Histogram
 import org.typelevel.otel4s.metrics.MeasurementValue
@@ -57,7 +58,7 @@ private object SdkHistogram {
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Histogram.Backend[F, A] {
-    val meta: Histogram.Meta[F] = Histogram.Meta.enabled
+    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
     def record(
         value: A,


### PR DESCRIPTION
I cannot recall why it was implemented that way in the very first place. 

`Histogram.Meta` was needed to provide the `def resourceUnit: Resource[F, Unit]`. However, we can construct `Resource.unit` anywhere since it doesn't require `Applicative`.
