### PR TITLE
Add implicit `Otel4s#localContext`

### DIFF
--- a/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
+++ b/core/all/src/main/scala/org/typelevel/otel4s/Otel4s.scala
@@ -16,20 +16,25 @@
 
 package org.typelevel.otel4s
 
+import cats.mtl.Local
 import org.typelevel.otel4s.context.propagation.ContextPropagators
 import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.trace.TracerProvider
 
 trait Otel4s[F[_]] {
+
+  /** The type of context used by telemetry components. */
   type Ctx
 
+  /** The [[cats.mtl.Local `Local`]] context. */
+  implicit def localContext: Local[F, Ctx]
+
+  /** The registered propagators. */
   def propagators: ContextPropagators[Ctx]
 
-  /** A registry for creating named meters.
-    */
+  /** A registry for creating named meters. */
   def meterProvider: MeterProvider[F]
 
-  /** An entry point of the tracing API.
-    */
+  /** An entry point of the tracing API. */
   def tracerProvider: TracerProvider[F]
 }


### PR DESCRIPTION
Add `implicit def localContext: Local[F, Ctx]` to `Otel4s`, where previously it was only defined on subtypes.

I think the reason we didn't do this originally is because we thought that in conflicted with no-op implementations—because `Local` has an API contract to adhere to which does not permit no-op implementations—but in practice all the `Otel4s` implementations define it anyway, and just have a working `Local` context in their no-op implementations