### PR TITLE
sdk-exporter-prometheus: unify `PrometheusWriter.Config` options

### DIFF
--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusMetricExporter.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusMetricExporter.scala
@@ -97,10 +97,6 @@ object PrometheusMetricExporter {
   private[prometheus] object Defaults {
     val Host: Host = host"localhost"
     val Port: Port = port"9464"
-    val WithoutUnits = false
-    val WithoutTypeSuffixes = false
-    val DisableScopeInfo = false
-    val DisableTargetInfo = false
   }
 
   /** Builder for [[PrometheusMetricExporter]] */
@@ -204,13 +200,6 @@ object PrometheusMetricExporter {
         val routes = PrometheusHttpRoutes
           .routes[F](exporter, writerConfig)
 
-        val metricOptions =
-          "{" +
-            s"withoutUnits=${writerConfig.noUnits}, " +
-            s"withoutTypeSuffixes=${writerConfig.noTypeSuffixes}, " +
-            s"disableScopeInfo=${writerConfig.disabledScopeInfo}, " +
-            s"disableTargetInfo=${writerConfig.disabledTargetInfo}}"
-
         EmberServerBuilder
           .default[F]
           .withHost(host)
@@ -219,8 +208,7 @@ object PrometheusMetricExporter {
           .build
           .evalTap { _ =>
             val consoleMsg =
-              s"PrometheusMetricsExporter: launched Prometheus server at $host:$port, " +
-                s"metric options: $metricOptions"
+              s"PrometheusMetricsExporter: launched Prometheus server at $host:$port, writer options: $writerConfig"
             Console[F].println(consoleMsg)
           }
           .as(exporter)

--- a/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigureSuite.scala
+++ b/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigureSuite.scala
@@ -35,11 +35,11 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
         Entry(
           Op.Println,
           "PrometheusMetricsExporter: launched Prometheus server at localhost:9464, " +
-            "metric options: {" +
-            "withoutUnits=false, " +
-            "withoutTypeSuffixes=false, " +
-            "disableScopeInfo=false, " +
-            "disableTargetInfo=false}"
+            "writer options: PrometheusWriter.Config{" +
+            "unitSuffixDisabled=false, " +
+            "typeSuffixDisabled=false, " +
+            "scopeInfoDisabled=false, " +
+            "targetInfoDisabled=false}"
         )
       )
     }
@@ -61,9 +61,9 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
         "otel.exporter.prometheus.port" -> "",
         "otel.exporter.prometheus.default.aggregation" -> "",
         "otel.exporter.prometheus.without.units" -> "",
-        "otel.exporter.prometheus.without.type.suffixes" -> "",
-        "otel.exporter.prometheus.disable.scope.info" -> "",
-        "otel.exporter.prometheus.disable.target.info" -> ""
+        "otel.exporter.prometheus.without.type.suffix" -> "",
+        "otel.exporter.prometheus.without.scope.info" -> "",
+        "otel.exporter.prometheus.without.target.info" -> ""
       )
     )
 
@@ -74,11 +74,11 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
         Entry(
           Op.Println,
           "PrometheusMetricsExporter: launched Prometheus server at localhost:9464, " +
-            "metric options: {" +
-            "withoutUnits=false, " +
-            "withoutTypeSuffixes=false, " +
-            "disableScopeInfo=false, " +
-            "disableTargetInfo=false}"
+            "writer options: PrometheusWriter.Config{" +
+            "unitSuffixDisabled=false, " +
+            "typeSuffixDisabled=false, " +
+            "scopeInfoDisabled=false, " +
+            "targetInfoDisabled=false}"
         )
       )
     }
@@ -99,9 +99,9 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
         "otel.exporter.prometheus.host" -> "127.0.0.2",
         "otel.exporter.prometheus.port" -> "9465",
         "otel.exporter.prometheus.without.units" -> "true",
-        "otel.exporter.prometheus.without.type.suffixes" -> "true",
-        "otel.exporter.prometheus.disable.scope.info" -> "true",
-        "otel.exporter.prometheus.disable.target.info" -> "true"
+        "otel.exporter.prometheus.without.type.suffix" -> "true",
+        "otel.exporter.prometheus.without.scope.info" -> "true",
+        "otel.exporter.prometheus.without.target.info" -> "true"
       )
     )
 
@@ -112,11 +112,11 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
         Entry(
           Op.Println,
           "PrometheusMetricsExporter: launched Prometheus server at 127.0.0.2:9465, " +
-            "metric options: {" +
-            "withoutUnits=true, " +
-            "withoutTypeSuffixes=true, " +
-            "disableScopeInfo=true, " +
-            "disableTargetInfo=true}"
+            "writer options: PrometheusWriter.Config{" +
+            "unitSuffixDisabled=true, " +
+            "typeSuffixDisabled=true, " +
+            "scopeInfoDisabled=true, " +
+            "targetInfoDisabled=true}"
         )
       )
     }
@@ -146,11 +146,11 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
              |Cause: $error.
              |Config:
              |1) `otel.exporter.prometheus.default.aggregation` - unspecified
-             |2) `otel.exporter.prometheus.disable.scope.info` - N/A
-             |3) `otel.exporter.prometheus.disable.target.info` - N/A
-             |4) `otel.exporter.prometheus.host` - N/A
-             |5) `otel.exporter.prometheus.port` - N/A
-             |6) `otel.exporter.prometheus.without.type.suffixes` - N/A
+             |2) `otel.exporter.prometheus.host` - N/A
+             |3) `otel.exporter.prometheus.port` - N/A
+             |4) `otel.exporter.prometheus.without.scope.info` - N/A
+             |5) `otel.exporter.prometheus.without.target.info` - N/A
+             |6) `otel.exporter.prometheus.without.type.suffix` - N/A
              |7) `otel.exporter.prometheus.without.units` - N/A""".stripMargin
         )
       )


### PR DESCRIPTION
A bit of unification of the config properties:
- noUnits -> unitSuffixDisabled
- noTypeSuffixes -> typeSuffixDisabled
- disabledScopeInfo -> scopeInfoDisabled
- disabledTargetInfo -> targetInfoDisabled
