### PR TITLE
benchmarks: add metrics benchmark

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MetricsBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MetricsBenchmark.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.benchmarks
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.unsafe.implicits.global
+import cats.mtl.Ask
+import cats.syntax.foldable._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.ThreadParams
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.metrics.MeterProvider
+
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+import scala.util.chaining._
+
+// benchmarks/Jmh/run org.typelevel.otel4s.benchmarks.MetricsBenchmark -prof gc
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+class MetricsBenchmark {
+  import MetricsBenchmark._
+
+  @Benchmark
+  @Threads(1)
+  def recordToMultipleAttributes(state: BenchThreadState): Unit =
+    AttributesList.traverse_(attributes => state.op.run(attributes)).unsafeRunSync()
+
+  @Benchmark
+  @Threads(1)
+  def oneThread(state: BenchThreadState): Unit =
+    state.op.run(SharedAttributes).unsafeRunSync()
+
+  @Benchmark
+  @Threads(8)
+  def eightThreadsCommonLabelSet(state: BenchThreadState): Unit =
+    state.op.run(SharedAttributes).unsafeRunSync()
+
+  @Benchmark
+  @Threads(8)
+  def eightThreadsSeparateLabelSets(state: BenchThreadState): Unit =
+    state.op.run(state.threadUniqueLabelSet).unsafeRunSync()
+
+}
+
+object MetricsBenchmark {
+
+  private val AttributesList: List[Attributes] = {
+    val keys = 5
+    val valuePerKey = 5
+
+    List.tabulate(keys) { key =>
+      List
+        .tabulate(valuePerKey) { value =>
+          Attribute(s"key_$key", s"value_$value")
+        }
+        .to(Attributes)
+    }
+  }
+
+  private val SharedAttributes: Attributes =
+    Attributes(Attribute("key", "value"))
+
+  trait BenchOperation {
+    def run(attributes: Attributes): IO[Unit]
+  }
+
+  @State(Scope.Benchmark)
+  class BenchThreadState {
+
+    @Param(Array("oteljava", "sdk", "noop"))
+    var backend: String = _
+
+    @Param(Array("noop", "sdk_cumulative", "sdk_delta"))
+    var variation: String = _
+
+    @Param(Array("long_counter", "double_counter", "double_histogram", "long_histogram"))
+    var operation: String = _
+
+    var op: BenchOperation = _
+    var threadUniqueLabelSet: Attributes = _
+
+    private var finalizer: IO[Unit] = _
+
+    @Setup()
+    def setup(params: ThreadParams): Unit = {
+      threadUniqueLabelSet = Attributes(Attribute("key", params.getThreadIndex.toString))
+
+      backend match {
+        case "sdk" =>
+          val (o, release) = sdkMeter(variation).evalMap(bench(operation, _)).allocated.unsafeRunSync()
+
+          op = o
+          finalizer = release
+
+        case "oteljava" =>
+          val (o, release) = otelJavaMeter(variation).evalMap(bench(operation, _)).allocated.unsafeRunSync()
+
+          op = o
+          finalizer = release
+
+        case "noop" =>
+          op = bench(operation, noopMeter).unsafeRunSync()
+          finalizer = IO.unit
+
+        case other =>
+          sys.error(s"unknown backend [$other]")
+      }
+    }
+
+    @TearDown()
+    def cleanup(): Unit =
+      finalizer.unsafeRunSync()
+
+  }
+
+  private def bench(operation: String, meter: Meter[IO]): IO[BenchOperation] = {
+    operation match {
+      case "long_counter" =>
+        for {
+          counter <- meter.counter[Long]("counter.long").create
+        } yield new BenchOperation {
+          def run(attributes: Attributes): IO[Unit] = counter.add(5L, attributes)
+        }
+
+      case "double_counter" =>
+        for {
+          counter <- meter.counter[Double]("counter.double").create
+        } yield new BenchOperation {
+          def run(attributes: Attributes): IO[Unit] = counter.add(5.0, attributes)
+        }
+
+      case "long_histogram" =>
+        for {
+          histogram <- meter.histogram[Long]("histogram.long").create
+        } yield new BenchOperation {
+          def run(attributes: Attributes): IO[Unit] =
+            histogram.record(ThreadLocalRandom.current().nextLong(0, 20000), attributes)
+        }
+
+      case "double_histogram" =>
+        for {
+          histogram <- meter.histogram[Double]("histogram.double").create
+        } yield new BenchOperation {
+          def run(attributes: Attributes): IO[Unit] =
+            histogram.record(ThreadLocalRandom.current().nextDouble(0, 20000.0), attributes)
+        }
+
+      case other =>
+        sys.error(s"unknown operation [$other]")
+    }
+  }
+
+  private def otelJavaMeter(variation: String): Resource[IO, Meter[IO]] = {
+    import io.opentelemetry.sdk.OpenTelemetrySdk
+    import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+    import io.opentelemetry.sdk.metrics.SdkMeterProvider
+    import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
+    import org.typelevel.otel4s.oteljava.OtelJava
+
+    val namespace = "otel4s.sdk.metrics"
+
+    def create(
+        reader: InMemoryMetricReader,
+        customize: SdkMeterProviderBuilder => SdkMeterProviderBuilder = identity,
+    ): Resource[IO, Meter[IO]] = {
+
+      def meterProvider = SdkMeterProvider
+        .builder()
+        .registerMetricReader(reader)
+        .pipe(customize)
+        .build()
+
+      def otel = OpenTelemetrySdk
+        .builder()
+        .setMeterProvider(meterProvider)
+        .build()
+
+      OtelJava
+        .resource[IO](IO(otel))
+        .evalMap(_.meterProvider.meter("otel4s.sdk.metrics").get)
+    }
+
+    variation match {
+      case "noop" =>
+        Resource.eval(MeterProvider.noop[IO].get(namespace))
+
+      case "sdk_cumulative" =>
+        create(InMemoryMetricReader.create())
+
+      case "sdk_delta" =>
+        create(InMemoryMetricReader.createDelta())
+
+      case other =>
+        sys.error(s"unknown variation [$other]")
+    }
+  }
+
+  private def sdkMeter(variation: String): Resource[IO, Meter[IO]] = {
+    import cats.effect.std.Random
+    import org.typelevel.otel4s.sdk.context.AskContext
+    import org.typelevel.otel4s.sdk.context.Context
+    import org.typelevel.otel4s.sdk.metrics.SdkMeterProvider
+    import org.typelevel.otel4s.sdk.metrics.data.AggregationTemporality
+    import org.typelevel.otel4s.sdk.metrics.exporter.AggregationTemporalitySelector
+    import org.typelevel.otel4s.sdk.testkit.metrics.InMemoryMetricReader
+
+    val namespace = "otel4s.sdk.metrics"
+
+    def create(
+        customize: SdkMeterProvider.Builder[IO] => SdkMeterProvider.Builder[IO] = identity,
+        aggregationTemporality: AggregationTemporalitySelector = AggregationTemporalitySelector.alwaysCumulative
+    ): Resource[IO, Meter[IO]] =
+      Resource.eval {
+        Random.scalaUtilRandom[IO].flatMap { implicit random =>
+          InMemoryMetricReader.create[IO](aggregationTemporality).flatMap { reader =>
+            implicit val askContext: AskContext[IO] = Ask.const(Context.root)
+            SdkMeterProvider
+              .builder[IO]
+              .registerMetricReader(reader)
+              .pipe(customize)
+              .build
+              .flatMap(_.get(namespace))
+          }
+        }
+      }
+
+    variation match {
+      case "noop" =>
+        Resource.eval(MeterProvider.noop[IO].get(namespace))
+
+      case "sdk_cumulative" =>
+        create()
+
+      case "sdk_delta" =>
+        create(aggregationTemporality = _ => AggregationTemporality.Delta)
+
+      case other =>
+        sys.error(s"unknown variation [$other]")
+    }
+  }
+
+  private def noopMeter: Meter[IO] =
+    Meter.noop
+
+}


