### PR TITLE
sdk-trace: make `Sampler` effectful

### DIFF
--- a/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
+++ b/sdk/all/src/main/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdk.scala
@@ -279,9 +279,7 @@ object OpenTelemetrySdk {
         * @param configurer
         *   the configurer to add
         */
-      def addSamplerConfigurer(
-          configurer: AutoConfigure.Named[F, Sampler]
-      ): Builder[F]
+      def addSamplerConfigurer(configurer: AutoConfigure.Named[F, Sampler[F]]): Builder[F]
 
       /** Adds the text map propagator configurer. Can be used to register propagators that aren't included in the SDK.
         *
@@ -330,7 +328,7 @@ object OpenTelemetrySdk {
           AutoConfigure.Named[F, MetricExporter[F]]
         ],
         spanExporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]],
-        samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
+        samplerConfigurers: Set[AutoConfigure.Named[F, Sampler[F]]],
         textMapPropagatorConfigurers: Set[
           AutoConfigure.Named[F, TextMapPropagator[Context]]
         ]
@@ -387,9 +385,7 @@ object OpenTelemetrySdk {
       ): Builder[F] =
         copy(spanExporterConfigurers = spanExporterConfigurers + configurer)
 
-      def addSamplerConfigurer(
-          configurer: AutoConfigure.Named[F, Sampler]
-      ): Builder[F] =
+      def addSamplerConfigurer(configurer: AutoConfigure.Named[F, Sampler[F]]): Builder[F] =
         copy(samplerConfigurers = samplerConfigurers + configurer)
 
       def addTextMapPropagatorConfigurer(

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -56,7 +56,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   private val DefaultSdk =
     sdkToString(
       TelemetryResource.default,
-      sampler = Sampler.parentBased(Sampler.AlwaysOn)
+      sampler = Sampler.parentBased(Sampler.alwaysOn)
     )
 
   private val NoopSdk =
@@ -131,7 +131,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
       )
     )
 
-    val sampler = Sampler.AlwaysOff
+    val sampler = Sampler.alwaysOff[IO]
 
     OpenTelemetrySdk
       .autoConfigured[IO](
@@ -222,7 +222,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
       )
     )
 
-    val sampler: Sampler = new Sampler {
+    val sampler: Sampler[IO] = new Sampler[IO] {
       def shouldSample(
           parentContext: Option[SpanContext],
           traceId: ByteVector,
@@ -230,8 +230,8 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
           spanKind: SpanKind,
           attributes: Attributes,
           parentLinks: Vector[LinkData]
-      ): SamplingResult =
-        SamplingResult.Drop
+      ): IO[SamplingResult] =
+        IO.pure(SamplingResult.Drop)
 
       def description: String = "CustomSampler"
     }
@@ -389,7 +389,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
   private def sdkToString(
       resource: TelemetryResource = TelemetryResource.default,
       spanLimits: SpanLimits = SpanLimits.default,
-      sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      sampler: Sampler[IO] = Sampler.parentBased(Sampler.alwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,
         W3CBaggagePropagator.default

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
@@ -120,7 +120,7 @@ class SdkTracerSuite extends BaseTracerSuite[Context, Context.Key] {
 
   sdkTest(
     "keep propagating non-recording spans, but don't record them",
-    _.withSampler(Sampler.AlwaysOff)
+    _.withSampler(Sampler.alwaysOff)
   ) { sdk =>
     for {
       tracer <- sdk.provider.get("tracer")

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -133,10 +133,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
         .filter(_.isValid)
         .fold(idGenerator.generateTraceId)(ctx => Temporal[F].pure(ctx.traceId))
 
-    def sample(
-        parent: Option[SpanContext],
-        traceId: ByteVector
-    ): SamplingResult =
+    def sample(parent: Option[SpanContext], traceId: ByteVector): F[SamplingResult] =
       tracerSharedState.sampler.shouldSample(
         parentContext = parent,
         traceId = traceId,
@@ -151,8 +148,8 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
       spanId <- idGenerator.generateSpanId
       traceId <- genTraceId(parentSpanContext)
 
+      samplingResult <- sample(parentSpanContext, traceId)
       backend <- {
-        val samplingResult = sample(parentSpanContext, traceId)
         val samplingDecision = samplingResult.decision
 
         val traceFlags =

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -37,7 +37,7 @@ private class SdkTracerProvider[F[_]: Temporal: Parallel: Console](
     idGenerator: IdGenerator[F],
     resource: TelemetryResource,
     spanLimits: SpanLimits,
-    sampler: Sampler,
+    sampler: Sampler[F],
     propagators: ContextPropagators[Context],
     spanProcessors: List[SpanProcessor[F]],
     traceScope: TraceScope[F, Context],
@@ -126,7 +126,7 @@ object SdkTracerProvider {
       * @param sampler
       *   the [[org.typelevel.otel4s.sdk.trace.samplers.Sampler Sampler]] to use
       */
-    def withSampler(sampler: Sampler): Builder[F]
+    def withSampler(sampler: Sampler[F]): Builder[F]
 
     /** Adds [[org.typelevel.otel4s.context.propagation.TextMapPropagator TextMapPropagator]]s to use for the context
       * propagation.
@@ -134,9 +134,7 @@ object SdkTracerProvider {
       * @param propagators
       *   the propagators to add
       */
-    def addTextMapPropagators(
-        propagators: TextMapPropagator[Context]*
-    ): Builder[F]
+    def addTextMapPropagators(propagators: TextMapPropagator[Context]*): Builder[F]
 
     /** Adds a [[org.typelevel.otel4s.sdk.trace.processor.SpanProcessor SpanProcessor]] to the span processing pipeline
       * that will be built.
@@ -167,7 +165,7 @@ object SdkTracerProvider {
       idGenerator = IdGenerator.random,
       resource = TelemetryResource.default,
       spanLimits = SpanLimits.default,
-      sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      sampler = Sampler.parentBased(Sampler.alwaysOn),
       propagators = Nil,
       spanProcessors = Nil
     )
@@ -178,7 +176,7 @@ object SdkTracerProvider {
       idGenerator: IdGenerator[F],
       resource: TelemetryResource,
       spanLimits: SpanLimits,
-      sampler: Sampler,
+      sampler: Sampler[F],
       propagators: List[TextMapPropagator[Context]],
       spanProcessors: List[SpanProcessor[F]]
   ) extends Builder[F] {
@@ -195,7 +193,7 @@ object SdkTracerProvider {
     def withSpanLimits(limits: SpanLimits): Builder[F] =
       copy(spanLimits = limits)
 
-    def withSampler(sampler: Sampler): Builder[F] =
+    def withSampler(sampler: Sampler[F]): Builder[F] =
       copy(sampler = sampler)
 
     def addTextMapPropagators(

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTraces.scala
@@ -199,9 +199,7 @@ object SdkTraces {
         * @param configurer
         *   the configurer to add
         */
-      def addSamplerConfigurer(
-          configurer: AutoConfigure.Named[F, Sampler]
-      ): Builder[F]
+      def addSamplerConfigurer(configurer: AutoConfigure.Named[F, Sampler[F]]): Builder[F]
 
       /** Adds the text map propagator configurer. Can be used to register propagators that aren't included in the SDK.
         *
@@ -244,7 +242,7 @@ object SdkTraces {
         tracerProviderCustomizer: Customizer[SdkTracerProvider.Builder[F]],
         resourceDetectors: Set[TelemetryResourceDetector[F]],
         exporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]],
-        samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
+        samplerConfigurers: Set[AutoConfigure.Named[F, Sampler[F]]],
         textMapPropagatorConfigurers: Set[
           AutoConfigure.Named[F, TextMapPropagator[Context]]
         ]
@@ -283,9 +281,7 @@ object SdkTraces {
       ): Builder[F] =
         copy(exporterConfigurers = this.exporterConfigurers + configurer)
 
-      def addSamplerConfigurer(
-          configurer: AutoConfigure.Named[F, Sampler]
-      ): Builder[F] =
+      def addSamplerConfigurer(configurer: AutoConfigure.Named[F, Sampler[F]]): Builder[F] =
         copy(samplerConfigurers = this.samplerConfigurers + configurer)
 
       def addTextMapPropagatorConfigurer(

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
@@ -24,6 +24,6 @@ private final case class TracerSharedState[F[_]](
     idGenerator: IdGenerator[F],
     resource: TelemetryResource,
     spanLimits: SpanLimits,
-    sampler: Sampler,
+    sampler: Sampler[F],
     spanProcessor: SpanProcessor[F]
 )

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigure.scala
@@ -42,7 +42,7 @@ private final class TracerProviderAutoConfigure[
     resource: TelemetryResource,
     contextPropagators: ContextPropagators[Context],
     customizer: Customizer[SdkTracerProvider.Builder[F]],
-    samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
+    samplerConfigurers: Set[AutoConfigure.Named[F, Sampler[F]]],
     exporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]]
 ) extends AutoConfigure.WithHint[F, TracerProvider[F]](
       "TracerProvider",
@@ -136,7 +136,7 @@ private[sdk] object TracerProviderAutoConfigure {
       resource: TelemetryResource,
       contextPropagators: ContextPropagators[Context],
       tracerProviderBuilderCustomizer: Customizer[SdkTracerProvider.Builder[F]],
-      samplerConfigurers: Set[AutoConfigure.Named[F, Sampler]],
+      samplerConfigurers: Set[AutoConfigure.Named[F, Sampler[F]]],
       exporterConfigurers: Set[AutoConfigure.Named[F, SpanExporter[F]]]
   ): AutoConfigure[F, TracerProvider[F]] =
     new TracerProviderAutoConfigure[F](

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
@@ -132,7 +132,7 @@ class SdkSpanBuilderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       for {
         traceScope <- createTraceScope
         inMemory <- InMemorySpanExporter.create[IO](None)
-        state <- createState(inMemory, sampler = Sampler.AlwaysOff)
+        state <- createState(inMemory, sampler = Sampler.alwaysOff)
         builder = SdkSpanBuilder(name, scope, state, traceScope)
         span <- builder.build.use(IO.pure)
         spans <- inMemory.finishedSpans
@@ -153,7 +153,7 @@ class SdkSpanBuilderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   private def createState(
       exporter: SpanExporter[IO],
       spanLimits: SpanLimits = SpanLimits.default,
-      sampler: Sampler = Sampler.AlwaysOn
+      sampler: Sampler[IO] = Sampler.alwaysOn
   ): IO[TracerSharedState[IO]] =
     Random.scalaUtilRandom[IO].map { implicit random =>
       TracerSharedState(

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -50,7 +50,7 @@ class SdkTracesSuite extends CatsEffectSuite {
     tracesToString(
       TelemetryResource.default,
       SpanLimits.default,
-      Sampler.parentBased(Sampler.AlwaysOn)
+      Sampler.parentBased(Sampler.alwaysOn)
     )
 
   private val NoopTraces =
@@ -114,7 +114,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   test("addTracerProviderCustomizer - customize tracer provider") {
     val config = Config.ofProps(Map("otel.traces.exporter" -> "none"))
 
-    val sampler = Sampler.AlwaysOff
+    val sampler = Sampler.alwaysOff[IO]
     val resource = TelemetryResource.default
     val spanLimits = SpanLimits.default
 
@@ -211,7 +211,7 @@ class SdkTracesSuite extends CatsEffectSuite {
       )
     )
 
-    val sampler: Sampler = new Sampler {
+    val sampler: Sampler[IO] = new Sampler[IO] {
       def shouldSample(
           parentContext: Option[SpanContext],
           traceId: ByteVector,
@@ -219,8 +219,8 @@ class SdkTracesSuite extends CatsEffectSuite {
           spanKind: SpanKind,
           attributes: Attributes,
           parentLinks: Vector[LinkData]
-      ): SamplingResult =
-        SamplingResult.Drop
+      ): IO[SamplingResult] =
+        IO.pure(SamplingResult.Drop)
 
       def description: String = "CustomSampler"
     }
@@ -283,7 +283,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   private def tracesToString(
       resource: TelemetryResource = TelemetryResource.default,
       spanLimits: SpanLimits = SpanLimits.default,
-      sampler: Sampler = Sampler.parentBased(Sampler.AlwaysOn),
+      sampler: Sampler[IO] = Sampler.parentBased(Sampler.alwaysOn),
       propagators: ContextPropagators[Context] = ContextPropagators.of(
         W3CTraceContextPropagator.default,
         W3CBaggagePropagator.default

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/samplers/SamplerSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/samplers/SamplerSuite.scala
@@ -17,51 +17,63 @@
 package org.typelevel.otel4s.sdk.trace
 package samplers
 
+import cats.effect.IO
 import munit._
-import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
 
-class SamplerSuite extends ScalaCheckSuite {
+class SamplerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("AlwaysOn - correct description and toString") {
-    assertEquals(Sampler.AlwaysOn.toString, "AlwaysOnSampler")
-    assertEquals(Sampler.AlwaysOn.description, "AlwaysOnSampler")
+    val sampler = Sampler.alwaysOn[IO]
+    assertEquals(sampler.toString, "AlwaysOnSampler")
+    assertEquals(sampler.description, "AlwaysOnSampler")
   }
 
   test("AlwaysOn - always return 'RecordAndSample'") {
-    Prop.forAll(ShouldSampleInput.shouldSampleInputGen) { input =>
+    PropF.forAllF(ShouldSampleInput.shouldSampleInputGen) { input =>
       val expected = SamplingResult.RecordAndSample
-      val result = Sampler.AlwaysOn.shouldSample(
-        input.parentContext,
-        input.traceId,
-        input.name,
-        input.spanKind,
-        input.attributes,
-        input.parentLinks
-      )
 
-      assertEquals(result, expected)
+      Sampler
+        .alwaysOn[IO]
+        .shouldSample(
+          input.parentContext,
+          input.traceId,
+          input.name,
+          input.spanKind,
+          input.attributes,
+          input.parentLinks
+        )
+        .assertEquals(expected)
     }
   }
 
   test("AlwaysOff - correct description and toString") {
-    assertEquals(Sampler.AlwaysOff.toString, "AlwaysOffSampler")
-    assertEquals(Sampler.AlwaysOff.description, "AlwaysOffSampler")
+    val sampler = Sampler.alwaysOff[IO]
+    assertEquals(sampler.toString, "AlwaysOffSampler")
+    assertEquals(sampler.description, "AlwaysOffSampler")
   }
 
   test("AlwaysOff - always return 'Drop'") {
-    Prop.forAll(ShouldSampleInput.shouldSampleInputGen) { input =>
+    PropF.forAllF(ShouldSampleInput.shouldSampleInputGen) { input =>
       val expected = SamplingResult.Drop
-      val result = Sampler.AlwaysOff.shouldSample(
-        input.parentContext,
-        input.traceId,
-        input.name,
-        input.spanKind,
-        input.attributes,
-        input.parentLinks
-      )
 
-      assertEquals(result, expected)
+      Sampler
+        .alwaysOff[IO]
+        .shouldSample(
+          input.parentContext,
+          input.traceId,
+          input.name,
+          input.spanKind,
+          input.attributes,
+          input.parentLinks
+        )
+        .assertEquals(expected)
     }
   }
 
+  override protected def scalaCheckTestParameters: Test.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(10)
+      .withMaxSize(10)
 }


### PR DESCRIPTION
Sampler, unfortunately, can be effectful. 

For example: https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java.