### PR TITLE
Let Scala Steward ignore otel4s-java updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -593,7 +593,9 @@ lazy val scalafix = tlScalafixProject
   )
   .inputSettings(
     crossScalaVersions := Seq(Scala213),
+    // scala-steward:off
     libraryDependencies += "org.typelevel" %% "otel4s-java" % "0.4.0",
+    // scala-steward:on
     headerSources / excludeFilter := AllPassFilter
   )
   .inputConfigure(_.disablePlugins(ScalafixPlugin))


### PR DESCRIPTION
This should prevent useless PRs like:
* #746 
* #716 
* #689

https://github.com/scala-steward-org/scala-steward/blob/806529ada57067262eaf9425efe52bb2249b6047/docs/repo-specific-configuration.md?plain=1#L210