### PR TITLE
semconv-metrics: use a reference to semantic attributes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -631,7 +631,7 @@ lazy val `semconv-metrics-stable` =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("semconv/metrics/stable"))
-    .dependsOn(`core-metrics`)
+    .dependsOn(`core-metrics`, `semconv-stable`)
     .settings(
       name := "otel4s-semconv-metrics",
       startYear := Some(2024),
@@ -644,7 +644,7 @@ lazy val `semconv-metrics-experimental` =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)
     .crossType(CrossType.Pure)
     .in(file("semconv/metrics/experimental"))
-    .dependsOn(`core-metrics`, `semconv-metrics-stable`)
+    .dependsOn(`core-metrics`, `semconv-metrics-stable`, `semconv-experimental`)
     .settings(
       name := "otel4s-semconv-metrics-experimental",
       startYear := Some(2024),

--- a/buildscripts/semantic-convention/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
@@ -52,6 +52,14 @@
 {%- endif -%}
 {% endmacro %}
 
+{%- macro attributeRef(attribute) -%}
+  {%- if attribute is stable -%}
+    {{ attribute.name.split(".")[0] | pascal_case }}Attributes.{{ attribute.name | pascal_case }}
+  {%- else -%}
+    {{ attribute.name.split(".")[0] | pascal_case }}ExperimentalAttributes.{{ attribute.name | pascal_case }}
+  {%- endif -%}
+{%- endmacro -%}
+
 {%- set object_name = ctx.root_namespace | pascal_case ~ params.object_prefix ~ "Metrics" -%}
 
 /*
@@ -80,6 +88,22 @@ package metrics
 {%- endif %}
 
 import org.typelevel.otel4s.metrics._
+{%- set required_imports = namespace(stable = false, experimental = false) -%}
+{%- for metric in ctx.metrics -%}
+  {% for attribute in metric.attributes %}
+    {%- if attribute is stable -%}
+      {%- set required_imports.stable = true -%}
+    {%- else -%}
+      {%- set required_imports.experimental = true -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+{%- if required_imports.stable == true %}
+import org.typelevel.otel4s.semconv.attributes._
+{%- endif %}
+{%- if required_imports.experimental == true %}
+import org.typelevel.otel4s.semconv.experimental.attributes._
+{%- endif %}
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object {{ object_name }} {
@@ -103,7 +127,7 @@ object {{ object_name }} {
       {%- endif %}
       val {{ attribute.name | camel_case }}: AttributeSpec[{{to_scala_key_type(attribute)}}] =
         AttributeSpec(
-          AttributeKey("{{attribute.name}}"),
+          {{ attributeRef(attribute) }},
           List(
             {% for example in attribute.examples -%} {{ exampleValue(attribute.type | instantiated_type, example) }}, {% endfor %}
           ),

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ContainerExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ContainerExperimentalMetrics.scala
@@ -20,6 +20,7 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object ContainerExperimentalMetrics {
@@ -43,7 +44,7 @@ object ContainerExperimentalMetrics {
         */
       val cpuMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("cpu.mode"),
+          CpuExperimentalAttributes.CpuMode,
           List(
             "user",
             "system",
@@ -83,7 +84,7 @@ object ContainerExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -95,7 +96,7 @@ object ContainerExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -154,7 +155,7 @@ object ContainerExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -166,7 +167,7 @@ object ContainerExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DbExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DbExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object DbExperimentalMetrics {
@@ -42,7 +44,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -54,7 +56,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.state"),
+          DbExperimentalAttributes.DbClientConnectionState,
           List(
             "idle",
           ),
@@ -96,7 +98,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -138,7 +140,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -179,7 +181,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -220,7 +222,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -261,7 +263,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -302,7 +304,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -343,7 +345,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -385,7 +387,7 @@ object DbExperimentalMetrics {
         */
       val dbClientConnectionPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connection.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionPoolName,
           List(
             "myDataSource",
           ),
@@ -426,7 +428,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -466,7 +468,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -505,7 +507,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -544,7 +546,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -583,7 +585,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -622,7 +624,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -661,7 +663,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -674,7 +676,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.state`.", "")
       val dbClientConnectionsState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.state"),
+          DbExperimentalAttributes.DbClientConnectionsState,
           List(
             "idle",
           ),
@@ -715,7 +717,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -756,7 +758,7 @@ object DbExperimentalMetrics {
       @deprecated("Replaced by `db.client.connection.pool.name`.", "")
       val dbClientConnectionsPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.client.connections.pool.name"),
+          DbExperimentalAttributes.DbClientConnectionsPoolName,
           List(
             "myDataSource",
           ),
@@ -803,7 +805,7 @@ object DbExperimentalMetrics {
         */
       val dbCollectionName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.collection.name"),
+          DbExperimentalAttributes.DbCollectionName,
           List(
             "public.users",
             "customers",
@@ -825,7 +827,7 @@ object DbExperimentalMetrics {
         */
       val dbNamespace: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.namespace"),
+          DbExperimentalAttributes.DbNamespace,
           List(
             "customers",
             "test.users",
@@ -844,7 +846,7 @@ object DbExperimentalMetrics {
         */
       val dbOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.operation.name"),
+          DbExperimentalAttributes.DbOperationName,
           List(
             "findAndModify",
             "HMSET",
@@ -864,7 +866,7 @@ object DbExperimentalMetrics {
         */
       val dbSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("db.system"),
+          DbExperimentalAttributes.DbSystem,
           List(
           ),
           Requirement.required,
@@ -879,7 +881,7 @@ object DbExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -899,7 +901,7 @@ object DbExperimentalMetrics {
         */
       val networkPeerAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.peer.address"),
+          NetworkAttributes.NetworkPeerAddress,
           List(
             "10.1.2.80",
             "/tmp/my.sock",
@@ -912,7 +914,7 @@ object DbExperimentalMetrics {
         */
       val networkPeerPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("network.peer.port"),
+          NetworkAttributes.NetworkPeerPort,
           List(
             65123,
           ),
@@ -927,7 +929,7 @@ object DbExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -944,7 +946,7 @@ object DbExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DnsExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DnsExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object DnsExperimentalMetrics {
@@ -42,7 +44,7 @@ object DnsExperimentalMetrics {
         */
       val dnsQuestionName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("dns.question.name"),
+          DnsExperimentalAttributes.DnsQuestionName,
           List(
             "www.example.com",
             "dot.net",
@@ -61,7 +63,7 @@ object DnsExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "host_not_found",
             "no_recovery",

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/FaasExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/FaasExperimentalMetrics.scala
@@ -20,6 +20,7 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object FaasExperimentalMetrics {
@@ -38,7 +39,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -74,7 +75,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -111,7 +112,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -147,7 +148,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -184,7 +185,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -220,7 +221,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -257,7 +258,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -294,7 +295,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,
@@ -331,7 +332,7 @@ object FaasExperimentalMetrics {
         */
       val faasTrigger: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("faas.trigger"),
+          FaasExperimentalAttributes.FaasTrigger,
           List(
           ),
           Requirement.recommended,

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/GenAiExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/GenAiExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object GenAiExperimentalMetrics {
@@ -42,7 +44,7 @@ object GenAiExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -62,7 +64,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.operation.name"),
+          GenAiExperimentalAttributes.GenAiOperationName,
           List(
           ),
           Requirement.required,
@@ -73,7 +75,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiRequestModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.request.model"),
+          GenAiExperimentalAttributes.GenAiRequestModel,
           List(
             "g",
             "p",
@@ -89,7 +91,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiResponseModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.response.model"),
+          GenAiExperimentalAttributes.GenAiResponseModel,
           List(
             "gpt-4-0613",
           ),
@@ -108,7 +110,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.system"),
+          GenAiExperimentalAttributes.GenAiSystem,
           List(
             "o",
             "p",
@@ -128,7 +130,7 @@ object GenAiExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -145,7 +147,7 @@ object GenAiExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -196,7 +198,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.operation.name"),
+          GenAiExperimentalAttributes.GenAiOperationName,
           List(
           ),
           Requirement.required,
@@ -207,7 +209,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiRequestModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.request.model"),
+          GenAiExperimentalAttributes.GenAiRequestModel,
           List(
             "g",
             "p",
@@ -223,7 +225,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiResponseModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.response.model"),
+          GenAiExperimentalAttributes.GenAiResponseModel,
           List(
             "gpt-4-0613",
           ),
@@ -242,7 +244,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.system"),
+          GenAiExperimentalAttributes.GenAiSystem,
           List(
             "o",
             "p",
@@ -259,7 +261,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiTokenType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.token.type"),
+          GenAiExperimentalAttributes.GenAiTokenType,
           List(
             "input",
             "output",
@@ -275,7 +277,7 @@ object GenAiExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -292,7 +294,7 @@ object GenAiExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -342,7 +344,7 @@ object GenAiExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -362,7 +364,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.operation.name"),
+          GenAiExperimentalAttributes.GenAiOperationName,
           List(
           ),
           Requirement.required,
@@ -373,7 +375,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiRequestModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.request.model"),
+          GenAiExperimentalAttributes.GenAiRequestModel,
           List(
             "g",
             "p",
@@ -389,7 +391,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiResponseModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.response.model"),
+          GenAiExperimentalAttributes.GenAiResponseModel,
           List(
             "gpt-4-0613",
           ),
@@ -408,7 +410,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.system"),
+          GenAiExperimentalAttributes.GenAiSystem,
           List(
             "o",
             "p",
@@ -428,7 +430,7 @@ object GenAiExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -445,7 +447,7 @@ object GenAiExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -496,7 +498,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.operation.name"),
+          GenAiExperimentalAttributes.GenAiOperationName,
           List(
           ),
           Requirement.required,
@@ -507,7 +509,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiRequestModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.request.model"),
+          GenAiExperimentalAttributes.GenAiRequestModel,
           List(
             "g",
             "p",
@@ -523,7 +525,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiResponseModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.response.model"),
+          GenAiExperimentalAttributes.GenAiResponseModel,
           List(
             "gpt-4-0613",
           ),
@@ -542,7 +544,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.system"),
+          GenAiExperimentalAttributes.GenAiSystem,
           List(
             "o",
             "p",
@@ -562,7 +564,7 @@ object GenAiExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -579,7 +581,7 @@ object GenAiExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -629,7 +631,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.operation.name"),
+          GenAiExperimentalAttributes.GenAiOperationName,
           List(
           ),
           Requirement.required,
@@ -640,7 +642,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiRequestModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.request.model"),
+          GenAiExperimentalAttributes.GenAiRequestModel,
           List(
             "g",
             "p",
@@ -656,7 +658,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiResponseModel: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.response.model"),
+          GenAiExperimentalAttributes.GenAiResponseModel,
           List(
             "gpt-4-0613",
           ),
@@ -675,7 +677,7 @@ object GenAiExperimentalMetrics {
         */
       val genAiSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("gen_ai.system"),
+          GenAiExperimentalAttributes.GenAiSystem,
           List(
             "o",
             "p",
@@ -695,7 +697,7 @@ object GenAiExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -712,7 +714,7 @@ object GenAiExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HttpExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HttpExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object HttpExperimentalMetrics {
@@ -53,7 +55,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -71,7 +73,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -89,7 +91,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -104,7 +106,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -121,7 +123,7 @@ object HttpExperimentalMetrics {
         */
       val urlTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.template"),
+          UrlExperimentalAttributes.UrlTemplate,
           List(
             "/users/{id}",
             "/users/:id",
@@ -164,7 +166,7 @@ object HttpExperimentalMetrics {
         */
       val networkPeerAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.peer.address"),
+          NetworkAttributes.NetworkPeerAddress,
           List(
             "10.1.2.80",
             "/tmp/my.sock",
@@ -181,7 +183,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.1",
             "2",
@@ -198,7 +200,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -216,7 +218,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -231,7 +233,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -274,7 +276,7 @@ object HttpExperimentalMetrics {
         */
       val httpConnectionState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.connection.state"),
+          HttpExperimentalAttributes.HttpConnectionState,
           List(
             "active",
             "idle",
@@ -287,7 +289,7 @@ object HttpExperimentalMetrics {
         */
       val networkPeerAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.peer.address"),
+          NetworkAttributes.NetworkPeerAddress,
           List(
             "10.1.2.80",
             "/tmp/my.sock",
@@ -304,7 +306,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.1",
             "2",
@@ -321,7 +323,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -339,7 +341,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -354,7 +356,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -414,7 +416,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -444,7 +446,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -458,7 +460,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -472,7 +474,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -489,7 +491,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -508,7 +510,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -526,7 +528,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -541,7 +543,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -558,7 +560,7 @@ object HttpExperimentalMetrics {
         */
       val urlTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.template"),
+          UrlExperimentalAttributes.UrlTemplate,
           List(
             "/users/{id}",
             "/users/:id",
@@ -618,7 +620,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -648,7 +650,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -662,7 +664,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -676,7 +678,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -693,7 +695,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -712,7 +714,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -730,7 +732,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -745,7 +747,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -808,7 +810,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -838,7 +840,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -852,7 +854,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -866,7 +868,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -883,7 +885,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -902,7 +904,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -920,7 +922,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -935,7 +937,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -952,7 +954,7 @@ object HttpExperimentalMetrics {
         */
       val urlTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.template"),
+          UrlExperimentalAttributes.UrlTemplate,
           List(
             "/users/{id}",
             "/users/:id",
@@ -1015,7 +1017,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -1034,7 +1036,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1053,7 +1055,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1068,7 +1070,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -1126,7 +1128,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -1156,7 +1158,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -1170,7 +1172,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -1186,7 +1188,7 @@ object HttpExperimentalMetrics {
         */
       val httpRoute: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.route"),
+          HttpAttributes.HttpRoute,
           List(
             "/users/:userID?",
             "{controller}/{action}/{id?}",
@@ -1201,7 +1203,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -1218,7 +1220,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -1238,7 +1240,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1257,7 +1259,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1277,7 +1279,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -1336,7 +1338,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -1366,7 +1368,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -1380,7 +1382,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -1396,7 +1398,7 @@ object HttpExperimentalMetrics {
         */
       val httpRoute: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.route"),
+          HttpAttributes.HttpRoute,
           List(
             "/users/:userID?",
             "{controller}/{action}/{id?}",
@@ -1411,7 +1413,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -1428,7 +1430,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -1448,7 +1450,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1467,7 +1469,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1487,7 +1489,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -1551,7 +1553,7 @@ object HttpExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -1581,7 +1583,7 @@ object HttpExperimentalMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -1595,7 +1597,7 @@ object HttpExperimentalMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -1611,7 +1613,7 @@ object HttpExperimentalMetrics {
         */
       val httpRoute: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.route"),
+          HttpAttributes.HttpRoute,
           List(
             "/users/:userID?",
             "{controller}/{action}/{id?}",
@@ -1626,7 +1628,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -1643,7 +1645,7 @@ object HttpExperimentalMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -1663,7 +1665,7 @@ object HttpExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1682,7 +1684,7 @@ object HttpExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1702,7 +1704,7 @@ object HttpExperimentalMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/JvmExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/JvmExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object JvmExperimentalMetrics {
@@ -41,7 +43,7 @@ object JvmExperimentalMetrics {
         */
       val jvmBufferPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.buffer.pool.name"),
+          JvmExperimentalAttributes.JvmBufferPoolName,
           List(
             "mapped",
             "direct",
@@ -82,7 +84,7 @@ object JvmExperimentalMetrics {
         */
       val jvmBufferPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.buffer.pool.name"),
+          JvmExperimentalAttributes.JvmBufferPoolName,
           List(
             "mapped",
             "direct",
@@ -124,7 +126,7 @@ object JvmExperimentalMetrics {
         */
       val jvmBufferPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.buffer.pool.name"),
+          JvmExperimentalAttributes.JvmBufferPoolName,
           List(
             "mapped",
             "direct",
@@ -165,7 +167,7 @@ object JvmExperimentalMetrics {
         */
       val jvmBufferPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.buffer.pool.name"),
+          JvmExperimentalAttributes.JvmBufferPoolName,
           List(
             "mapped",
             "direct",
@@ -312,7 +314,7 @@ object JvmExperimentalMetrics {
         */
       val jvmGcAction: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.gc.action"),
+          JvmAttributes.JvmGcAction,
           List(
             "end of minor GC",
             "end of major GC",
@@ -328,7 +330,7 @@ object JvmExperimentalMetrics {
         */
       val jvmGcName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.gc.name"),
+          JvmAttributes.JvmGcName,
           List(
             "G1 Young Generation",
             "G1 Old Generation",
@@ -371,7 +373,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -385,7 +387,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -427,7 +429,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -441,7 +443,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -483,7 +485,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -497,7 +499,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -539,7 +541,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -553,7 +555,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -595,7 +597,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -609,7 +611,7 @@ object JvmExperimentalMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -691,7 +693,7 @@ object JvmExperimentalMetrics {
         */
       val jvmThreadDaemon: AttributeSpec[Boolean] =
         AttributeSpec(
-          AttributeKey("jvm.thread.daemon"),
+          JvmAttributes.JvmThreadDaemon,
           List(
           ),
           Requirement.recommended,
@@ -702,7 +704,7 @@ object JvmExperimentalMetrics {
         */
       val jvmThreadState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.thread.state"),
+          JvmAttributes.JvmThreadState,
           List(
             "runnable",
             "blocked",

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/MessagingExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/MessagingExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object MessagingExperimentalMetrics {
@@ -54,7 +56,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -71,7 +73,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingConsumerGroupName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.consumer.group.name"),
+          MessagingExperimentalAttributes.MessagingConsumerGroupName,
           List(
             "my-group",
             "indexer",
@@ -87,7 +89,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.name"),
+          MessagingExperimentalAttributes.MessagingDestinationName,
           List(
             "MyQueue",
             "MyTopic",
@@ -103,7 +105,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationPartitionId: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.partition.id"),
+          MessagingExperimentalAttributes.MessagingDestinationPartitionId,
           List(
             "1",
           ),
@@ -118,7 +120,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationSubscriptionName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.subscription.name"),
+          MessagingExperimentalAttributes.MessagingDestinationSubscriptionName,
           List(
             "subscription-a",
           ),
@@ -134,7 +136,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.template"),
+          MessagingExperimentalAttributes.MessagingDestinationTemplate,
           List(
             "/customers/{customerId}",
           ),
@@ -146,7 +148,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "receive",
             "peek",
@@ -165,7 +167,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.system"),
+          MessagingExperimentalAttributes.MessagingSystem,
           List(
           ),
           Requirement.required,
@@ -180,7 +182,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -197,7 +199,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -259,7 +261,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -276,7 +278,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingConsumerGroupName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.consumer.group.name"),
+          MessagingExperimentalAttributes.MessagingConsumerGroupName,
           List(
             "my-group",
             "indexer",
@@ -292,7 +294,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.name"),
+          MessagingExperimentalAttributes.MessagingDestinationName,
           List(
             "MyQueue",
             "MyTopic",
@@ -308,7 +310,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationPartitionId: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.partition.id"),
+          MessagingExperimentalAttributes.MessagingDestinationPartitionId,
           List(
             "1",
           ),
@@ -323,7 +325,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationSubscriptionName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.subscription.name"),
+          MessagingExperimentalAttributes.MessagingDestinationSubscriptionName,
           List(
             "subscription-a",
           ),
@@ -339,7 +341,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.template"),
+          MessagingExperimentalAttributes.MessagingDestinationTemplate,
           List(
             "/customers/{customerId}",
           ),
@@ -351,7 +353,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "send",
             "receive",
@@ -367,7 +369,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.type"),
+          MessagingExperimentalAttributes.MessagingOperationType,
           List(
           ),
           Requirement.conditionallyRequired("If applicable."),
@@ -382,7 +384,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.system"),
+          MessagingExperimentalAttributes.MessagingSystem,
           List(
           ),
           Requirement.required,
@@ -397,7 +399,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -414,7 +416,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -477,7 +479,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -494,7 +496,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.name"),
+          MessagingExperimentalAttributes.MessagingDestinationName,
           List(
             "MyQueue",
             "MyTopic",
@@ -510,7 +512,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationPartitionId: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.partition.id"),
+          MessagingExperimentalAttributes.MessagingDestinationPartitionId,
           List(
             "1",
           ),
@@ -526,7 +528,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.template"),
+          MessagingExperimentalAttributes.MessagingDestinationTemplate,
           List(
             "/customers/{customerId}",
           ),
@@ -538,7 +540,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "send",
             "schedule",
@@ -556,7 +558,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.system"),
+          MessagingExperimentalAttributes.MessagingSystem,
           List(
           ),
           Requirement.required,
@@ -571,7 +573,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -588,7 +590,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -647,7 +649,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -664,7 +666,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingConsumerGroupName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.consumer.group.name"),
+          MessagingExperimentalAttributes.MessagingConsumerGroupName,
           List(
             "my-group",
             "indexer",
@@ -680,7 +682,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.name"),
+          MessagingExperimentalAttributes.MessagingDestinationName,
           List(
             "MyQueue",
             "MyTopic",
@@ -696,7 +698,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationPartitionId: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.partition.id"),
+          MessagingExperimentalAttributes.MessagingDestinationPartitionId,
           List(
             "1",
           ),
@@ -711,7 +713,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationSubscriptionName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.subscription.name"),
+          MessagingExperimentalAttributes.MessagingDestinationSubscriptionName,
           List(
             "subscription-a",
           ),
@@ -727,7 +729,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingDestinationTemplate: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.destination.template"),
+          MessagingExperimentalAttributes.MessagingDestinationTemplate,
           List(
             "/customers/{customerId}",
           ),
@@ -739,7 +741,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "process",
             "consume",
@@ -757,7 +759,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingSystem: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.system"),
+          MessagingExperimentalAttributes.MessagingSystem,
           List(
           ),
           Requirement.required,
@@ -772,7 +774,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -789,7 +791,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -850,7 +852,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -864,7 +866,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "ack",
             "nack",
@@ -882,7 +884,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -899,7 +901,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -953,7 +955,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -967,7 +969,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "ack",
             "nack",
@@ -985,7 +987,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1002,7 +1004,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1057,7 +1059,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -1071,7 +1073,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "ack",
             "nack",
@@ -1089,7 +1091,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1106,7 +1108,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1160,7 +1162,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -1174,7 +1176,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "ack",
             "nack",
@@ -1192,7 +1194,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1209,7 +1211,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -1264,7 +1266,7 @@ object MessagingExperimentalMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "amqp:decode-error",
             "KAFKA_STORAGE_ERROR",
@@ -1278,7 +1280,7 @@ object MessagingExperimentalMetrics {
         */
       val messagingOperationName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("messaging.operation.name"),
+          MessagingExperimentalAttributes.MessagingOperationName,
           List(
             "ack",
             "nack",
@@ -1296,7 +1298,7 @@ object MessagingExperimentalMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -1313,7 +1315,7 @@ object MessagingExperimentalMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ProcessExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ProcessExperimentalMetrics.scala
@@ -20,6 +20,7 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object ProcessExperimentalMetrics {
@@ -38,7 +39,7 @@ object ProcessExperimentalMetrics {
         */
       val processContextSwitchType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("process.context_switch_type"),
+          ProcessExperimentalAttributes.ProcessContextSwitchType,
           List(
           ),
           Requirement.recommended,
@@ -77,7 +78,7 @@ object ProcessExperimentalMetrics {
         */
       val cpuMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("cpu.mode"),
+          CpuExperimentalAttributes.CpuMode,
           List(
             "user",
             "system",
@@ -120,7 +121,7 @@ object ProcessExperimentalMetrics {
         */
       val cpuMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("cpu.mode"),
+          CpuExperimentalAttributes.CpuMode,
           List(
             "user",
             "system",
@@ -158,7 +159,7 @@ object ProcessExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -229,7 +230,7 @@ object ProcessExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -284,7 +285,7 @@ object ProcessExperimentalMetrics {
         */
       val processPagingFaultType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("process.paging.fault_type"),
+          ProcessExperimentalAttributes.ProcessPagingFaultType,
           List(
           ),
           Requirement.recommended,

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/SystemExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/SystemExperimentalMetrics.scala
@@ -20,6 +20,8 @@ package experimental
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
+import org.typelevel.otel4s.semconv.experimental.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object SystemExperimentalMetrics {
@@ -38,7 +40,7 @@ object SystemExperimentalMetrics {
         */
       val systemCpuLogicalNumber: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("system.cpu.logical_number"),
+          SystemExperimentalAttributes.SystemCpuLogicalNumber,
           List(
             1,
           ),
@@ -113,7 +115,7 @@ object SystemExperimentalMetrics {
         */
       val cpuMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("cpu.mode"),
+          CpuExperimentalAttributes.CpuMode,
           List(
             "user",
             "system",
@@ -126,7 +128,7 @@ object SystemExperimentalMetrics {
         */
       val systemCpuLogicalNumber: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("system.cpu.logical_number"),
+          SystemExperimentalAttributes.SystemCpuLogicalNumber,
           List(
             1,
           ),
@@ -168,7 +170,7 @@ object SystemExperimentalMetrics {
         */
       val cpuMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("cpu.mode"),
+          CpuExperimentalAttributes.CpuMode,
           List(
             "user",
             "system",
@@ -181,7 +183,7 @@ object SystemExperimentalMetrics {
         */
       val systemCpuLogicalNumber: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("system.cpu.logical_number"),
+          SystemExperimentalAttributes.SystemCpuLogicalNumber,
           List(
             1,
           ),
@@ -218,7 +220,7 @@ object SystemExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -230,7 +232,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -275,7 +277,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -311,7 +313,7 @@ object SystemExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -323,7 +325,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -366,7 +368,7 @@ object SystemExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -378,7 +380,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -415,7 +417,7 @@ object SystemExperimentalMetrics {
         */
       val diskIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("disk.io.direction"),
+          DiskExperimentalAttributes.DiskIoDirection,
           List(
             "read",
           ),
@@ -427,7 +429,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -464,7 +466,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -476,7 +478,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.mode"),
+          SystemExperimentalAttributes.SystemFilesystemMode,
           List(
             "rw, ro",
           ),
@@ -488,7 +490,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemMountpoint: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.mountpoint"),
+          SystemExperimentalAttributes.SystemFilesystemMountpoint,
           List(
             "/mnt/data",
           ),
@@ -500,7 +502,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.state"),
+          SystemExperimentalAttributes.SystemFilesystemState,
           List(
             "used",
           ),
@@ -512,7 +514,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.type"),
+          SystemExperimentalAttributes.SystemFilesystemType,
           List(
             "ext4",
           ),
@@ -552,7 +554,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -564,7 +566,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemMode: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.mode"),
+          SystemExperimentalAttributes.SystemFilesystemMode,
           List(
             "rw, ro",
           ),
@@ -576,7 +578,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemMountpoint: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.mountpoint"),
+          SystemExperimentalAttributes.SystemFilesystemMountpoint,
           List(
             "/mnt/data",
           ),
@@ -588,7 +590,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.state"),
+          SystemExperimentalAttributes.SystemFilesystemState,
           List(
             "used",
           ),
@@ -600,7 +602,7 @@ object SystemExperimentalMetrics {
         */
       val systemFilesystemType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.filesystem.type"),
+          SystemExperimentalAttributes.SystemFilesystemType,
           List(
             "ext4",
           ),
@@ -671,7 +673,7 @@ object SystemExperimentalMetrics {
         */
       val linuxMemorySlabState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("linux.memory.slab.state"),
+          LinuxExperimentalAttributes.LinuxMemorySlabState,
           List(
             "reclaimable",
             "unreclaimable",
@@ -751,7 +753,7 @@ object SystemExperimentalMetrics {
         */
       val systemMemoryState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.memory.state"),
+          SystemExperimentalAttributes.SystemMemoryState,
           List(
             "free",
             "cached",
@@ -788,7 +790,7 @@ object SystemExperimentalMetrics {
         */
       val systemMemoryState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.memory.state"),
+          SystemExperimentalAttributes.SystemMemoryState,
           List(
             "free",
             "cached",
@@ -830,7 +832,7 @@ object SystemExperimentalMetrics {
         */
       val networkTransport: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.transport"),
+          NetworkAttributes.NetworkTransport,
           List(
             "tcp",
             "udp",
@@ -843,7 +845,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -855,7 +857,7 @@ object SystemExperimentalMetrics {
         */
       val systemNetworkState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.network.state"),
+          SystemExperimentalAttributes.SystemNetworkState,
           List(
             "close_wait",
           ),
@@ -901,7 +903,7 @@ object SystemExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -913,7 +915,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -958,7 +960,7 @@ object SystemExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -970,7 +972,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -1007,7 +1009,7 @@ object SystemExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -1019,7 +1021,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -1056,7 +1058,7 @@ object SystemExperimentalMetrics {
         */
       val networkIoDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.io.direction"),
+          NetworkExperimentalAttributes.NetworkIoDirection,
           List(
             "transmit",
           ),
@@ -1068,7 +1070,7 @@ object SystemExperimentalMetrics {
         */
       val systemDevice: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.device"),
+          SystemExperimentalAttributes.SystemDevice,
           List(
             "(identifier)",
           ),
@@ -1105,7 +1107,7 @@ object SystemExperimentalMetrics {
         */
       val systemPagingType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.paging.type"),
+          SystemExperimentalAttributes.SystemPagingType,
           List(
             "minor",
           ),
@@ -1141,7 +1143,7 @@ object SystemExperimentalMetrics {
         */
       val systemPagingDirection: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.paging.direction"),
+          SystemExperimentalAttributes.SystemPagingDirection,
           List(
             "in",
           ),
@@ -1153,7 +1155,7 @@ object SystemExperimentalMetrics {
         */
       val systemPagingType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.paging.type"),
+          SystemExperimentalAttributes.SystemPagingType,
           List(
             "minor",
           ),
@@ -1191,7 +1193,7 @@ object SystemExperimentalMetrics {
         */
       val systemPagingState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.paging.state"),
+          SystemExperimentalAttributes.SystemPagingState,
           List(
             "free",
           ),
@@ -1227,7 +1229,7 @@ object SystemExperimentalMetrics {
         */
       val systemPagingState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.paging.state"),
+          SystemExperimentalAttributes.SystemPagingState,
           List(
             "free",
           ),
@@ -1265,7 +1267,7 @@ object SystemExperimentalMetrics {
         */
       val systemProcessStatus: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("system.process.status"),
+          SystemExperimentalAttributes.SystemProcessStatus,
           List(
             "running",
           ),

--- a/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/HttpMetrics.scala
+++ b/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/HttpMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object HttpMetrics {
@@ -49,7 +50,7 @@ object HttpMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -79,7 +80,7 @@ object HttpMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -93,7 +94,7 @@ object HttpMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -107,7 +108,7 @@ object HttpMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -124,7 +125,7 @@ object HttpMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -143,7 +144,7 @@ object HttpMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -161,7 +162,7 @@ object HttpMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -176,7 +177,7 @@ object HttpMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",
@@ -234,7 +235,7 @@ object HttpMetrics {
         */
       val errorType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("error.type"),
+          ErrorAttributes.ErrorType,
           List(
             "timeout",
             "java.net.UnknownHostException",
@@ -264,7 +265,7 @@ object HttpMetrics {
         */
       val httpRequestMethod: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.request.method"),
+          HttpAttributes.HttpRequestMethod,
           List(
             "GET",
             "POST",
@@ -278,7 +279,7 @@ object HttpMetrics {
         */
       val httpResponseStatusCode: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("http.response.status_code"),
+          HttpAttributes.HttpResponseStatusCode,
           List(
             200,
           ),
@@ -294,7 +295,7 @@ object HttpMetrics {
         */
       val httpRoute: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("http.route"),
+          HttpAttributes.HttpRoute,
           List(
             "/users/:userID?",
             "{controller}/{action}/{id?}",
@@ -309,7 +310,7 @@ object HttpMetrics {
         */
       val networkProtocolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.name"),
+          NetworkAttributes.NetworkProtocolName,
           List(
             "http",
             "spdy",
@@ -326,7 +327,7 @@ object HttpMetrics {
         */
       val networkProtocolVersion: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("network.protocol.version"),
+          NetworkAttributes.NetworkProtocolVersion,
           List(
             "1.0",
             "1.1",
@@ -346,7 +347,7 @@ object HttpMetrics {
         */
       val serverAddress: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("server.address"),
+          ServerAttributes.ServerAddress,
           List(
             "example.com",
             "10.1.2.80",
@@ -365,7 +366,7 @@ object HttpMetrics {
         */
       val serverPort: AttributeSpec[Long] =
         AttributeSpec(
-          AttributeKey("server.port"),
+          ServerAttributes.ServerPort,
           List(
             80,
             8080,
@@ -385,7 +386,7 @@ object HttpMetrics {
         */
       val urlScheme: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("url.scheme"),
+          UrlAttributes.UrlScheme,
           List(
             "http",
             "https",

--- a/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/JvmMetrics.scala
+++ b/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/JvmMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package metrics
 
 import org.typelevel.otel4s.metrics._
+import org.typelevel.otel4s.semconv.attributes._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
 object JvmMetrics {
@@ -146,7 +147,7 @@ object JvmMetrics {
         */
       val jvmGcAction: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.gc.action"),
+          JvmAttributes.JvmGcAction,
           List(
             "end of minor GC",
             "end of major GC",
@@ -162,7 +163,7 @@ object JvmMetrics {
         */
       val jvmGcName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.gc.name"),
+          JvmAttributes.JvmGcName,
           List(
             "G1 Young Generation",
             "G1 Old Generation",
@@ -205,7 +206,7 @@ object JvmMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -219,7 +220,7 @@ object JvmMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -261,7 +262,7 @@ object JvmMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -275,7 +276,7 @@ object JvmMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -317,7 +318,7 @@ object JvmMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -331,7 +332,7 @@ object JvmMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -373,7 +374,7 @@ object JvmMetrics {
         */
       val jvmMemoryPoolName: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.pool.name"),
+          JvmAttributes.JvmMemoryPoolName,
           List(
             "G1 Old Gen",
             "G1 Eden space",
@@ -387,7 +388,7 @@ object JvmMetrics {
         */
       val jvmMemoryType: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.memory.type"),
+          JvmAttributes.JvmMemoryType,
           List(
             "heap",
             "non_heap",
@@ -426,7 +427,7 @@ object JvmMetrics {
         */
       val jvmThreadDaemon: AttributeSpec[Boolean] =
         AttributeSpec(
-          AttributeKey("jvm.thread.daemon"),
+          JvmAttributes.JvmThreadDaemon,
           List(
           ),
           Requirement.recommended,
@@ -437,7 +438,7 @@ object JvmMetrics {
         */
       val jvmThreadState: AttributeSpec[String] =
         AttributeSpec(
-          AttributeKey("jvm.thread.state"),
+          JvmAttributes.JvmThreadState,
           List(
             "runnable",
             "blocked",


### PR DESCRIPTION
A minor improvement. That way we can also ensure that we use valid attributes. 