### PR TITLE
core-common: add `Attribute.Make`

### DIFF
--- a/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/AttributeSuite.scala
@@ -47,4 +47,28 @@ class AttributeSuite extends FunSuite {
     assertEquals(builder.result(), expected)
   }
 
+  test("use implicit Attribute.Make to create an attribute") {
+    case class AssetId(id: Int)
+
+    val assetIdKey: AttributeKey[Long] = AttributeKey("asset.id")
+
+    implicit val assetIdFrom: Attribute.From[AssetId, Long] =
+      _.id.toLong
+
+    implicit val userIdAttributeMake: Attribute.Make[UserId, String] =
+      Attribute.Make.const("user.id")
+
+    implicit val assetIdAttributeMake: Attribute.Make[AssetId, Long] =
+      Attribute.Make.const(assetIdKey)
+
+    val builder = Attributes.newBuilder
+    builder += Attribute.from(UserId("321"))
+    builder ++= Option(Attribute.from(AssetId(123)))
+
+    val attributes = builder.result()
+
+    assertEquals(attributes.get[String]("user.id").map(_.value), Some("321"))
+    assertEquals(attributes.get[Long]("asset.id").map(_.value), Some(123L))
+  }
+
 }


### PR DESCRIPTION
### Motivation

Many codebases utilize newtype/opaque types for type safety. When converted to attributes, some entities must always use the same name. 

With `Attribute.Make` the conversion process can be simplified. 
____

### Example

The model definition:
```scala
case class UserId(id: Int)

object UserId {
  implicit val userIdAttributeFrom: Attribute.From[UserId, Long] =
    _.id.toLong
    
  implicit val userIdAttributeMake: Attribute.Make[UserId, Long] =
    Attribute.Make.const("user.id")
}
```

#### Before

```scala
def findUser(userId: UserId): F[Unit] = 
  Tracer[F].span("findUser", Attribute("user.id", userId.id.toLong))

```

#### After

```scala
def findUser(userId: UserId): F[Unit] = 
  Tracer[F].span("findUser", Attribute.from(userId))
```




