### PR TITLE
sdk-trace: use `MapRef` in `SpanStorage`

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/TraceBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/TraceBenchmark.scala
@@ -17,84 +17,124 @@
 package org.typelevel.otel4s.benchmarks
 
 import cats.effect.IO
+import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
-import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
-import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import org.openjdk.jmh.annotations._
-import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.trace.Tracer
 
 import java.util.concurrent.TimeUnit
 
+// benchmarks/Jmh/run org.typelevel.otel4s.benchmarks.TraceBenchmark -prof gc
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(2)
+@Measurement(iterations = 40, time = 1)
+@Warmup(iterations = 5, time = 1)
 class TraceBenchmark {
 
   import TraceBenchmark._
+
+  @Param(Array("noop", "oteljava", "sdk"))
+  var backend: String = _
+  var tracer: Tracer[IO] = _
+  var finalizer: IO[Unit] = _
 
   @Benchmark
   def pure(): Unit =
     IO.unit.unsafeRunSync()
 
   @Benchmark
-  def noop(ctx: NoopTracer): Unit = {
-    import ctx._
+  def span(): Unit =
     tracer.span("span").use_.unsafeRunSync()
-  }
 
   @Benchmark
-  def inMemoryDisabled(ctx: InMemoryTracer): Unit = {
-    import ctx._
-    tracer
-      .noopScope(
-        tracer.span("span").use_
-      )
-      .unsafeRunSync()
-  }
+  def noopScope(): Unit =
+    tracer.noopScope(tracer.span("span").use_).unsafeRunSync()
 
   @Benchmark
-  def inMemoryEnabled(ctx: InMemoryTracer): Unit = {
-    import ctx._
-    tracer
-      .rootScope(
-        tracer.span("span").use_
-      )
-      .unsafeRunSync()
-  }
+  def rootScope(): Unit =
+    tracer.rootScope(tracer.span("span").use_).unsafeRunSync()
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    backend match {
+      case "noop" =>
+        tracer = noopTracer
+        finalizer = IO.unit
+
+      case "oteljava" =>
+        val (t, release) = otelJavaTracer.allocated.unsafeRunSync()
+
+        tracer = t
+        finalizer = release
+
+      case "sdk" =>
+        val (t, release) = sdkTracer.allocated.unsafeRunSync()
+
+        tracer = t
+        finalizer = release
+
+      case other =>
+        sys.error(s"unknown backend [$other]")
+    }
+
+  @TearDown(Level.Trial)
+  def cleanup(): Unit =
+    finalizer.unsafeRunSync()
 }
 
 object TraceBenchmark {
-  @State(Scope.Benchmark)
-  class NoopTracer {
-    implicit val tracer: Tracer[IO] = Tracer.noop
+
+  private def otelJavaTracer: Resource[IO, Tracer[IO]] = {
+    import io.opentelemetry.sdk.OpenTelemetrySdk
+    import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+    import io.opentelemetry.sdk.trace.SdkTracerProvider
+    import io.opentelemetry.sdk.trace.`export`.BatchSpanProcessor
+    import org.typelevel.otel4s.oteljava.OtelJava
+
+    def exporter = InMemorySpanExporter.create()
+
+    def builder = SdkTracerProvider
+      .builder()
+      .addSpanProcessor(BatchSpanProcessor.builder(exporter).build())
+
+    def tracerProvider: SdkTracerProvider =
+      builder.build()
+
+    def otel = OpenTelemetrySdk
+      .builder()
+      .setTracerProvider(tracerProvider)
+      .build()
+
+    OtelJava
+      .resource[IO](IO(otel))
+      .evalMap(_.tracerProvider.tracer("trace-benchmark").get)
   }
 
-  @State(Scope.Benchmark)
-  class InMemoryTracer {
-    private def makeTracer: IO[Tracer[IO]] = {
-      val exporter = InMemorySpanExporter.create()
+  private def sdkTracer: Resource[IO, Tracer[IO]] = {
+    import cats.effect.std.Random
+    import org.typelevel.otel4s.context.LocalProvider
+    import org.typelevel.otel4s.sdk.context.Context
+    import org.typelevel.otel4s.sdk.testkit.trace.InMemorySpanExporter
+    import org.typelevel.otel4s.sdk.trace.SdkTracerProvider
+    import org.typelevel.otel4s.sdk.trace.processor.BatchSpanProcessor
 
-      val builder = SdkTracerProvider
-        .builder()
-        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
-
-      val tracerProvider: SdkTracerProvider =
-        builder.build()
-
-      val otel = OpenTelemetrySdk
-        .builder()
-        .setTracerProvider(tracerProvider)
-        .build()
-
-      OtelJava.forAsync[IO](otel).flatMap {
-        _.tracerProvider.tracer("trace-benchmark").get
+    Resource.eval(InMemorySpanExporter.create[IO](None)).flatMap { exporter =>
+      BatchSpanProcessor.builder(exporter).build.evalMap { processor =>
+        Random.scalaUtilRandom[IO].flatMap { implicit random =>
+          LocalProvider[IO, Context].local.flatMap { implicit local =>
+            for {
+              tracerProvider <- SdkTracerProvider.builder[IO].addSpanProcessor(processor).build
+              tracer <- tracerProvider.get("trace-benchmark")
+            } yield tracer
+          }
+        }
       }
     }
-
-    implicit val tracer: Tracer[IO] =
-      makeTracer.unsafeRunSync()
   }
+
+  private def noopTracer: Tracer[IO] =
+    Tracer.noop
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.10"
+ThisBuild / tlBaseVersion := "0.11"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
@@ -710,7 +710,7 @@ lazy val benchmarks = project
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(JmhPlugin)
   .in(file("benchmarks"))
-  .dependsOn(core.jvm, sdk.jvm, oteljava)
+  .dependsOn(core.jvm, sdk.jvm, `sdk-testkit`.jvm, oteljava)
   .settings(
     name := "otel4s-benchmarks",
     libraryDependencies ++= Seq(

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/OpenTelemetrySdkSuite.scala
@@ -401,9 +401,7 @@ class OpenTelemetrySdkSuite extends CatsEffectSuite {
       s"OpenTelemetrySdk{meterProvider=$meterProvider, " +
       "tracerProvider=" +
       s"SdkTracerProvider{resource=$resource, spanLimits=$spanLimits, sampler=$sampler, " +
-      "spanProcessor=SpanProcessor.Multi(" +
-      s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
-      "SpanStorage)}, " +
+      s"spanProcessor=BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}}, " +
       s"propagators=$propagators}, resource=$resource}"
 
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -177,6 +177,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
               parentContext = parentSpanContext,
               spanLimits = tracerSharedState.spanLimits,
               processor = tracerSharedState.spanProcessor,
+              spanStorage = tracerSharedState.spanStorage,
               attributes = attributes.appendAll(samplingResult.attributes),
               links = links,
               userStartTimestamp = state.startTimestamp

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerBuilder.scala
@@ -23,7 +23,6 @@ import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.context.propagation.ContextPropagators
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
 import org.typelevel.otel4s.sdk.context.Context
-import org.typelevel.otel4s.sdk.trace.processor.SpanStorage
 import org.typelevel.otel4s.trace.TraceScope
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerBuilder
@@ -32,7 +31,6 @@ private final case class SdkTracerBuilder[F[_]: Temporal: Console](
     propagators: ContextPropagators[Context],
     traceScope: TraceScope[F, Context],
     sharedState: TracerSharedState[F],
-    storage: SpanStorage[F],
     name: String,
     version: Option[String] = None,
     schemaUrl: Option[String] = None
@@ -50,8 +48,7 @@ private final case class SdkTracerBuilder[F[_]: Temporal: Console](
         InstrumentationScope(name, version, schemaUrl, Attributes.empty),
         propagators,
         sharedState,
-        traceScope,
-        storage
+        traceScope
       )
     )
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -27,7 +27,6 @@ import org.typelevel.otel4s.context.propagation.TextMapPropagator
 import org.typelevel.otel4s.sdk.context.Context
 import org.typelevel.otel4s.sdk.context.LocalContext
 import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
-import org.typelevel.otel4s.sdk.trace.processor.SpanStorage
 import org.typelevel.otel4s.sdk.trace.samplers.Sampler
 import org.typelevel.otel4s.trace.TraceScope
 import org.typelevel.otel4s.trace.TracerBuilder
@@ -50,11 +49,12 @@ private class SdkTracerProvider[F[_]: Temporal: Parallel: Console](
       resource,
       spanLimits,
       sampler,
-      SpanProcessor.of(spanProcessors: _*)
+      SpanProcessor.of(spanProcessors: _*),
+      storage
     )
 
   def tracer(name: String): TracerBuilder[F] =
-    new SdkTracerBuilder[F](propagators, traceScope, sharedState, storage, name)
+    new SdkTracerBuilder[F](propagators, traceScope, sharedState, name)
 
   override def toString: String =
     "SdkTracerProvider{" +
@@ -212,7 +212,7 @@ object SdkTracerProvider {
           spanLimits,
           sampler,
           ContextPropagators.of(propagators: _*),
-          spanProcessors :+ storage,
+          spanProcessors,
           SdkTraceScope.fromLocal[F],
           storage
         )

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
@@ -25,5 +25,6 @@ private final case class TracerSharedState[F[_]](
     resource: TelemetryResource,
     spanLimits: SpanLimits,
     sampler: Sampler[F],
-    spanProcessor: SpanProcessor[F]
+    spanProcessor: SpanProcessor[F],
+    spanStorage: SpanStorage[F]
 )

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -381,6 +381,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
         TestControl.executeEmbed {
           for {
+            spanStorage <- SpanStorage.create[IO]
             span <- SdkSpanBackend.start[IO](
               ctx,
               name,
@@ -390,6 +391,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
               parentCtx,
               spanLimits,
               Defaults.spanProcessor,
+              spanStorage,
               LimitedData
                 .attributes(
                   spanLimits.maxNumberOfAttributes,
@@ -516,7 +518,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       spanProcessor: SpanProcessor[IO] = Defaults.spanProcessor,
       links: Vector[LinkData] = Vector.empty,
       userStartTimestamp: Option[FiniteDuration] = None
-  ): IO[SdkSpanBackend[IO]] = {
+  ): IO[SdkSpanBackend[IO]] = SpanStorage.create[IO].flatMap { spanStorage =>
     SdkSpanBackend.start[IO](
       context = context,
       name = name,
@@ -526,6 +528,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       parentContext = parentSpanContext,
       spanLimits = spanLimits,
       processor = spanProcessor,
+      spanStorage = spanStorage,
       attributes = LimitedData
         .attributes(
           spanLimits.maxNumberOfAttributes,

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
@@ -155,14 +155,17 @@ class SdkSpanBuilderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       spanLimits: SpanLimits = SpanLimits.default,
       sampler: Sampler[IO] = Sampler.alwaysOn
   ): IO[TracerSharedState[IO]] =
-    Random.scalaUtilRandom[IO].map { implicit random =>
-      TracerSharedState(
-        IdGenerator.random[IO],
-        TelemetryResource.default,
-        spanLimits,
-        sampler,
-        SimpleSpanProcessor(exporter)
-      )
+    Random.scalaUtilRandom[IO].flatMap { implicit random =>
+      SpanStorage.create[IO].map { spanStorage =>
+        TracerSharedState(
+          IdGenerator.random[IO],
+          TelemetryResource.default,
+          spanLimits,
+          sampler,
+          SimpleSpanProcessor(exporter),
+          spanStorage
+        )
+      }
     }
 
   override protected def scalaCheckTestParameters: Test.Parameters =

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracesSuite.scala
@@ -292,9 +292,7 @@ class SdkTracesSuite extends CatsEffectSuite {
   ) =
     "SdkTraces{tracerProvider=" +
       s"SdkTracerProvider{resource=$resource, spanLimits=$spanLimits, sampler=$sampler, " +
-      "spanProcessor=SpanProcessor.Multi(" +
-      s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
-      "SpanStorage)}, " +
+      s"spanProcessor=BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}}, " +
       s"propagators=$propagators}"
 
 }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/autoconfigure/TracerProviderAutoConfigureSuite.scala
@@ -184,8 +184,7 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
         s"sampler=${Sampler.alwaysOff[IO]}, " +
         "spanProcessor=SpanProcessor.Multi(" +
         "SimpleSpanProcessor{exporter=ConsoleSpanExporter, exportOnlySampled=true}, " +
-        "BatchSpanProcessor{exporter=CustomExporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
-        "SpanStorage)}"
+        "BatchSpanProcessor{exporter=CustomExporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512})}"
 
     configure(config, exporterConfigurers = configurers) { provider =>
       IO(assertEquals(provider.toString, expected))
@@ -231,8 +230,6 @@ class TracerProviderAutoConfigureSuite extends CatsEffectSuite {
       s"resource=$resource, " +
       s"spanLimits=$spanLimits, " +
       s"sampler=$sampler, " +
-      "spanProcessor=SpanProcessor.Multi(" +
-      s"BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}, " +
-      "SpanStorage)}"
+      s"spanProcessor=BatchSpanProcessor{exporter=$exporter, scheduleDelay=5 seconds, exporterTimeout=30 seconds, maxQueueSize=2048, maxExportBatchSize=512}}"
 
 }


### PR DESCRIPTION
## Benchmarks

Before:
```
Benchmark                               (backend)   Mode  Cnt      Score      Error   Units
TraceBenchmark.span                           sdk  thrpt   80  37936.668 ± 1867.799   ops/s
TraceBenchmark.span:async                     sdk  thrpt             NaN                ---
TraceBenchmark.span:gc.alloc.rate             sdk  thrpt   80   1721.229 ±   62.352  MB/sec
TraceBenchmark.span:gc.alloc.rate.norm        sdk  thrpt   80  48424.089 ± 2845.034    B/op
TraceBenchmark.span:gc.count                  sdk  thrpt   80     93.000             counts
TraceBenchmark.span:gc.time                   sdk  thrpt   80   5132.000                 ms
```

After:
```
Benchmark                               (backend)   Mode  Cnt      Score      Error   Units
TraceBenchmark.span                           sdk  thrpt   80  43930.485 ± 1372.618   ops/s
TraceBenchmark.span:async                     sdk  thrpt             NaN                ---
TraceBenchmark.span:gc.alloc.rate             sdk  thrpt   80   1698.339 ±   59.193  MB/sec
TraceBenchmark.span:gc.alloc.rate.norm        sdk  thrpt   80  40544.982 ±  530.282    B/op
TraceBenchmark.span:gc.count                  sdk  thrpt   80     85.000             counts
TraceBenchmark.span:gc.time                   sdk  thrpt   80   5635.000                 ms
```

There is ~16% improvement in throughput and ~17% less memory allocation. 

## oteljava vs SDK

```
Benchmark                  (backend)   Mode  Cnt      Score      Error   Units
TraceBenchmark.noopScope        noop  thrpt   80  194900.259 ± 4233.790   ops/s
TraceBenchmark.noopScope    oteljava  thrpt   80  167703.033 ± 2820.815   ops/s
TraceBenchmark.noopScope         sdk  thrpt   80  130521.459 ± 5903.623   ops/s
TraceBenchmark.pure             noop  thrpt   80  203382.916 ± 4371.169   ops/s
TraceBenchmark.pure         oteljava  thrpt   80  194281.902 ± 3699.690   ops/s
TraceBenchmark.pure              sdk  thrpt   80  187178.501 ± 5383.391   ops/s
TraceBenchmark.rootScope        noop  thrpt   80  204148.742 ± 3868.173   ops/s
TraceBenchmark.rootScope    oteljava  thrpt   80  103563.256 ± 7134.662   ops/s
TraceBenchmark.rootScope         sdk  thrpt   80   44412.737 ±  952.992   ops/s
TraceBenchmark.span             noop  thrpt   80  202511.661 ± 4672.375   ops/s
TraceBenchmark.span         oteljava  thrpt   80  113092.272 ± 7984.096   ops/s
TraceBenchmark.span              sdk  thrpt   80   45129.609 ± 1034.677   ops/s
```