### PR TITLE
Prometheus exporter: correctly treat wildcard Accept

### DIFF
--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutes.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutes.scala
@@ -43,7 +43,14 @@ object PrometheusHttpRoutes {
 
     val routes: HttpRoutes[F] = HttpRoutes.of {
       case Request(GET, _, _, headers, _, _) =>
-        if (headers.get[Accept].forall(_.values.exists(_.mediaRange.satisfies(MediaRange.`text/*`)))) {
+        if (
+          headers
+            .get[Accept]
+            .forall(
+              _.values
+                .exists(v => v.mediaRange.equals(MediaRange.`*/*`) || v.mediaRange.satisfies(MediaRange.`text/*`))
+            )
+        ) {
           for {
             metrics <- exporter.metricReader.collectAllMetrics
           } yield Response().withEntity(writer.write(metrics)).withHeaders("Content-Type" -> writer.contentType)

--- a/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutesSuite.scala
+++ b/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusHttpRoutesSuite.scala
@@ -82,6 +82,23 @@ class PrometheusHttpRoutesSuite extends CatsEffectSuite with SuiteRuntimePlatfor
     }
   }
 
+  test("respond with a text on GET request and wildcard accept") {
+    PrometheusMetricExporter.builder[IO].build.flatMap { exporter =>
+      val routes: HttpRoutes[IO] = PrometheusHttpRoutes.routes(exporter, PrometheusWriter.Config.default)
+
+      routes.orNotFound
+        .run(
+          Request(method = Method.GET, uri = uri"/", headers = Headers(Accept(MediaRange.`*/*`)))
+        )
+        .flatMap { response =>
+          IO {
+            assertEquals(response.status, Status.Ok)
+            assertEquals(response.contentType.exists(_.mediaType.isText), true)
+          }
+        }
+    }
+  }
+
   test("respond with an empty body on HEAD request and wildcard accept") {
     PrometheusMetricExporter.builder[IO].build.flatMap { exporter =>
       val routes: HttpRoutes[IO] = PrometheusHttpRoutes.routes(exporter, PrometheusWriter.Config.default)


### PR DESCRIPTION
It turns out that now Prometheus exporter endpoint returns `Not Acceptable` error response for GET request with `*/*` Accept header, while the more correct approach looks to treat it the same as non-existent Accept header, that is "user agent will accept any media type in response".