### PR TITLE
core-common: add `Attribute.from`

### DIFF
--- a/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+
+import munit.FunSuite
+
+class AttributeSuite extends FunSuite {
+
+  private case class UserId(id: String)
+  private val userIdKey: AttributeKey[String] = AttributeKey("user.id")
+  private implicit val userIdFrom: Attribute.From[UserId, String] = _.id
+
+  test("use implicit From to derive a type of an attribute") {
+    val stringAttribute = Attribute("user.id", "123")
+    val liftedAttribute = Attribute.from("user.id", UserId("123"))
+
+    assertEquals(stringAttribute, liftedAttribute)
+  }
+
+  test("use implicit From to add an attribute to a builder") {
+    val builder = Attributes.newBuilder
+
+    builder += userIdKey(UserId("1"))
+    builder ++= userIdKey.maybe(Some(UserId("2")))
+    builder.addOne(Attribute.from(userIdKey, UserId("3")))
+
+    val expected = Attributes(
+      Attribute("user.id", "1"),
+      Attribute("user.id", "2"),
+      Attribute("user.id", "3")
+    )
+
+    assertEquals(builder.result(), expected)
+  }
+
+}


### PR DESCRIPTION
### Motivation 

Users would like to use a newtype/opaque types as an attribute. Currently, the API is cumbersome:
```scala
case class UserId(id: Int)
val id = UserId(1)
span.addAttribute(Attribute("id", id.value.toLong))
```

But we can make it more usable via `Attribute.From`:
```scala
case class UserId(id: Int)
implicit val userIdFrom: Attribute.From[UserId, Long] = _.id.toLong

val id = UserId(1)
span.addAttribute(Attribute.from("id", id))
```

### Why don't we implement `AttributeKey#contramap`?

According to the [specification](https://opentelemetry.io/docs/specs/otel/common/#attribute) the attribute value must always be one of: string, boolean, double, long, and array variants. 
So, we can't have the `Attribute[UserId]`.

_____

From the implementation standpoint, the definition is detached from the materialization. 

There are 4 components:
- [AttributeType](https://github.com/typelevel/otel4s/blob/main/core/common/src/main/scala/org/typelevel/otel4s/AttributeType.scala) - represents the attribute type (bool, string, double, bool arr, bool string, etc)|
- [AttributeKey](https://github.com/typelevel/otel4s/blob/main/core/common/src/main/scala/org/typelevel/otel4s/AttributeKey.scala) - name with type
- [Attribute](https://github.com/typelevel/otel4s/blob/main/core/common/src/main/scala/org/typelevel/otel4s/Attribute.scala) - key + value
- [Attributes](https://github.com/typelevel/otel4s/blob/main/core/common/src/main/scala/org/typelevel/otel4s/Attributes.scala) - collection of Attribute (type is erased)

Since the type is erased, we rely on the `attribute.key.type` to do unsafe conversions: https://github.com/typelevel/otel4s/blob/main/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/AttributeConverters.scala#L112.

On top of that, the relationship between `io.opentelemetry.api.common.AttributeKey/Type` and `org.typelevel.otel4s.common.AttributeKey/Type` must be isomorphic. 

Therefore, although we can implement `AttributeKey[X]` for arbitrary types, we cannot translate it into its Java counterpart without shenanigans.

For example, we can implement `JAttributeType` as:
```scala
case class UserId(id: Int)

val key = new JAttributeKey[UserId] {
  def getKey: String = "key"
  def getType: JAttributeType = JAttributeType.STRING
}

val att = JAttributes.of(key, UserId(1))
```

However, a span or metric exporter will fail while exporting such an attribute because it will try to cast `UserId` as `String`.