### PR DESCRIPTION
Yet another part of the #786.

### Baseline 

Measurment: average time, lower is better.

SDK is roughly 15% to 30% slower than the OtelJava.

```
Benchmark                      (backend)       (operation)     (variation)  Mode  Cnt      Score      Error   Units

eightThreadsCommonLabelSet      oteljava      long_counter            noop  avgt   10  28638.180 ±  3617.497   ns/op
eightThreadsCommonLabelSet      oteljava      long_counter  sdk_cumulative  avgt   10  27742.687 ±  1200.754   ns/op
eightThreadsCommonLabelSet      oteljava      long_counter       sdk_delta  avgt   10  28586.511 ±  2407.448   ns/op
eightThreadsCommonLabelSet           sdk      long_counter            noop  avgt   10  26353.959 ±   771.915   ns/op
eightThreadsCommonLabelSet           sdk      long_counter  sdk_cumulative  avgt   10  35163.158 ±   375.981   ns/op
eightThreadsCommonLabelSet           sdk      long_counter       sdk_delta  avgt   10  34662.634 ±   360.655   ns/op

eightThreadsSeparateLabelSets   oteljava      long_counter            noop  avgt   10  26951.976 ±  2104.885   ns/op
eightThreadsSeparateLabelSets   oteljava      long_counter  sdk_cumulative  avgt   10  28151.917 ±  3897.626   ns/op
eightThreadsSeparateLabelSets   oteljava      long_counter       sdk_delta  avgt   10  26909.918 ±   571.061   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter            noop  avgt   10  27774.570 ±  2493.445   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter  sdk_cumulative  avgt   10  35102.793 ±   784.706   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter       sdk_delta  avgt   10  34650.908 ±   320.706   ns/op

oneThread                       oteljava      long_counter            noop  avgt   10   4948.533 ±    81.298   ns/op
oneThread                       oteljava      long_counter  sdk_cumulative  avgt   10   5326.867 ±   277.532   ns/op
oneThread                       oteljava      long_counter       sdk_delta  avgt   10   5255.243 ±   122.588   ns/op
oneThread                            sdk      long_counter            noop  avgt   10   5120.052 ±   223.250   ns/op
oneThread                            sdk      long_counter  sdk_cumulative  avgt   10   6962.334 ±   266.006   ns/op
oneThread                            sdk      long_counter       sdk_delta  avgt   10   7658.263 ±   969.198   ns/op

recordToMultipleAttributes      oteljava      long_counter            noop  avgt   10   5469.453 ±   436.134   ns/op
recordToMultipleAttributes      oteljava      long_counter  sdk_cumulative  avgt   10   7049.623 ±   897.224   ns/op
recordToMultipleAttributes      oteljava      long_counter       sdk_delta  avgt   10   8618.673 ±  4704.295   ns/op
recordToMultipleAttributes           sdk      long_counter            noop  avgt   10   5533.041 ±   118.798   ns/op
recordToMultipleAttributes           sdk      long_counter  sdk_cumulative  avgt   10  11766.431 ±   226.243   ns/op
recordToMultipleAttributes           sdk      long_counter       sdk_delta  avgt   10  11744.749 ±  1033.673   ns/op
```

