### PR TITLE
oteljava: TextMapPropagatorWrapper - add meaningful `toString`

### DIFF
--- a/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/context/propagation/JavaPropagatorWrappers.scala
+++ b/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/context/propagation/JavaPropagatorWrappers.scala
@@ -74,6 +74,8 @@ private[propagation] object JavaPropagatorWrappers {
       Option(carrier)
         .fold(context)(underlying.extract(Context.wrap(context), _).underlying)
     }
+
+    override def toString: String = s"TextMapPropagatorWrapper{$underlying}"
   }
 
   class JTextMapPropagatorWrapper(val underlying: JTextMapPropagator)
@@ -101,5 +103,7 @@ private[propagation] object JavaPropagatorWrappers {
       )
       res
     }
+
+    override def toString: String = s"JTextMapPropagatorWrapper{$underlying}"
   }
 }

--- a/oteljava/common/src/test/scala/org/typelevel/otel4s/oteljava/context/propagation/PropagatorConvertersSuite.scala
+++ b/oteljava/common/src/test/scala/org/typelevel/otel4s/oteljava/context/propagation/PropagatorConvertersSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.oteljava.context.propagation
+
+import io.opentelemetry.api.incubator.propagation.{
+  PassThroughPropagator => JPassThroughPropagator
+}
+import munit.FunSuite
+import org.typelevel.otel4s.context.propagation.PassThroughPropagator
+import org.typelevel.otel4s.oteljava.context.Context
+import org.typelevel.otel4s.oteljava.context.propagation.PropagatorConverters._
+
+class PropagatorConvertersSuite extends FunSuite {
+
+  test("TextMapPropagatorWrapper - proper to string") {
+    assertEquals(
+      PassThroughPropagator[Context, Context.Key]("key").asJava.toString,
+      "TextMapPropagatorWrapper{PassThroughPropagator{fields=[key]}}"
+    )
+  }
+
+  test("JTextMapPropagatorWrapper - proper to string") {
+    assertEquals(
+      JPassThroughPropagator.create("key").asScala.toString,
+      "JTextMapPropagatorWrapper{PassThroughPropagator{fields=[key]}}"
+    )
+  }
+
+}


### PR DESCRIPTION
Before this change, the `toString` didn't provide any useful information:
```scala
OtelJava.autoConfigured[IO]().use { otel4s =>
  IO.println("Propagators: " + otel4s.propagators)
}
```

Prints:
```
Propagators: ContextPropagators.Default{textMapPropagator=
org.typelevel.otel4s.oteljava.context.propagation.JavaPropagatorWrappers$JTextMapPropagatorWrapper@47a8424c}
```