### PR TITLE
docs: update OpenTelemetry configuration links

### DIFF
--- a/docs/customization/histogram-custom-buckets/README.md
+++ b/docs/customization/histogram-custom-buckets/README.md
@@ -53,7 +53,7 @@ Add directives to the `histogram-buckets.scala`:
 
 As mentioned above, we use `otel.service.name` system properties to configure the OpenTelemetry SDK.
 The SDK can be configured via environment variables too. Check the full list
-of [environment variable configurations](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md)
+of [environment variable configurations](https://opentelemetry.io/docs/languages/java/configuration/)
 for more options.
 
 ### OpenTelemetry Autoconfigure extension customization

--- a/docs/examples/grafana/README.md
+++ b/docs/examples/grafana/README.md
@@ -52,7 +52,7 @@ Add directives to the `grafana.scala`:
 As mentioned above, we use `otel.service.name` and `otel.metrics.exporter` system properties to configure the
 OpenTelemetry SDK.
 The SDK can be configured via environment variables too. Check the full list
-of [environment variable configurations](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md)
+of [environment variable configurations](https://opentelemetry.io/docs/languages/java/configuration)
 for more options.
 
 ### Observability stack configuration

--- a/docs/examples/honeycomb/README.md
+++ b/docs/examples/honeycomb/README.md
@@ -58,7 +58,7 @@ Add directives to the `tracing.scala`:
 As mentioned above, we use `otel.java.global-autoconfigure.enabled` and `otel.service.name` system properties to configure the
 OpenTelemetry SDK.
 The SDK can be configured via environment variables too. Check the full list
-of [environment variable configurations](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md)
+of [environment variable configurations](https://opentelemetry.io/docs/languages/java/configuration)
 for more options.
 
 ### Acquiring a Honeycomb API key

--- a/docs/examples/jaeger-docker/README.md
+++ b/docs/examples/jaeger-docker/README.md
@@ -52,7 +52,7 @@ Add directives to the `tracing.scala`:
 As mentioned above, we use `otel.service.name` and `otel.metrics.exporter` system properties to configure the
 OpenTelemetry SDK.
 The SDK can be configured via environment variables too. Check the full list
-of [environment variable configurations](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md)
+of [environment variable configurations](https://opentelemetry.io/docs/languages/java/configuration)
 for more options.
 
 ### Jaeger configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,6 @@ val io: IO[Unit] = program[IO]
 
 [cats-effect]: https://typelevel.org/cats-effect/
 [opentelemetry-java]: https://github.com/open-telemetry/opentelemetry-java/tree/main/api/all
-[opentelemetry-java-autoconfigure]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md
+[opentelemetry-java-autoconfigure]: https://opentelemetry.io/docs/languages/java/configuration/
 [otel]: https://opentelemetry.io/
 [otel spec]: https://opentelemetry.io/docs/reference/specification/

--- a/docs/instrumentation/metrics.md
+++ b/docs/instrumentation/metrics.md
@@ -196,4 +196,4 @@ object CatsEffectMetrics {
 ```
 
 [opentelemetry-java]: https://github.com/open-telemetry/opentelemetry-java
-[opentelemetry-java-autoconfigure]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md
+[opentelemetry-java-autoconfigure]: https://opentelemetry.io/docs/languages/java/configuration/

--- a/docs/instrumentation/tracing.md
+++ b/docs/instrumentation/tracing.md
@@ -158,4 +158,4 @@ class InternalUserService[F[_]: Tracer](repo: UserRepository[F]) {
 ```
 
 [opentelemetry-java]: https://github.com/open-telemetry/opentelemetry-java
-[opentelemetry-java-autoconfigure]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md
+[opentelemetry-java-autoconfigure]: https://opentelemetry.io/docs/languages/java/configuration/

--- a/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigure.scala
+++ b/sdk-exporter/common/src/main/scala/org/typelevel/otel4s/sdk/exporter/otlp/autoconfigure/OtlpHttpClientAutoConfigure.scala
@@ -64,7 +64,7 @@ import scala.concurrent.duration.FiniteDuration
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-span-metric-and-log-exporters]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#otlp-exporter-span-metric-and-log-exporters]]
   */
 private final class OtlpHttpClientAutoConfigure[
     F[_]: Async: Network: Compression: Console,

--- a/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
+++ b/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
@@ -106,7 +106,7 @@ object OpenTelemetrySdk {
   /** The auto-configured [[OpenTelemetrySdk]].
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md]]
+    *   [[https://typelevel.org/otel4s/sdk/configuration.html]]
     *
     * @tparam F
     *   the higher-kinded type of a polymorphic effect

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/autoconfigure/TelemetryResourceAutoConfigure.scala
@@ -44,7 +44,7 @@ import java.nio.charset.StandardCharsets
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#resources]]
   *
   * @param extraDetectors
   *   the extra detectors to use
@@ -223,7 +223,7 @@ private[sdk] object TelemetryResourceAutoConfigure {
     * }}}
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#resources]]
     *
     * @param extraDetectors
     *   the extra detectors to use

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/autoconfigure/ExemplarFilterAutoConfigure.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/autoconfigure/ExemplarFilterAutoConfigure.scala
@@ -39,7 +39,7 @@ import org.typelevel.otel4s.sdk.metrics.exemplar.TraceContextLookup
   *   - `trace_based` - [[ExemplarFilter.traceBased]]
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exemplars]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#exemplars]]
   */
 private final class ExemplarFilterAutoConfigure[F[_]: MonadThrow](
     lookup: TraceContextLookup
@@ -113,7 +113,7 @@ private[sdk] object ExemplarFilterAutoConfigure {
     *   - `trace_based` - [[ExemplarFilter.traceBased]]
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exemplars]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#exemplars]]
     *
     * @param traceContextLookup
     *   used by the exemplar reservoir to extract tracing information from the

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/autoconfigure/MetricExportersAutoConfigure.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/autoconfigure/MetricExportersAutoConfigure.scala
@@ -39,7 +39,7 @@ import org.typelevel.otel4s.sdk.metrics.exporter.MetricExporter
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#metric-exporters]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#metric-exporters]]
   */
 private final class MetricExportersAutoConfigure[F[_]: MonadThrow: Console](
     extra: Set[AutoConfigure.Named[F, MetricExporter[F]]]
@@ -157,7 +157,7 @@ private[sdk] object MetricExportersAutoConfigure {
     * }}}
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#metric-exporters]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#metric-exporters]]
     *
     * @param configurers
     *   the configurers to use

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/BatchSpanProcessorAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/BatchSpanProcessorAutoConfigure.scala
@@ -41,7 +41,7 @@ import scala.concurrent.duration.FiniteDuration
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#batch-span-processor]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#batch-span-processor]]
   *
   * @param exporter
   *   the exporter to use with the configured batch span processor
@@ -125,7 +125,7 @@ private[sdk] object BatchSpanProcessorAutoConfigure {
     * }}}
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#batch-span-processor]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#batch-span-processor]]
     *
     * @param exporter
     *   the exporter to use with the configured batch span processor

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/ContextPropagatorsAutoConfigure.scala
@@ -41,7 +41,7 @@ import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropaga
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#propagator]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#propagators]]
   */
 private final class ContextPropagatorsAutoConfigure[F[_]: MonadThrow](
     extra: Set[AutoConfigure.Named[F, TextMapPropagator[Context]]]
@@ -144,7 +144,7 @@ private[sdk] object ContextPropagatorsAutoConfigure {
     *   - [[OtTracePropagator ottrace]]
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#propagator]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#propagators]]
     *
     * @param extra
     *   extra configurers to use

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SamplerAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SamplerAutoConfigure.scala
@@ -35,7 +35,7 @@ import org.typelevel.otel4s.sdk.trace.samplers.Sampler
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#sampler]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#sampler]]
   */
 private final class SamplerAutoConfigure[F[_]: MonadThrow](
     extra: Set[AutoConfigure.Named[F, Sampler]]
@@ -161,7 +161,7 @@ private[sdk] object SamplerAutoConfigure {
     *     the ratio
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#sampler]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#sampler]]
     */
   def apply[F[_]: MonadThrow](
       extra: Set[AutoConfigure.Named[F, Sampler]]

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/SpanExportersAutoConfigure.scala
@@ -39,7 +39,7 @@ import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
   * }}}
   *
   * @see
-  *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#span-exporters]]
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#span-exporters]]
   */
 private final class SpanExportersAutoConfigure[F[_]: MonadThrow: Console](
     extra: Set[AutoConfigure.Named[F, SpanExporter[F]]]
@@ -152,7 +152,7 @@ private[sdk] object SpanExportersAutoConfigure {
     * }}}
     *
     * @see
-    *   [[https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#span-exporters]]
+    *   [[https://opentelemetry.io/docs/languages/java/configuration/#span-exporters]]
     *
     * @param configurers
     *   the configurers to use


### PR DESCRIPTION
The old link is outdated.