### This PR

SDK is only 1-10% slower (depending on the number of attributes and concurrency levels).

```
Benchmark                      (backend)       (operation)     (variation)  Mode  Cnt      Score      Error   Units

eightThreadsCommonLabelSet      oteljava      long_counter            noop  avgt   10  27182.080 ± 2064.094   ns/op
eightThreadsCommonLabelSet      oteljava      long_counter  sdk_cumulative  avgt   10  27002.882 ±  624.538   ns/op
eightThreadsCommonLabelSet      oteljava      long_counter       sdk_delta  avgt   10  26991.866 ±  551.068   ns/op
eightThreadsCommonLabelSet           sdk      long_counter            noop  avgt   10  26568.445 ±  559.356   ns/op
eightThreadsCommonLabelSet           sdk      long_counter  sdk_cumulative  avgt   10  26970.777 ±  534.541   ns/op
eightThreadsCommonLabelSet           sdk      long_counter       sdk_delta  avgt   10  28479.440 ± 3924.062   ns/op

eightThreadsSeparateLabelSets   oteljava      long_counter            noop  avgt   10  31506.592 ± 6814.522   ns/op
eightThreadsSeparateLabelSets   oteljava      long_counter  sdk_cumulative  avgt   10  28212.355 ± 2481.786   ns/op
eightThreadsSeparateLabelSets   oteljava      long_counter       sdk_delta  avgt   10  27082.346 ±  544.882   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter            noop  avgt   10  26845.652 ±  646.818   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter  sdk_cumulative  avgt   10  27930.532 ± 2891.188   ns/op
eightThreadsSeparateLabelSets        sdk      long_counter       sdk_delta  avgt   10  27270.965 ±  606.613   ns/op

oneThread                       oteljava      long_counter            noop  avgt   10   4817.086 ±   47.913   ns/op
oneThread                       oteljava      long_counter  sdk_cumulative  avgt   10   5373.915 ±  165.448   ns/op
oneThread                       oteljava      long_counter       sdk_delta  avgt   10   5137.084 ±   50.088   ns/op
oneThread                            sdk      long_counter            noop  avgt   10   4912.818 ±  295.623   ns/op
oneThread                            sdk      long_counter  sdk_cumulative  avgt   10   5320.152 ±  261.549   ns/op
oneThread                            sdk      long_counter       sdk_delta  avgt   10   5770.930 ±  172.216   ns/op

recordToMultipleAttributes      oteljava      long_counter            noop  avgt   10   5160.638 ±  566.987   ns/op
recordToMultipleAttributes      oteljava      long_counter  sdk_cumulative  avgt   10   5922.355 ±  199.489   ns/op
recordToMultipleAttributes      oteljava      long_counter       sdk_delta  avgt   10   6391.997 ±  249.286   ns/op
recordToMultipleAttributes           sdk      long_counter            noop  avgt   10   5460.340 ±  246.778   ns/op
recordToMultipleAttributes           sdk      long_counter  sdk_cumulative  avgt   10   7095.079 ±  156.089   ns/op
recordToMultipleAttributes           sdk      long_counter       sdk_delta  avgt   10   7142.590 ±  174.927   ns/op
```