### PR TITLE
core-common: add `AttributeKey.Make`

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/Attribute.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/Attribute.scala
@@ -77,14 +77,25 @@ object Attribute {
     * val boolSeqAttribute: Attribute[Seq[Boolean]] = Attribute("key", Seq(false))
     *   }}}
     *
+    * @example
+    *   a projected attribute type:
+    *   {{{
+    * case class UserId(id: Int)
+    * implicit val userIdKeySelect: AttributeKey.Focus[UserId, Long] = _.id.toLong
+    * val attribute: Attribute[Long] = Attribute("key", UserId(1))
+    *   }}}
+    *
     * @param name
     *   the key name of an attribute
     *
     * @param value
     *   the value of an attribute
     */
-  def apply[A: AttributeKey.KeySelect](name: String, value: A): Attribute[A] =
-    Impl(AttributeKey.KeySelect[A].make(name), value)
+  def apply[A, Key](name: String, value: A)(implicit
+      focus: AttributeKey.Focus[A, Key],
+      select: AttributeKey.KeySelect[Key]
+  ): Attribute[Key] =
+    AttributeKey.KeySelect[Key].make(name).apply(value)
 
   implicit val showAttribute: Show[Attribute[_]] = (a: Attribute[_]) => s"${show"${a.key}"}=${a.value}"
 

--- a/core/common/src/main/scala/org/typelevel/otel4s/Attributes.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/Attributes.scala
@@ -50,7 +50,10 @@ sealed trait Attributes
   /** Adds an [[`Attribute`]] with the given name and value to these `Attributes`, replacing any `Attribute` with the
     * same name and type if one exists.
     */
-  final def added[T: KeySelect](name: String, value: T): Attributes =
+  final def added[T, Key](name: String, value: T)(implicit
+      focus: AttributeKey.Focus[T, Key],
+      select: KeySelect[Key]
+  ): Attributes =
     added(Attribute(name, value))
 
   /** Adds an [[`Attribute`]] with the given key and value to these `Attributes`, replacing any `Attribute` with the
@@ -204,9 +207,12 @@ object Attributes extends SpecificIterableFactory[Attribute[_], Attributes] {
       * @param value
       *   the value of the attribute
       */
-    def addOne[A: KeySelect](name: String, value: A): this.type = {
-      val key = KeySelect[A].make(name)
-      builder.addOne(key.name -> Attribute(key, value))
+    def addOne[A, Key](name: String, value: A)(implicit
+        focus: AttributeKey.Focus[A, Key],
+        select: KeySelect[Key]
+    ): this.type = {
+      val key = KeySelect[Key].make(name)
+      builder.addOne(key.name -> key(value))
       this
     }
 

--- a/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+
+import munit.FunSuite
+
+class AttributeSuite extends FunSuite {
+
+  private case class UserId(id: String)
+  private val userIdKey: AttributeKey[String] = AttributeKey("user.id")
+  private implicit val userIdFocus: AttributeKey.Focus[UserId, String] = _.id
+
+  test("use implicit Focus to derive a type of an attribute") {
+    val stringAttribute = Attribute("user.id", "123")
+    val liftedAttribute = Attribute("user.id", UserId("123"))
+
+    assertEquals(stringAttribute, liftedAttribute)
+  }
+
+  test("use implicit Focus to add an attribute to a builder") {
+    val builder = Attributes.newBuilder
+
+    builder += userIdKey(UserId("1"))
+    builder ++= userIdKey.maybe(Some(UserId("2")))
+    builder.addOne("user.id", UserId("3"))
+
+    val expected = Attributes(
+      Attribute("user.id", "1"),
+      Attribute("user.id", "2"),
+      Attribute("user.id", "3")
+    )
+
+    assertEquals(builder.result(), expected)
+  }
+
+  test("use implicit Focus to add an attribute to attributes") {
+    val attributes = Attributes.empty.added("user.id", UserId("1"))
+
+    assertEquals(attributes.get[String]("user.id").map(_.value), Some("1"))
+  }
+
+}

--- a/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
@@ -53,4 +53,22 @@ class AttributeSuite extends FunSuite {
     assertEquals(attributes.get[String]("user.id").map(_.value), Some("1"))
   }
 
+  test("implicitly materialize an attribute using Attribute.Make") {
+    case class AssetId(id: Int)
+
+    implicit val assetIdFocus: AttributeKey.Focus[AssetId, Long] =
+      _.id.toLong
+
+    implicit val userIdAttribute: Attribute.Make[UserId] =
+      Attribute.Make.named("user.id")
+
+    implicit val assetIdAttribute: Attribute.Make[AssetId] =
+      Attribute.Make.named("asset.id")
+
+    val attributes = Attributes(UserId("321"), AssetId(123))
+
+    assertEquals(attributes.get[String]("user.id").map(_.value), Some("321"))
+    assertEquals(attributes.get[Long]("asset.id").map(_.value), Some(123L))
+  }
+
 }

--- a/oteljava/all/src/test/scala/org/typelevel/otel4s/oteljava/metrics/ObservableSuite.scala
+++ b/oteljava/all/src/test/scala/org/typelevel/otel4s/oteljava/metrics/ObservableSuite.scala
@@ -144,7 +144,7 @@ class ObservableSuite extends CatsEffectSuite {
           .withUnit("unit")
           .withDescription("description")
           .createWithCallback(
-            _.record(1234, Attribute[Boolean]("is_false", true))
+            _.record(1234, Attribute("is_false", true))
           )
           .use(_ =>
             sdk


### PR DESCRIPTION
The PR is based on https://github.com/typelevel/otel4s/pull/911. 

### Motivation

Many codebases utilize newtype/opaque types for type safety. When converted to attributes, some entities must always use the same name. 

With `Attribute.Make` the conversion process can be simplified. 
____

### Example

The model definition:
```scala
case class UserId(id: Int)

object UserId {
  implicit val userIdFocus: AttributeKey.Focus[UserId, Long] =
    _.id.toLong
    
  implicit val userIdAttribute: Attribute.Make[UserId] =
    Attribute.Make.named("user.id")
}
```

#### Before

```scala
def findUser(userId: UserId): F[Unit] = 
  Tracer[F].span("findUser", Attribute("user.id", userId.id.toLong))

```

#### After

```scala
def findUser(userId: UserId): F[Unit] = 
  Tracer[F].span("findUser", userId)
```




