### PR TITLE
prometheus exporter: accept more text media type

### DIFF
--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutes.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutes.scala
@@ -43,7 +43,7 @@ object PrometheusHttpRoutes {
 
     val routes: HttpRoutes[F] = HttpRoutes.of {
       case Request(GET, _, _, headers, _, _) =>
-        if (headers.get[Accept].forall(_.values.exists(_.mediaRange.satisfiedBy(MediaRange.`text/*`)))) {
+        if (headers.get[Accept].forall(_.values.exists(_.mediaRange.satisfies(MediaRange.`text/*`)))) {
           for {
             metrics <- exporter.metricReader.collectAllMetrics
           } yield Response().withEntity(writer.write(metrics)).withHeaders("Content-Type" -> writer.contentType)

--- a/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutesSuite.scala
+++ b/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutesSuite.scala
@@ -65,6 +65,23 @@ class PrometheusHttpRoutesSuite extends CatsEffectSuite with SuiteRuntimePlatfor
     }
   }
 
+  test("respond with a text on GET request and text/plain accept") {
+    PrometheusMetricExporter.builder[IO].build.flatMap { exporter =>
+      val routes: HttpRoutes[IO] = PrometheusHttpRoutes.routes(exporter, PrometheusWriter.Config.default)
+
+      routes.orNotFound
+        .run(
+          Request(method = Method.GET, uri = uri"/", headers = Headers(Accept(MediaType.text.plain)))
+        )
+        .flatMap { response =>
+          IO {
+            assertEquals(response.status, Status.Ok)
+            assertEquals(response.contentType.exists(_.mediaType.isText), true)
+          }
+        }
+    }
+  }
+
   test("respond with a text on GET request and wildcard accept") {
     PrometheusMetricExporter.builder[IO].build.flatMap { exporter =>
       val routes: HttpRoutes[IO] = PrometheusHttpRoutes.routes(exporter, PrometheusWriter.Config.default)


### PR DESCRIPTION
currently `curl -v -H "Accept:text/plain" http://localhost:9464/metrics` return 406. Fixed by reversing the logic of checking MediaRange.