### PR TITLE
sdk-trace: define `meta: InstrumentMeta[F]` as `val`

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
@@ -51,7 +51,7 @@ private object SdkCounter {
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Counter.Backend[F, A] {
-    def meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
@@ -46,7 +46,7 @@ private object SdkGauge {
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Gauge.Backend[F, A] {
-    def meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -57,7 +57,7 @@ private object SdkHistogram {
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Histogram.Backend[F, A] {
-    def meta: Histogram.Meta[F] = Histogram.Meta.enabled
+    val meta: Histogram.Meta[F] = Histogram.Meta.enabled
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -50,7 +50,7 @@ private object SdkUpDownCounter {
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends UpDownCounter.Backend[F, A] {
-    def meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -74,7 +74,7 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
 ) extends Span.Backend[F]
     with SpanRef[F] {
 
-  def meta: InstrumentMeta[F] =
+  val meta: InstrumentMeta[F] =
     InstrumentMeta.enabled
 
   def context: SpanContext =


### PR DESCRIPTION
`{instrument}.meta` is always used by the macro under the hood: `Counter#add`, `Histogram#record`, etc. So, it makes sense to allocate it only once. 

Instruments in the `oteljava` module also define `meta` as a const variable. 