### PR TITLE
core-common: `AttributeKey` add `maybe` method

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala
@@ -35,6 +35,11 @@ sealed trait AttributeKey[A] {
   final def apply(value: A): Attribute[A] = Attribute(this, value)
 
   /** @return
+    *   an [[`Attribute`]] associating this key with the given value if the value is defined
+    */
+  final def maybe(value: Option[A]): Option[Attribute[A]] = value.map(apply)
+
+  /** @return
     *   an [[`AttributeKey`]] of the same type as this key, with name transformed by `f`
     */
   final def transformName(f: String => String): AttributeKey[A] =

--- a/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsBeanstalkDetector.scala
+++ b/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsBeanstalkDetector.scala
@@ -67,9 +67,9 @@ private class AwsBeanstalkDetector[F[_]: Concurrent: Files: Console] private (
     builder.addOne(Keys.CloudProvider, Const.CloudProvider)
     builder.addOne(Keys.CloudPlatform, Const.CloudPlatform)
 
-    metadata.deploymentId.foreach(id => builder.addOne(Keys.ServiceInstanceId, id.toString))
-    metadata.versionLabel.foreach(v => builder.addOne(Keys.ServiceVersion, v))
-    metadata.environmentName.foreach(n => builder.addOne(Keys.ServiceNamespace, n))
+    builder.addAll(Keys.ServiceInstanceId.maybe(metadata.deploymentId.map(_.toString)))
+    builder.addAll(Keys.ServiceVersion.maybe(metadata.versionLabel))
+    builder.addAll(Keys.ServiceNamespace.maybe(metadata.environmentName))
 
     TelemetryResource(builder.result(), Some(SchemaUrls.Current))
   }

--- a/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsEcsDetector.scala
+++ b/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsEcsDetector.scala
@@ -86,14 +86,14 @@ private class AwsEcsDetector[F[_]: Async: Network: Env: Console] private (
     builder.addOne(Keys.CloudPlatform, Const.CloudPlatform)
     builder.addOne(Keys.CloudResourceId, container.containerArn)
     builder.addOne(Keys.CloudAvailabilityZones, task.availabilityZone)
-    regionOpt.foreach(region => builder.addOne(Keys.CloudRegion, region))
-    accountIdOpt.foreach(accountId => builder.addOne(Keys.CloudAccountId, accountId))
+    builder.addAll(Keys.CloudRegion.maybe(regionOpt))
+    builder.addAll(Keys.CloudAccountId.maybe(accountIdOpt))
 
     // container
     builder.addOne(Keys.ContainerId, container.dockerId)
     builder.addOne(Keys.ContainerName, container.dockerName)
-    imageNameOpt.foreach(name => builder.addOne(Keys.ContainerImageName, name))
-    imageTagOpt.foreach(tag => builder.addOne(Keys.ContainerImageTags, Seq(tag)))
+    builder.addAll(Keys.ContainerImageName.maybe(imageNameOpt))
+    builder.addAll(Keys.ContainerImageTags.maybe(imageTagOpt.map(Seq(_))))
 
     // aws
     builder.addOne(Keys.AwsLogGroupNames, Seq(container.logOptions.group))

--- a/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsLambdaDetector.scala
+++ b/sdk-contrib/aws/resource/src/main/scala/org/typelevel/otel4s/sdk/contrib/aws/resource/AwsLambdaDetector.scala
@@ -51,9 +51,9 @@ private class AwsLambdaDetector[F[_]: Env: Monad] extends TelemetryResourceDetec
       builder.addOne(Keys.CloudProvider, Const.CloudProvider)
       builder.addOne(Keys.CloudPlatform, Const.CloudPlatform)
 
-      region.foreach(r => builder.addOne(Keys.CloudRegion, r))
-      functionName.foreach(name => builder.addOne(Keys.FaasName, name))
-      functionVersion.foreach(v => builder.addOne(Keys.FaasVersion, v))
+      builder.addAll(Keys.CloudRegion.maybe(region))
+      builder.addAll(Keys.FaasName.maybe(functionName))
+      builder.addAll(Keys.FaasVersion.maybe(functionVersion))
 
       TelemetryResource(builder.result(), Some(SchemaUrls.Current))
     }

--- a/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
+++ b/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/HostDetectorPlatform.scala
@@ -36,15 +36,16 @@ private[resource] trait HostDetectorPlatform { self: HostDetector.type =>
 
     def detect: F[Option[TelemetryResource]] =
       for {
-        hostOpt <- Sync[F]
-          .blocking(InetAddress.getLocalHost.getHostName)
-          .redeem(_ => None, Some(_))
-
-        archOpt <- Sync[F].delay(sys.props.get("os.arch"))
+        host <- Sync[F].blocking(InetAddress.getLocalHost.getHostName).redeem(_ => None, Some(_))
+        arch <- Sync[F].delay(sys.props.get("os.arch"))
       } yield {
-        val host = hostOpt.map(Keys.Host(_))
-        val arch = archOpt.map(Keys.Arch(_))
-        val attributes = host.to(Attributes) ++ arch.to(Attributes)
+        val builder = Attributes.newBuilder
+
+        builder.addAll(Keys.Host.maybe(host))
+        builder.addAll(Keys.Arch.maybe(arch))
+
+        val attributes = builder.result()
+
         Option.when(attributes.nonEmpty)(
           TelemetryResource(attributes, Some(SchemaUrls.Current))
         )

--- a/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessDetectorPlatform.scala
+++ b/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessDetectorPlatform.scala
@@ -49,7 +49,7 @@ private[resource] trait ProcessDetectorPlatform { self: ProcessDetector.type =>
       } yield {
         val builder = Attributes.newBuilder
 
-        getPid(runtime).foreach(pid => builder.addOne(Keys.Pid(pid)))
+        builder.addAll(Keys.Pid.maybe(getPid(runtime)))
 
         javaHomeOpt.foreach { javaHome =>
           val exePath = executablePath(javaHome, osNameOpt)

--- a/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
+++ b/sdk/common/jvm/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala
@@ -43,11 +43,14 @@ private[resource] trait ProcessRuntimeDetectorPlatform {
       } yield {
         val attributes = Attributes.newBuilder
 
-        runtimeName.foreach(name => attributes.addOne(Keys.Name(name)))
-        runtimeVersion.foreach(name => attributes.addOne(Keys.Version(name)))
-        (vmVendor, vmName, vmVersion).mapN { (vendor, name, version) =>
-          attributes.addOne(Keys.Description(s"$vendor $name $version"))
-        }
+        val description =
+          (vmVendor, vmName, vmVersion).mapN { (vendor, name, version) =>
+            s"$vendor $name $version"
+          }
+
+        attributes.addAll(Keys.Name.maybe(runtimeName))
+        attributes.addAll(Keys.Version.maybe(runtimeVersion))
+        attributes.addAll(Keys.Description.maybe(description))
 
         Some(TelemetryResource(attributes.result(), Some(SchemaUrls.Current)))
       }


### PR DESCRIPTION
Resolves #2 (in some way). 

## Motivation

Adding optional attribute values is rather verbose. To make these operations more bearable, we can allow passing optional values. 