### PR TITLE
oteljava: refactor Metrics, Traces, and OtelJava API

### DIFF
--- a/docs/oteljava/tracing-java-interop.md
+++ b/docs/oteljava/tracing-java-interop.md
@@ -50,14 +50,8 @@ It can be constructed in the following way:
 ```scala mdoc:silent
 import cats.effect._
 import cats.mtl.Local
-import cats.syntax.functor._
-import org.typelevel.otel4s.instances.local._ // brings Local derived from IOLocal
 import org.typelevel.otel4s.oteljava.context.Context
 import org.typelevel.otel4s.oteljava.OtelJava
-import io.opentelemetry.api.GlobalOpenTelemetry
-
-def createOtel4s[F[_]: Async](implicit L: Local[F, Context]): F[OtelJava[F]] =
-  Async[F].delay(GlobalOpenTelemetry.get).map(OtelJava.local[F])
 
 def program[F[_]: Async](otel4s: OtelJava[F])(implicit L: Local[F, Context]): F[Unit] = {
   val _ = (otel4s, L) // both OtelJava and Local[F, Context] are available here
@@ -65,8 +59,9 @@ def program[F[_]: Async](otel4s: OtelJava[F])(implicit L: Local[F, Context]): F[
 }
 
 val run: IO[Unit] =
-  IOLocal(Context.root).flatMap { implicit ioLocal: IOLocal[Context] =>
-    createOtel4s[IO].flatMap(otel4s => program(otel4s))
+  OtelJava.global[IO].flatMap { otel4s =>
+    implicit val local: Local[IO, Context] = otel4s.localContext
+    program(otel4s)
   }
 ```
 

