### PR TITLE
core-trace: use `ExitCase` to build attributes in `Histogram#recordDuration`

### DIFF
--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
@@ -118,11 +118,11 @@ object Histogram {
       *   the time unit of the duration measurement
       *
       * @param attributes
-      *   the set of attributes to associate with the value
+      *   the function to build set of attributes to associate with the value
       */
     def recordDuration(
         timeUnit: TimeUnit,
-        attributes: immutable.Iterable[Attribute[_]]
+        attributes: Resource.ExitCase => immutable.Iterable[Attribute[_]]
     ): Resource[F, Unit]
   }
 
@@ -137,7 +137,7 @@ object Histogram {
           ): F[Unit] = meta.unit
           def recordDuration(
               timeUnit: TimeUnit,
-              attributes: immutable.Iterable[Attribute[_]]
+              attributes: Resource.ExitCase => immutable.Iterable[Attribute[_]]
           ): Resource[F, Unit] = Resource.unit
         }
     }

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -112,7 +112,7 @@ object HistogramBuilderImpl {
 
             def recordDuration(
                 timeUnit: TimeUnit,
-                attributes: immutable.Iterable[Attribute[_]]
+                attributes: Resource.ExitCase => immutable.Iterable[Attribute[_]]
             ): Resource[F, Unit] =
               Resource
                 .makeCase(Sync[F].monotonic) { case (start, ec) =>
@@ -120,7 +120,7 @@ object HistogramBuilderImpl {
                     end <- Sync[F].monotonic
                     _ <- doRecord(
                       (end - start).toUnit(timeUnit).toLong,
-                      attributes ++ Histogram.causeAttributes(ec)
+                      attributes(ec)
                     )
                   } yield ()
                 }
@@ -172,7 +172,7 @@ object HistogramBuilderImpl {
 
             def recordDuration(
                 timeUnit: TimeUnit,
-                attributes: immutable.Iterable[Attribute[_]]
+                attributes: Resource.ExitCase => immutable.Iterable[Attribute[_]]
             ): Resource[F, Unit] =
               Resource
                 .makeCase(Sync[F].monotonic) { case (start, ec) =>
@@ -180,7 +180,7 @@ object HistogramBuilderImpl {
                     end <- Sync[F].monotonic
                     _ <- doRecord(
                       (end - start).toUnit(timeUnit),
-                      attributes ++ Histogram.causeAttributes(ec)
+                      attributes(ec)
                     )
                   } yield ()
                 }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -67,7 +67,7 @@ private object SdkHistogram {
 
     def recordDuration(
         timeUnit: TimeUnit,
-        attributes: immutable.Iterable[Attribute[_]]
+        attributes: Resource.ExitCase => immutable.Iterable[Attribute[_]]
     ): Resource[F, Unit] =
       Resource
         .makeCase(Clock[F].monotonic) { case (start, ec) =>
@@ -75,7 +75,7 @@ private object SdkHistogram {
             end <- Clock[F].monotonic
             _ <- doRecord(
               castDuration((end - start).toUnit(timeUnit)),
-              (attributes ++ Histogram.causeAttributes(ec)).to(Attributes)
+              attributes(ec).to(Attributes)
             )
           } yield ()
         }


### PR DESCRIPTION
There is also a major behavior change: `recordDuration` no longer adds `cause` attribute by default.

To preserve old behavior, users must use `histogram.recordDuration(TimeUnit.SECONDS, Histogram.recordCause)`.

### Motivation

`cause` attribute is opinionated and doesn't go along with most of the semantic conventions. 
In most conventions, it would be [error.type](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/#metric-dbclientoperationduration) instead. 

