### PR TITLE
core-trace: skip `addAttributes` when varargs are empty

### DIFF
--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -153,7 +153,11 @@ object SpanBuilderMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
-    whenEnabled(c)(q"_.addAttributes(_root_.scala.Seq(..$attributes))")
+    if (attributes.nonEmpty) {
+      whenEnabled(c)(q"_.addAttributes(_root_.scala.Seq(..$attributes))")
+    } else {
+      c.prefix.tree
+    }
   }
 
   def addAttributesColl(c: blackbox.Context)(

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -223,7 +223,12 @@ object SpanMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
-    addAttributesColl(c)(c.Expr(q"_root_.scala.Seq(..$attributes)"))
+
+    if (attributes.nonEmpty) {
+      addAttributesColl(c)(c.Expr(q"_root_.scala.Seq(..$attributes)"))
+    } else {
+      q"${c.prefix}.backend.meta.unit"
+    }
   }
 
   def addAttributesColl(c: blackbox.Context)(

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/TracerMacro.scala
@@ -137,7 +137,11 @@ object TracerMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
-    spanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+    if (attributes.nonEmpty) {
+      spanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+    } else {
+      q"${c.prefix}.spanBuilder($name).build"
+    }
   }
 
   def spanColl(c: blackbox.Context)(
@@ -153,7 +157,11 @@ object TracerMacro {
       attributes: c.Expr[Attribute[_]]*
   ): c.universe.Tree = {
     import c.universe._
-    rootSpanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+    if (attributes.nonEmpty) {
+      rootSpanColl(c)(name, c.Expr(q"_root_.scala.Seq(..$attributes)"))
+    } else {
+      q"${c.prefix}.spanBuilder($name).root.build"
+    }
   }
 
   def rootSpanColl(c: blackbox.Context)(

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -159,7 +159,7 @@ object SpanBuilderMacro {
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
+      if ($builder.meta.isEnabled && $attributes.nonEmpty)
         $builder.modifyState(_.addAttributes($attributes))
       else $builder
     }

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -230,7 +230,7 @@ object SpanMacro {
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F]) =
     '{
-      if ($span.backend.meta.isEnabled)
+      if ($span.backend.meta.isEnabled && $attributes.nonEmpty)
         $span.backend.addAttributes($attributes)
       else $span.backend.meta.unit
     }

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
@@ -277,14 +277,22 @@ class SpanBuilderSuite extends FunSuite {
     assertEquals(result.state, expected)
   }
 
+  test("addAttributes: eliminate empty varargs calls") {
+    val builder = InMemoryBuilder(InstrumentMeta.enabled, SpanBuilder.State.init)
+    val result = builder.addAttributes().asInstanceOf[InMemoryBuilder]
+
+    assertEquals(result.modifications, 0)
+  }
+
   case class InMemoryBuilder(
       meta: InstrumentMeta[IO],
-      state: SpanBuilder.State
+      state: SpanBuilder.State,
+      modifications: Int = 0
   ) extends SpanBuilder[IO] {
     def modifyState(
         f: SpanBuilder.State => SpanBuilder.State
     ): SpanBuilder[IO] =
-      copy(state = f(state))
+      copy(state = f(state), modifications = modifications + 1)
 
     def build: SpanOps[IO] =
       ???

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanSuite.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.trace
+
+import cats.effect.IO
+import cats.effect.Ref
+import munit._
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.meta.InstrumentMeta
+
+import scala.collection.immutable
+import scala.concurrent.duration.FiniteDuration
+
+class SpanSuite extends CatsEffectSuite {
+  import SpanSuite._
+
+  test("addAttributes: eliminate empty varargs calls") {
+    for {
+      ops <- IO.ref(Vector.empty[BackendOp])
+      span = Span.fromBackend(new OpsBackend(ops))
+      _ <- span.addAttributes()
+      result <- ops.get
+    } yield assertEquals(result, Vector.empty)
+  }
+
+}
+
+object SpanSuite {
+
+  private sealed trait BackendOp
+  private object BackendOp {
+    final case class UpdateName(name: String) extends BackendOp
+    final case class AddAttributes(attributes: immutable.Iterable[Attribute[_]]) extends BackendOp
+    final case class AddEvent(
+        name: String,
+        timestamp: Option[FiniteDuration],
+        attributes: immutable.Iterable[Attribute[_]]
+    ) extends BackendOp
+    final case class AddLink(
+        spanContext: SpanContext,
+        attributes: immutable.Iterable[Attribute[_]]
+    ) extends BackendOp
+    final case class RecordException(
+        exception: Throwable,
+        attributes: immutable.Iterable[Attribute[_]]
+    ) extends BackendOp
+    final case class SetStatus(status: StatusCode, description: Option[String]) extends BackendOp
+    final case class End(timestamp: Option[FiniteDuration]) extends BackendOp
+  }
+
+  private class OpsBackend(state: Ref[IO, Vector[BackendOp]]) extends Span.Backend[IO] {
+    import BackendOp._
+
+    val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
+
+    def context: SpanContext = ???
+
+    def updateName(name: String): IO[Unit] =
+      state.update(_ :+ UpdateName(name))
+
+    def addAttributes(attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+      state.update(_ :+ AddAttributes(attributes))
+
+    def addEvent(name: String, attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+      state.update(_ :+ AddEvent(name, None, attributes))
+
+    def addEvent(name: String, timestamp: FiniteDuration, attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+      state.update(_ :+ AddEvent(name, Some(timestamp), attributes))
+
+    def addLink(spanContext: SpanContext, attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+      state.update(_ :+ AddLink(spanContext, attributes))
+
+    def recordException(exception: Throwable, attributes: immutable.Iterable[Attribute[_]]): IO[Unit] =
+      state.update(_ :+ RecordException(exception, attributes))
+
+    def setStatus(status: StatusCode): IO[Unit] =
+      state.update(_ :+ SetStatus(status, None))
+
+    def setStatus(status: StatusCode, description: String): IO[Unit] =
+      state.update(_ :+ SetStatus(status, Some(description)))
+
+    def end: IO[Unit] =
+      state.update(_ :+ End(None))
+
+    def end(timestamp: FiniteDuration): IO[Unit] =
+      state.update(_ :+ End(Some(timestamp)))
+
+  }
+
+}


### PR DESCRIPTION
A micro-optimization.