### PR TITLE
prometheus exporter: add shutdown timeout config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 ThisBuild / tlBaseVersion := "0.11"
 
 ThisBuild / organization := "org.typelevel"
@@ -446,6 +448,18 @@ lazy val `sdk-exporter-prometheus` =
       startYear := Some(2024),
       libraryDependencies ++= Seq(
         "org.http4s" %%% "http4s-ember-server" % Http4sVersion
+      ),
+      mimaBinaryIssueFilters ++= Seq(
+        // see #838
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.typelevel.otel4s.sdk.exporter.prometheus.PrometheusMetricExporter#HttpServerBuilderImpl.*"
+        ),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.typelevel.otel4s.sdk.exporter.prometheus.PrometheusMetricExporter#HttpServerBuilderImpl.*"
+        ),
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "org.typelevel.otel4s.sdk.exporter.prometheus.PrometheusMetricExporter#HttpServerBuilder.withShutdownTimeout"
+        )
       )
     )
     .jsSettings(scalaJSLinkerSettings)

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -105,7 +105,7 @@ Target-specific properties are prioritized. E.g. `otel.exporter.otlp.metrics.end
 
 ### Prometheus exporter
 
-The exporter launches an HTTP server which responds to the HTTP requests with Prometheus metrics in the appropriate format. 
+The exporter launches an HTTP server which responds to the HTTP requests with Prometheus metrics in the appropriate format.
 
 | System property                              | Environment variable                                  | Description                                                                              |
 |----------------------------------------------|-------------------------------------------------------|------------------------------------------------------------------------------------------|
@@ -116,6 +116,7 @@ The exporter launches an HTTP server which responds to the HTTP requests with Pr
 | otel.exporter.prometheus.without.type.suffix | OTEL\\_EXPORTER\\_PROMETHEUS\_WITHOUT\\_TYPE\\_SUFFIX | If metrics are produced without a type suffix. Default is `false`.                       |
 | otel.exporter.prometheus.without.scope.info  | OTEL\\_EXPORTER\\_PROMETHEUS\_WITHOUT\\_SCOPE\\_INFO  | If metrics are produced without a scope info metric or scope labels. Default is `false`. |
 | otel.exporter.prometheus.without.target.info | OTEL\\_EXPORTER\\_PROMETHEUS\_WITHOUT\\_TARGET\\_INFO | If metrics are produced without a target info metric. Default is `false`.                |
+| otel.exporter.prometheus.shutdown.timeout    | OTEL\\_EXPORTER\\_PROMETHEUS\_SHUTDOWN\\_TIMEOUT      | The time to wait for provider to do any cleanup required. Default is `10 seconds`.       |
 
 ### Period metric reader
 

--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusMetricExporter.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusMetricExporter.scala
@@ -124,7 +124,7 @@ object PrometheusMetricExporter {
     /** Sets the port that metrics are served on. */
     def withPort(port: Port): HttpServerBuilder[F]
 
-    /** Sets the port that metrics are served on. */
+    /** Sets the shutdown timeout of the HTTP server. */
     def withShutdownTimeout(shutdownTimeout: FiniteDuration): HttpServerBuilder[F]
 
     /** Sets the default aggregation selector to use. */

--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigure.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigure.scala
@@ -189,6 +189,7 @@ object PrometheusMetricExporterAutoConfigure {
     * | otel.exporter.prometheus.without.type.suffix     | OTEL_EXPORTER_PROMETHEUS_WITHOUT_TYPE_SUFFIX     | If metrics are produced without a type suffix. Default is `false`.                       |
     * | otel.exporter.prometheus.without.scope.info      | OTEL_EXPORTER_PROMETHEUS_WITHOUT_SCOPE_INFO      | If metrics are produced without a scope info metric or scope labels. Default is `false`. |
     * | otel.exporter.prometheus.without.target.info     | OTEL_EXPORTER_PROMETHEUS_WITHOUT_TARGET_INFO     | If metrics are produced without a target info metric. Default is `false`.                |
+    * | otel.exporter.prometheus.shutdown.timeout        | OTEL_EXPORTER_PROMETHEUS_SHUTDOWN_TIMEOUT        | The time to wait for provider to do any cleanup required. Default is `10 seconds`.       |
     * }}}
     *
     * @see

--- a/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigureSuite.scala
+++ b/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/autoconfigure/PrometheusMetricExporterAutoConfigureSuite.scala
@@ -59,6 +59,7 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
       Map(
         "otel.exporter.prometheus.host" -> "",
         "otel.exporter.prometheus.port" -> "",
+        "otel.exporter.prometheus.shutdown.timeout" -> "",
         "otel.exporter.prometheus.default.aggregation" -> "",
         "otel.exporter.prometheus.without.units" -> "",
         "otel.exporter.prometheus.without.type.suffix" -> "",
@@ -98,6 +99,7 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
       Map(
         "otel.exporter.prometheus.host" -> "127.0.0.2",
         "otel.exporter.prometheus.port" -> "9465",
+        "otel.exporter.prometheus.shutdown.timeout" -> "10000",
         "otel.exporter.prometheus.without.units" -> "true",
         "otel.exporter.prometheus.without.type.suffix" -> "true",
         "otel.exporter.prometheus.without.scope.info" -> "true",
@@ -148,10 +150,11 @@ class PrometheusMetricExporterAutoConfigureSuite extends CatsEffectSuite with Su
              |1) `otel.exporter.prometheus.default.aggregation` - unspecified
              |2) `otel.exporter.prometheus.host` - N/A
              |3) `otel.exporter.prometheus.port` - N/A
-             |4) `otel.exporter.prometheus.without.scope.info` - N/A
-             |5) `otel.exporter.prometheus.without.target.info` - N/A
-             |6) `otel.exporter.prometheus.without.type.suffix` - N/A
-             |7) `otel.exporter.prometheus.without.units` - N/A""".stripMargin
+             |4) `otel.exporter.prometheus.shutdown.timeout` - N/A
+             |5) `otel.exporter.prometheus.without.scope.info` - N/A
+             |6) `otel.exporter.prometheus.without.target.info` - N/A
+             |7) `otel.exporter.prometheus.without.type.suffix` - N/A
+             |8) `otel.exporter.prometheus.without.units` - N/A""".stripMargin
         )
       )
   }


### PR DESCRIPTION
Allow users to customize the shutdown timeout of exporter server. Default value is 10 seconds