### PR TITLE
semconv-metrics: do not force a type of instrument

### DIFF
--- a/buildscripts/semantic-convention/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
@@ -7,19 +7,35 @@
 {%- endmacro -%}
 
 {%- macro instrumentType(type) -%}
-{%- if type == "gauge" -%}Gauge[F, Long]
-{%- elif type == "counter" -%}Counter[F, Long]
-{%- elif type == "updowncounter" -%}UpDownCounter[F, Long]
-{%- elif type == "histogram" -%}Histogram[F, Double]
+{%- if type == "gauge" -%}Gauge[F, A]
+{%- elif type == "counter" -%}Counter[F, A]
+{%- elif type == "updowncounter" -%}UpDownCounter[F, A]
+{%- elif type == "histogram" -%}Histogram[F, A]
 {%- else %}{{ type }}
 {%- endif -%}
 {%- endmacro -%}
 
 {%- macro instrumentFactory(type) -%}
-{%- if type == "gauge" -%}gauge[Long]
-{%- elif type == "counter" -%}counter[Long]
-{%- elif type == "updowncounter" -%}upDownCounter[Long]
-{%- elif type == "histogram" -%}histogram[Double]
+{%- if type == "gauge" -%}gauge[A]
+{%- elif type == "counter" -%}counter[A]
+{%- elif type == "updowncounter" -%}upDownCounter[A]
+{%- elif type == "histogram" -%}histogram[A]
+{%- else %}{{ type }}
+{%- endif -%}
+{%- endmacro -%}
+
+{%- macro observableInstrumentType(type) -%}
+{%- if type == "gauge" -%}ObservableGauge
+{%- elif type == "counter" -%}ObservableCounter
+{%- elif type == "updowncounter" -%}ObservableUpDownCounter
+{%- else %}{{ type }}
+{%- endif -%}
+{%- endmacro -%}
+
+{%- macro observableInstrumentFactory(type) -%}
+{%- if type == "gauge" -%}observableGauge[A]
+{%- elif type == "counter" -%}observableCounter[A]
+{%- elif type == "updowncounter" -%}observableUpDownCounter[A]
 {%- else %}{{ type }}
 {%- endif -%}
 {%- endmacro -%}
@@ -95,9 +111,11 @@ package metrics
 package metrics
 {%- endif %}
 
-import org.typelevel.otel4s.metrics._
-{%- set required_imports = namespace(stable = false, experimental = false) -%}
+{%- set required_imports = namespace(cats_effect = false, stable = false, experimental = false) -%}
 {%- for metric in ctx.metrics -%}
+  {%- if metric.instrument != "histogram" -%}
+    {%- set required_imports.cats_effect = true -%}
+  {%- endif -%}
   {% for attribute in metric.attributes %}
     {%- if attribute is stable -%}
       {%- set required_imports.stable = true -%}
@@ -105,7 +123,12 @@ import org.typelevel.otel4s.metrics._
       {%- set required_imports.experimental = true -%}
     {%- endif -%}
   {%- endfor -%}
-{%- endfor -%}
+{%- endfor %}
+
+{% if required_imports.cats_effect == true %}
+import cats.effect.Resource
+{%- endif %}
+import org.typelevel.otel4s.metrics._
 {%- if required_imports.stable == true %}
 import org.typelevel.otel4s.semconv.attributes._
 {%- endif %}
@@ -168,7 +191,7 @@ object {{ object_name }} {
         )
     }
     {% endif %}
-    def create[F[_]: Meter]{% if metric.instrument == "histogram" %}(boundaries: BucketBoundaries){% endif %}: F[{{ instrumentType(metric.instrument) }}] =
+    def create[F[_]: Meter, A: MeasurementValue]{% if metric.instrument == "histogram" %}(boundaries: BucketBoundaries){% endif %}: F[{{ instrumentType(metric.instrument) }}] =
       Meter[F]
         .{{ instrumentFactory(metric.instrument) }}(name)
         .withDescription(description)
