### PR TITLE
sdk: refactor SpanProcessor

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MultiSpanProcessorBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MultiSpanProcessorBenchmark.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.benchmarks
+
+import cats.effect.IO
+import cats.syntax.foldable._
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+// benchmarks/Jmh/run org.typelevel.otel4s.benchmarks.MultiSpanProcessorBenchmark -prof gc
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+class MultiSpanProcessorBenchmark {
+
+  import MultiSpanProcessorBenchmark._
+
+  @Param(Array("oteljava", "sdk"))
+  var backend: String = _
+
+  @Param(Array("1", "5", "10"))
+  var processorCount: Int = _
+
+  @Param(Array("1"))
+  var spanCount: Int = _
+
+  private var processor: Processor = _
+
+  @Benchmark
+  def onEnd(): Unit =
+    processor.onEnd()
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    backend match {
+      case "oteljava" =>
+        processor = Processor.otelJava(processorCount)
+
+      case "sdk" =>
+        processor = Processor.sdk(processorCount)
+
+      case other =>
+        sys.error(s"unknown backend [$other]")
+    }
+
+}
+
+object MultiSpanProcessorBenchmark {
+
+  trait Processor {
+    def onEnd(): Unit
+  }
+
+  object Processor {
+
+    def otelJava(processorCount: Int): Processor = {
+      import io.opentelemetry.api.trace.Span
+      import io.opentelemetry.sdk.trace.{ReadableSpan, SdkTracerProvider}
+      import io.opentelemetry.sdk.trace.SpanProcessor
+      import scala.jdk.CollectionConverters._
+
+      val tracer = SdkTracerProvider.builder().build().get("benchmarkTracer")
+
+      val span: Span =
+        tracer.spanBuilder("span").startSpan()
+
+      val processor = new SpanProcessor {
+        def onStart(parentContext: Context, span: ReadWriteSpan): Unit = ()
+        def isStartRequired: Boolean = true
+        def onEnd(span: ReadableSpan): Unit = ()
+        def isEndRequired: Boolean = true
+      }
+
+      val proc = SpanProcessor.composite(List.fill(processorCount)(processor).asJava)
+
+      new Processor {
+        def onEnd(): Unit =
+          proc.onEnd(span.asInstanceOf[ReadableSpan])
+      }
+    }
+
+    def sdk(processorCount: Int): Processor = {
+      import cats.effect.unsafe.implicits.global
+      import org.typelevel.otel4s.trace.{SpanContext, SpanKind}
+      import org.typelevel.otel4s.sdk.TelemetryResource
+      import org.typelevel.otel4s.sdk.common.InstrumentationScope
+      import org.typelevel.otel4s.sdk.trace.data.{LimitedData, SpanData, StatusData}
+      import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
+
+      val processor: SpanProcessor[IO] = new SpanProcessor[IO] {
+        def name: String = "Noop"
+        val onStart: SpanProcessor.OnStart[IO] = (_, _) => IO.unit
+        val onEnd: SpanProcessor.OnEnd[IO] = _ => IO.unit
+        def forceFlush: IO[Unit] = IO.unit
+      }
+
+      val spanData = SpanData(
+        name = "span",
+        spanContext = SpanContext.invalid,
+        parentSpanContext = None,
+        kind = SpanKind.Internal,
+        startTimestamp = Duration.Zero,
+        endTimestamp = None,
+        status = StatusData.Ok,
+        attributes = LimitedData.attributes(Int.MaxValue, 1024),
+        events = LimitedData.events(Int.MaxValue),
+        links = LimitedData.links(Int.MaxValue),
+        instrumentationScope = InstrumentationScope.empty,
+        resource = TelemetryResource.empty
+      )
+
+      val proc = List.fill(processorCount)(processor).combineAll
+
+      new Processor {
+        def onEnd(): Unit = proc.onEnd(spanData).unsafeRunSync()
+      }
+    }
+
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.11"
+ThisBuild / tlBaseVersion := "0.12"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -90,9 +90,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
 
     def release(backend: Span.Backend[F], ec: Resource.ExitCase): F[Unit] =
       for {
-        _ <- state.finalizationStrategy
-          .lift(ec)
-          .foldMapM(SpanFinalizer.run(backend, _))
+        _ <- state.finalizationStrategy.lift(ec).foldMapM(SpanFinalizer.run(backend, _))
         _ <- backend.end
       } yield ()
 

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -158,9 +158,7 @@ object SdkTracerProvider {
 
   /** Creates a new [[Builder]] with default configuration.
     */
-  def builder[
-      F[_]: Temporal: Parallel: Random: LocalContext: Console
-  ]: Builder[F] =
+  def builder[F[_]: Temporal: Parallel: Random: LocalContext: Console]: Builder[F] =
     BuilderImpl[F](
       idGenerator = IdGenerator.random,
       resource = TelemetryResource.default,
@@ -170,9 +168,7 @@ object SdkTracerProvider {
       spanProcessors = Nil
     )
 
-  private final case class BuilderImpl[
-      F[_]: Temporal: Parallel: LocalContext: Console
-  ](
+  private final case class BuilderImpl[F[_]: Temporal: Parallel: LocalContext: Console](
       idGenerator: IdGenerator[F],
       resource: TelemetryResource,
       spanLimits: SpanLimits,

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -484,23 +484,15 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
     }
   }
 
-  private def startEndRecorder(
-      start: Queue[IO, SpanData],
-      end: Queue[IO, SpanData]
-  ): SpanProcessor[IO] =
+  private def startEndRecorder(start: Queue[IO, SpanData], end: Queue[IO, SpanData]): SpanProcessor[IO] =
     new SpanProcessor[IO] {
       val name: String = "InMemorySpanProcessor"
-      val isStartRequired: Boolean = true
-      val isEndRequired: Boolean = true
 
-      def onStart(
-          parentContext: Option[SpanContext],
-          span: SpanRef[IO]
-      ): IO[Unit] =
-        span.toSpanData.flatMap(d => start.offer(d))
+      val onStart: SpanProcessor.OnStart[IO] =
+        (_, span) => span.toSpanData.flatMap(d => start.offer(d))
 
-      def onEnd(span: SpanData): IO[Unit] =
-        end.offer(span)
+      val onEnd: SpanProcessor.OnEnd[IO] =
+        end.offer(_)
 
       def forceFlush: IO[Unit] =
         IO.unit

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SpanProcessorSuite.scala
@@ -20,8 +20,6 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import munit.FunSuite
 import org.typelevel.otel4s.sdk.trace.SpanRef
-import org.typelevel.otel4s.sdk.trace.data.SpanData
-import org.typelevel.otel4s.trace.SpanContext
 
 class SpanProcessorSuite extends FunSuite {
 
@@ -136,26 +134,10 @@ class SpanProcessorSuite extends FunSuite {
       flush: IO[Unit] = IO.unit,
   ): SpanProcessor[IO] =
     new SpanProcessor[IO] {
-      def name: String =
-        processorName
-
-      def onStart(
-          parentContext: Option[SpanContext],
-          span: SpanRef[IO]
-      ): IO[Unit] =
-        start
-
-      def isStartRequired: Boolean =
-        false
-
-      def onEnd(span: SpanData): IO[Unit] =
-        end
-
-      def isEndRequired: Boolean =
-        false
-
-      def forceFlush: IO[Unit] =
-        flush
+      def name: String = processorName
+      def onStart: SpanProcessor.OnStart[IO] = (_, _) => start
+      def onEnd: SpanProcessor.OnEnd[IO] = _ => end
+      def forceFlush: IO[Unit] = flush
     }
 
 }


### PR DESCRIPTION
The original implementation of `SpanProcessor` is highly influenced by OpenTelemetry Java internals. 
For example, `isStartRequired` and `isEndRequired` are used for optimization purposes and also aren't required by the spec. 

We can replace:
```scala
def onStart(parentContext: Option[SpanContext], span: SpanRef[F]): F[Unit]
```
with:
```scala
def onStart: SpanProcessor.OnStart[F]

trait OnStart[F[_]] {
  def apply(parentContext: Option[SpanContext], span: SpanRef[F]): F[Unit]
}
```

A noop implementation of `OnStart` can be filtered out when combining multiple processors. 