### PR TITLE
core-common: redefine `Attribute` as a sealed trait

### DIFF
--- a/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/AttributeConverters.scala
+++ b/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/AttributeConverters.scala
@@ -108,7 +108,9 @@ object AttributeConverters {
     ): JAttributes = {
       val builder = JAttributes.builder
 
-      attributes.foreach { case Attribute(key, value) =>
+      attributes.foreach { attribute =>
+        val key = attribute.key
+        val value = attribute.value
         key.`type` match {
           case AttributeType.String =>
             builder.put(key.name, value.asInstanceOf[String])


### PR DESCRIPTION
That's the last public `case class` in the `core-*`. 
When it's a sealed trait, it should be easier to do binary-compatible changes to the `Attribute`.