@@ -179,6 +202,23 @@ object {{ object_name }} {
         {% else %}
         .create
         {% endif %}
+    {% if metric.instrument != "histogram" %}
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .{{ observableInstrumentFactory(metric.instrument) }}(name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, {{ observableInstrumentType(metric.instrument) }}] =
+      Meter[F]
+        .{{ observableInstrumentFactory(metric.instrument) }}(name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
+    {% endif %}
   }
   {% endfor %}
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ContainerExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ContainerExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.experimental.attributes._
 
@@ -71,12 +72,28 @@ object ContainerExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -118,12 +135,28 @@ object ContainerExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -172,12 +205,28 @@ object ContainerExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -193,12 +242,28 @@ object ContainerExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -247,12 +312,28 @@ object ContainerExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DbExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DbExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -96,12 +97,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -139,9 +156,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -183,12 +200,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -226,12 +259,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -269,12 +318,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -312,12 +377,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -356,12 +437,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -399,9 +496,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -443,9 +540,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -486,9 +583,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -528,12 +625,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -569,12 +682,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -610,12 +739,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -651,12 +796,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -692,12 +853,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -747,12 +924,28 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -789,9 +982,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -832,9 +1025,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1059,9 +1252,9 @@ object DbExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DnsExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/DnsExperimentalMetrics.scala
@@ -86,9 +86,9 @@ object DnsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/FaasExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/FaasExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.experimental.attributes._
 
@@ -66,12 +67,28 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -104,9 +121,9 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -143,12 +160,28 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -181,9 +214,9 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -220,12 +253,28 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -258,9 +307,9 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -297,9 +346,9 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -336,9 +385,9 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -375,12 +424,28 @@ object FaasExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/GenAiExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/GenAiExperimentalMetrics.scala
@@ -179,9 +179,9 @@ object GenAiExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -328,9 +328,9 @@ object GenAiExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -483,9 +483,9 @@ object GenAiExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -618,9 +618,9 @@ object GenAiExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -753,9 +753,9 @@ object GenAiExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HttpExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HttpExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -159,12 +160,28 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -270,9 +287,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -396,12 +413,28 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -606,9 +639,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -794,9 +827,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1005,9 +1038,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1117,12 +1150,28 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1333,9 +1382,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1546,9 +1595,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1763,9 +1812,9 @@ object HttpExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HwExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/HwExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -106,12 +107,28 @@ object HwExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -208,12 +225,28 @@ object HwExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -292,12 +325,28 @@ object HwExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -392,12 +441,28 @@ object HwExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/JvmExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/JvmExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -83,12 +84,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -126,12 +143,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -170,12 +203,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -213,12 +262,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -233,12 +298,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -253,12 +334,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -273,12 +370,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -293,12 +406,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -317,12 +446,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -337,12 +482,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -398,9 +559,9 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -458,12 +619,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -516,12 +693,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -575,12 +768,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -634,12 +843,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -694,12 +919,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -718,12 +959,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -741,12 +998,28 @@ object JvmExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -794,12 +1067,28 @@ object JvmExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/K8sExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/K8sExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/metrics/SemanticMetrics.scala.j2
@@ -45,12 +46,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -66,12 +83,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -87,12 +120,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -108,12 +157,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -129,12 +194,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -150,12 +231,28 @@ object K8sExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/MessagingExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/MessagingExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -240,12 +241,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -460,9 +477,9 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -632,12 +649,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -804,12 +837,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1009,9 +1058,9 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1115,12 +1164,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1220,9 +1285,9 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1326,12 +1391,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1431,9 +1512,9 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -1537,12 +1618,28 @@ object MessagingExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/NodejsExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/NodejsExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.experimental.attributes._
 
@@ -50,12 +51,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -72,12 +89,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -94,12 +127,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -116,12 +165,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -138,12 +203,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -160,12 +241,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -182,12 +279,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -224,12 +337,28 @@ object NodejsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -247,12 +376,28 @@ object NodejsExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ProcessExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/ProcessExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.experimental.attributes._
 
@@ -68,12 +69,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -111,12 +128,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -156,12 +189,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -195,12 +244,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -214,12 +279,28 @@ object ProcessExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -233,12 +314,28 @@ object ProcessExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -272,12 +369,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -291,12 +404,28 @@ object ProcessExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -330,12 +459,28 @@ object ProcessExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -349,12 +494,28 @@ object ProcessExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -371,12 +532,28 @@ object ProcessExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/RpcExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/RpcExperimentalMetrics.scala
@@ -50,9 +50,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -72,9 +72,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -95,9 +95,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -117,9 +117,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -140,9 +140,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -163,9 +163,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -185,9 +185,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -208,9 +208,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -230,9 +230,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -253,9 +253,9 @@ object RpcExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/SystemExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/SystemExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 import org.typelevel.otel4s.semconv.experimental.attributes._
@@ -90,12 +91,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -110,12 +127,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -129,12 +162,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -185,12 +234,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -242,12 +307,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -293,12 +374,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -339,12 +436,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -378,12 +491,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -429,12 +558,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -486,12 +631,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -537,12 +698,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -616,12 +793,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -711,12 +904,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -802,12 +1011,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -828,12 +1053,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -875,12 +1116,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -896,12 +1153,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -918,12 +1191,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -961,12 +1250,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1000,12 +1305,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1070,12 +1391,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1129,12 +1466,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1188,12 +1541,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1239,12 +1608,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1290,12 +1675,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1328,12 +1729,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1379,12 +1796,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1418,12 +1851,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1456,12 +1905,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1496,12 +1961,28 @@ object SystemExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -1515,12 +1996,28 @@ object SystemExperimentalMetrics {
     val stability: Stability = Stability.experimental
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/V8jsExperimentalMetrics.scala
+++ b/semconv/metrics/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/metrics/V8jsExperimentalMetrics.scala
@@ -19,6 +19,7 @@ package semconv
 package experimental
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.experimental.attributes._
 
@@ -66,9 +67,9 @@ object V8jsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -111,12 +112,28 @@ object V8jsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -155,12 +172,28 @@ object V8jsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -199,12 +232,28 @@ object V8jsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -243,12 +292,28 @@ object V8jsExperimentalMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 

--- a/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/HttpMetrics.scala
+++ b/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/HttpMetrics.scala
@@ -206,9 +206,9 @@ object HttpMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -418,9 +418,9 @@ object HttpMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)

--- a/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/JvmMetrics.scala
+++ b/semconv/metrics/stable/src/main/scala/org/typelevel/otel4s/semconv/metrics/JvmMetrics.scala
@@ -18,6 +18,7 @@ package org.typelevel.otel4s
 package semconv
 package metrics
 
+import cats.effect.Resource
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.semconv.attributes._
 
@@ -49,12 +50,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -68,12 +85,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -87,12 +120,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -106,12 +155,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -129,12 +194,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Gauge[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Gauge[F, A]] =
       Meter[F]
-        .gauge[Long](name)
+        .gauge[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableGauge] =
+      Meter[F]
+        .observableGauge[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -148,12 +229,28 @@ object JvmMetrics {
     val stability: Stability = Stability.stable
     val attributeSpecs: List[AttributeSpec[_]] = Nil
 
-    def create[F[_]: Meter]: F[Counter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[Counter[F, A]] =
       Meter[F]
-        .counter[Long](name)
+        .counter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableCounter] =
+      Meter[F]
+        .observableCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -208,9 +305,9 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter](boundaries: BucketBoundaries): F[Histogram[F, Double]] =
+    def create[F[_]: Meter, A: MeasurementValue](boundaries: BucketBoundaries): F[Histogram[F, A]] =
       Meter[F]
-        .histogram[Double](name)
+        .histogram[A](name)
         .withDescription(description)
         .withUnit(unit)
         .withExplicitBucketBoundaries(boundaries)
@@ -267,12 +364,28 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -325,12 +438,28 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -383,12 +512,28 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -442,12 +587,28 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 
@@ -494,12 +655,28 @@ object JvmMetrics {
         )
     }
 
-    def create[F[_]: Meter]: F[UpDownCounter[F, Long]] =
+    def create[F[_]: Meter, A: MeasurementValue]: F[UpDownCounter[F, A]] =
       Meter[F]
-        .upDownCounter[Long](name)
+        .upDownCounter[A](name)
         .withDescription(description)
         .withUnit(unit)
         .create
+
+    def createObserver[F[_]: Meter, A: MeasurementValue]: F[ObservableMeasurement[F, A]] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createObserver
+
+    def createWithCallback[F[_]: Meter, A: MeasurementValue](
+        callback: ObservableMeasurement[F, A] => F[Unit]
+    ): Resource[F, ObservableUpDownCounter] =
+      Meter[F]
+        .observableUpDownCounter[A](name)
+        .withDescription(description)
+        .withUnit(unit)
+        .createWithCallback(callback)
 
   }
 


### PR DESCRIPTION
It's an oversight from the original implementation: we shouldn't decide for a user which type of instrument they will use.

Bonus point: `createObserver` and `createWithCallback`. 