--- a/docs/oteljava/tracing-java-interop.md
+++ b/docs/oteljava/tracing-java-interop.md
@@ -60,7 +60,7 @@ def program[F[_]: Async](otel4s: OtelJava[F])(implicit L: Local[F, Context]): F[
 
 val run: IO[Unit] =
   OtelJava.global[IO].flatMap { otel4s =>
-    implicit val local: Local[IO, Context] = otel4s.localContext
+    import otel4s.localContext
     program(otel4s)
   }
 ```

--- a/docs/tracing-context-propagation.md
+++ b/docs/tracing-context-propagation.md
@@ -32,14 +32,14 @@ You can find both examples below and choose which one suits your requirements.
 ```scala mdoc:silent:reset
 import cats.effect._
 import cats.mtl.Local
-import cats.syntax.functor._
+import cats.syntax.flatMap._
 import org.typelevel.otel4s.instances.local._ // brings Local derived from IOLocal
 import org.typelevel.otel4s.oteljava.context.Context
 import org.typelevel.otel4s.oteljava.OtelJava
 import io.opentelemetry.api.GlobalOpenTelemetry
 
 def createOtel4s[F[_]: Async](implicit L: Local[F, Context]): F[OtelJava[F]] =
-  Async[F].delay(GlobalOpenTelemetry.get).map(OtelJava.local[F])
+  Async[F].delay(GlobalOpenTelemetry.get).flatMap(OtelJava.fromJOpenTelemetry[F])
     
 def program[F[_]: Async](otel4s: OtelJava[F]): F[Unit] = {
   val _ = otel4s
@@ -52,7 +52,7 @@ val run: IO[Unit] =
   }
 ```
 
-If you don't need direct access to the `IOLocal` instance, there is also a shortcut `OtelJava.forAsync`:
+If you don't need direct access to the `IOLocal` instance, there is also a shortcut `OtelJava.fromJOpenTelemetry`:
 
 ```scala mdoc:silent:reset
 import cats.effect._
@@ -61,7 +61,7 @@ import org.typelevel.otel4s.oteljava.OtelJava
 import io.opentelemetry.api.GlobalOpenTelemetry
 
 def createOtel4s[F[_]: Async: LiftIO]: F[OtelJava[F]] =
-  Async[F].delay(GlobalOpenTelemetry.get).flatMap(OtelJava.forAsync[F])
+  Async[F].delay(GlobalOpenTelemetry.get).flatMap(OtelJava.fromJOpenTelemetry[F])
 
 def program[F[_]: Async](otel4s: OtelJava[F]): F[Unit] = {
   val _ = otel4s
@@ -90,7 +90,7 @@ val run: IO[Unit] =
 
 ```scala mdoc:silent:reset
 import cats.effect._
-import cats.syntax.functor._
+import cats.syntax.flatMap._
 import cats.data.Kleisli
 import cats.mtl.Local
 import org.typelevel.otel4s.oteljava.context.Context
@@ -98,7 +98,7 @@ import org.typelevel.otel4s.oteljava.OtelJava
 import io.opentelemetry.api.GlobalOpenTelemetry
 
 def createOtel4s[F[_]: Async](implicit L: Local[F, Context]): F[OtelJava[F]] =
-  Async[F].delay(GlobalOpenTelemetry.get).map(OtelJava.local[F])
+  Async[F].delay(GlobalOpenTelemetry.get).flatMap(OtelJava.fromJOpenTelemetry[F])
     
 def program[F[_]: Async](otel4s: OtelJava[F]): F[Unit] = {
   val _ = otel4s

--- a/examples/src/main/scala/KleisliExample.scala
+++ b/examples/src/main/scala/KleisliExample.scala
@@ -19,7 +19,6 @@ import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.Resource
-import io.opentelemetry.api.GlobalOpenTelemetry
 import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.oteljava.context.Context
 import org.typelevel.otel4s.oteljava.context.LocalContext
@@ -30,10 +29,7 @@ object KleisliExample extends IOApp.Simple {
     Tracer[F].span("work").surround(Async[F].delay(println("I'm working")))
 
   private def tracerResource[F[_]: Async: LocalContext]: Resource[F, Tracer[F]] =
-    Resource
-      .eval(Async[F].delay(GlobalOpenTelemetry.get))
-      .map(OtelJava.local[F])
-      .evalMap(_.tracerProvider.get("kleisli-example"))
+    Resource.eval(OtelJava.global[F]).evalMap(_.tracerProvider.get("kleisli-example"))
 
   def run: IO[Unit] =
     tracerResource[Kleisli[IO, Context, *]]

--- a/examples/src/main/scala/PekkoHttpExample.scala
+++ b/examples/src/main/scala/PekkoHttpExample.scala
@@ -75,7 +75,7 @@ object PekkoHttpExample extends IOApp.Simple {
 
   def run: IO[Unit] =
     OtelJava.global[IO].flatMap { otelJava =>
-      implicit val local: LocalContext[IO] = otelJava.localContext
+      import otelJava.localContext
 
       otelJava.tracerProvider.get("com.example").flatMap { implicit tracer: Tracer[IO] =>
         createSystem.use { implicit actorSystem: ActorSystem =>

--- a/examples/src/main/scala/PekkoHttpExample.scala
+++ b/examples/src/main/scala/PekkoHttpExample.scala
@@ -17,7 +17,6 @@
 import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
-import cats.effect.IOLocal
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.effect.std.Random
@@ -26,7 +25,6 @@ import cats.mtl.Local
 import cats.syntax.applicative._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.{Context => JContext}
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.apache.pekko.actor.ActorSystem
@@ -37,9 +35,9 @@ import org.apache.pekko.http.scaladsl.server.Directives._
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.util.ByteString
 import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.instances.local._
 import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.oteljava.context.Context
+import org.typelevel.otel4s.oteljava.context.LocalContext
 import org.typelevel.otel4s.trace.Tracer
 
 import scala.concurrent.Future
@@ -76,9 +74,8 @@ import scala.concurrent.duration._
 object PekkoHttpExample extends IOApp.Simple {
 
   def run: IO[Unit] =
-    IOLocal(Context.root).flatMap { implicit ioLocal: IOLocal[Context] =>
-      implicit val local: Local[IO, Context] = localForIOLocal
-      val otelJava: OtelJava[IO] = OtelJava.local(GlobalOpenTelemetry.get())
+    OtelJava.global[IO].flatMap { otelJava =>
+      implicit val local: LocalContext[IO] = otelJava.localContext
 
       otelJava.tracerProvider.get("com.example").flatMap { implicit tracer: Tracer[IO] =>
         createSystem.use { implicit actorSystem: ActorSystem =>

--- a/examples/src/main/scala/PekkoHttpExample.scala
+++ b/examples/src/main/scala/PekkoHttpExample.scala
@@ -37,7 +37,6 @@ import org.apache.pekko.util.ByteString
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.oteljava.OtelJava
 import org.typelevel.otel4s.oteljava.context.Context
-import org.typelevel.otel4s.oteljava.context.LocalContext
 import org.typelevel.otel4s.trace.Tracer
 
 import scala.concurrent.Future

--- a/oteljava/all/src/test/scala/org/typelevel/otel4s/oteljava/OtelJavaSuite.scala
+++ b/oteljava/all/src/test/scala/org/typelevel/otel4s/oteljava/OtelJavaSuite.scala
@@ -25,7 +25,7 @@ class OtelJavaSuite extends CatsEffectSuite {
   test("OtelJava toString returns useful info") {
     val testSdk: JOpenTelemetrySdk = JOpenTelemetrySdk.builder().build()
     OtelJava
-      .forAsync[IO](testSdk)
+      .fromJOpenTelemetry[IO](testSdk)
       .map(testOtel4s => {
         val res = testOtel4s.toString()
         assert(clue(res).contains("OpenTelemetrySdk"))

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/Metrics.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/Metrics.scala
@@ -16,21 +16,58 @@
 
 package org.typelevel.otel4s.oteljava.metrics
 
-import cats.effect.kernel.Async
+import cats.effect.Async
+import cats.mtl.Ask
+import cats.syntax.functor._
 import io.opentelemetry.api.{OpenTelemetry => JOpenTelemetry}
+import io.opentelemetry.api.GlobalOpenTelemetry
 import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.oteljava.context.AskContext
+import org.typelevel.otel4s.oteljava.context.Context
 
-trait Metrics[F[_]] {
+/** The configured metrics module.
+  *
+  * @tparam F
+  *   the higher-kinded type of a polymorphic effect
+  */
+sealed trait Metrics[F[_]] {
+
+  /** The [[org.typelevel.otel4s.metrics.MeterProvider MeterProvider]].
+    */
   def meterProvider: MeterProvider[F]
 }
 
 object Metrics {
 
-  def forAsync[F[_]: Async: AskContext](jOtel: JOpenTelemetry): Metrics[F] =
-    new Metrics[F] {
-      val meterProvider: MeterProvider[F] =
-        new MeterProviderImpl[F](jOtel.getMeterProvider)
-    }
+  /** Creates a [[org.typelevel.otel4s.oteljava.metrics.Metrics]] from the global Java OpenTelemetry instance.
+    *
+    * @note
+    *   the created module is isolated and exemplars won't be collected. Use `OtelJava` if you need to capture
+    *   exemplars.
+    */
+  def global[F[_]: Async]: F[Metrics[F]] =
+    Async[F].delay(GlobalOpenTelemetry.get).map(fromJOpenTelemetry[F])
+
+  /** Creates a [[org.typelevel.otel4s.oteljava.metrics.Metrics]] from a Java OpenTelemetry instance.
+    *
+    * @note
+    *   the created module is isolated and exemplars won't be collected. Use `OtelJava` if you need to capture
+    *   exemplars.
+    *
+    * @param jOtel
+    *   A Java OpenTelemetry instance. It is the caller's responsibility to shut this down. Failure to do so may result
+    *   in lost metrics and traces.
+    */
+  def fromJOpenTelemetry[F[_]: Async](jOtel: JOpenTelemetry): Metrics[F] = {
+    implicit val askContext: AskContext[F] = Ask.const(Context.root)
+    create(jOtel)
+  }
+
+  private[oteljava] def create[F[_]: Async: AskContext](jOtel: JOpenTelemetry): Metrics[F] =
+    new Impl(new MeterProviderImpl(jOtel.getMeterProvider))
+
+  private final class Impl[F[_]](val meterProvider: MeterProvider[F]) extends Metrics[F] {
+    override def toString: String = s"Metrics{meterProvider=$meterProvider}"
+  }
 
 }


### PR DESCRIPTION
We are slowly getting closer to `1.0` and I want to revisit the OtelJava API.

Currently, the situation is the following.
```scala
object OtelJava {
  def forAsync[F[_]: Async: LocalContextProvider](jOtel: JOpenTelemetry): F[OtelJava[F]]
  def local[F[_]: Async: LocalContext](jOtel: JOpenTelemetry): OtelJava[F]
  def resource[F[_]: Async: LocalContextProvider](acquire: F[JOpenTelemetrySdk]): Resource[F, OtelJava[F]]
  def autoConfigured[F[_]: Async: LocalContextProvider](customize: ...): Resource[F, OtelJava[F]]
  def global[F[_]: Async: LocalContextProvider]: F[OtelJava[F]]
  def noop[F[_]: Applicative: LocalContextProvider]: F[OtelJava[F]]
}
```

I'm confident in the following:
- `autoConfigured`
- `global`
- `resource`
- `noop`

And less confident in:
- `forAsync`
- `local`

Both are relatively low-level and require `JOpenTelemetry`. These methods were popular before we implemented `LocalContextProvider`. 
Also, `forAsync` and `local` may be confusing for newcomers. 

What I propose to do here: 
1) Rename `forAsync` to `fromJOpenTelemetry`
2) Rename `local` to `create` and make it private

The API remains flexible and should be more apparent. 

What do you think?