### PR TITLE
core-trace: remove typed backend such as `{X}.LongBackend`, `{X}.DoubleBackend`

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
@@ -100,16 +100,6 @@ object Counter {
     def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
   }
 
-  trait LongBackend[F[_]] extends Backend[F, Long] {
-    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(1L, attributes)
-  }
-
-  trait DoubleBackend[F[_]] extends Backend[F, Double] {
-    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(1.0, attributes)
-  }
-
   def noop[F[_], A](implicit F: Applicative[F]): Counter[F, A] =
     new Counter[F, A] {
       val backend: Backend[F, A] =

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
@@ -108,22 +108,6 @@ object UpDownCounter {
     def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit]
   }
 
-  trait LongBackend[F[_]] extends Backend[F, Long] {
-    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(1L, attributes)
-
-    final def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(-1L, attributes)
-  }
-
-  trait DoubleBackend[F[_]] extends Backend[F, Double] {
-    final def inc(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(1.0, attributes)
-
-    final def dec(attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
-      add(-1.0, attributes)
-  }
-
   def noop[F[_], A](implicit F: Applicative[F]): UpDownCounter[F, A] =
     new UpDownCounter[F, A] {
       val backend: UpDownCounter.Backend[F, A] =

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/CounterSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/CounterSuite.scala
@@ -99,7 +99,7 @@ object CounterSuite {
       extends Counter[IO, Long] {
 
     val backend: Counter.Backend[IO, Long] =
-      new Counter.LongBackend[IO] {
+      new Counter.Backend[IO, Long] {
         val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
 
         def add(
@@ -107,6 +107,9 @@ object CounterSuite {
             attributes: immutable.Iterable[Attribute[_]]
         ): IO[Unit] =
           ref.update(_.appended(Record(value, attributes.to(Attributes))))
+
+        def inc(attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+          add(1L, attributes)
       }
 
     def records: IO[List[Record[Long]]] =

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
@@ -121,7 +121,7 @@ object UpDownCounterSuite {
       extends UpDownCounter[IO, Long] {
 
     val backend: UpDownCounter.Backend[IO, Long] =
-      new UpDownCounter.LongBackend[IO] {
+      new UpDownCounter.Backend[IO, Long] {
         val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
 
         def add(
@@ -129,6 +129,12 @@ object UpDownCounterSuite {
             attributes: immutable.Iterable[Attribute[_]]
         ): IO[Unit] =
           ref.update(_.appended(Record(value, attributes.to(Attributes))))
+
+        def inc(attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+          add(1L, attributes)
+
+        def dec(attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+          add(-1L, attributes)
       }
 
     def records: IO[List[Record[Long]]] =


### PR DESCRIPTION
The leftover from the #449. 