### PR TITLE
sdk trace: remove `exception.escaped` attribute

### DIFF
--- a/buildscripts/semantic-convention/templates/registry/otel4s/attributes/weaver.yaml
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/attributes/weaver.yaml
@@ -1,6 +1,6 @@
 params:
   excluded_namespaces: ["ios", "aspnetcore", "signalr", "dotnet"]
-  excluded_attributes: ["messaging.client_id"]
+  excluded_attributes: ["messaging.client_id", "exception.escaped"]
   object_prefix: "" # stable - "", experimental - "Experimental"
   stable_only: true # stable - true, experimental - false
 comment_formats:

--- a/buildscripts/semantic-convention/templates/registry/otel4s/metrics-tests/weaver.yaml
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/metrics-tests/weaver.yaml
@@ -1,6 +1,6 @@
 params:
   excluded_namespaces: ["ios", "aspnetcore", "signalr", "kestrel", "veightjs", "go", "dotnet"]
-  excluded_attributes: ["messaging.client_id"]
+  excluded_attributes: ["messaging.client_id", "exception.escaped"]
   object_prefix: "" # stable - "", experimental - "Experimental"
   stable_only: true # stable - true, experimental - false
 comment_formats:

--- a/buildscripts/semantic-convention/templates/registry/otel4s/metrics/weaver.yaml
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/metrics/weaver.yaml
@@ -1,6 +1,6 @@
 params:
   excluded_namespaces: ["ios", "aspnetcore", "signalr", "kestrel", "veightjs", "go", "dotnet"]
-  excluded_attributes: ["messaging.client_id"]
+  excluded_attributes: ["messaging.client_id", "exception.escaped"]
   object_prefix: "" # stable - "", experimental - "Experimental"
   stable_only: true # stable - true, experimental - false
 comment_formats:

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
@@ -90,12 +90,10 @@ class SdkTracerSuite extends BaseTracerSuite[Context, Context.Key] {
       EventData.fromException(
         timestamp = timestamp,
         exception = exception,
-        attributes = LimitedData
-          .attributes(
-            SpanLimits.default.maxNumberOfAttributesPerEvent,
-            SpanLimits.default.maxAttributeValueLength
-          ),
-        escaped = false
+        attributes = LimitedData.attributes(
+          SpanLimits.default.maxNumberOfAttributesPerEvent,
+          SpanLimits.default.maxAttributeValueLength
+        )
       )
 
     TestControl.executeEmbed {

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -154,8 +154,7 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
               spanLimits.maxNumberOfAttributesPerEvent,
               spanLimits.maxAttributeValueLength
             )
-            .appendAll(attributes.to(Attributes)),
-          escaped = false
+            .appendAll(attributes.to(Attributes))
         )
       )
     } yield ()

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/EventData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/EventData.scala
@@ -94,17 +94,11 @@ object EventData {
     *
     * @param attributes
     *   the attributes to associate with the event
-    *
-    * @param escaped
-    *   should be set to true if the exception is recorded at a point where it is known that the exception is escaping
-    *   the scope of the span
     */
-  @annotation.nowarn
   def fromException(
       timestamp: FiniteDuration,
       exception: Throwable,
-      attributes: LimitedData[Attribute[_], Attributes],
-      escaped: Boolean
+      attributes: LimitedData[Attribute[_], Attributes]
   ): EventData = {
     val exceptionAttributes = {
       val builder = Attributes.newBuilder
@@ -130,7 +124,6 @@ object EventData {
         )
       }
 
-      builder.addOne(ExceptionAttributes.ExceptionEscaped, escaped)
       builder.result()
     }
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -163,8 +163,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
             spanLimits.maxNumberOfAttributesPerEvent,
             spanLimits.maxAttributeValueLength
           )
-          .appendAll(attributes),
-        escaped = false
+          .appendAll(attributes)
       )
 
       TestControl.executeEmbed {

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
@@ -65,8 +65,7 @@ class EventDataSuite extends DisciplineSuite {
       val expectedAttributes = Attributes(
         Attribute("exception.type", exception.getClass.getName),
         Attribute("exception.message", exception.getMessage),
-        Attribute("exception.stacktrace", stringWriter.toString),
-        Attribute("exception.escaped", true)
+        Attribute("exception.stacktrace", stringWriter.toString)
       ) |+| attributes
 
       val data =
@@ -78,8 +77,7 @@ class EventDataSuite extends DisciplineSuite {
               SpanLimits.default.maxNumberOfAttributesPerEvent,
               SpanLimits.default.maxAttributeValueLength
             )
-            .appendAll(attributes),
-          escaped = true
+            .appendAll(attributes)
         )
 
       assertEquals(data.name, "exception")
@@ -97,8 +95,7 @@ class EventDataSuite extends DisciplineSuite {
       exception.printStackTrace(printWriter)
 
       val expectedAttributes = Attributes(
-        Attribute("exception.type", exception.getClass.getName),
-        Attribute("exception.escaped", false)
+        Attribute("exception.type", exception.getClass.getName)
       ) |+| attributes
 
       val data =
@@ -110,8 +107,7 @@ class EventDataSuite extends DisciplineSuite {
               SpanLimits.default.maxNumberOfAttributesPerEvent,
               SpanLimits.default.maxAttributeValueLength
             )
-            .appendAll(attributes),
-          escaped = false
+            .appendAll(attributes)
         )
 
       assertEquals(data.name, "exception")

--- a/semconv/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/attributes/ExceptionExperimentalAttributes.scala
+++ b/semconv/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/attributes/ExceptionExperimentalAttributes.scala
@@ -21,15 +21,6 @@ package experimental.attributes
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/attributes/SemanticAttributes.scala.j2
 object ExceptionExperimentalAttributes {
 
-  /** Indicates that the exception is escaping the scope of the span.
-    */
-  @deprecated(
-    "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span.",
-    ""
-  )
-  val ExceptionEscaped: AttributeKey[Boolean] =
-    AttributeKey("exception.escaped")
-
   /** The exception message.
     */
   @deprecated(

--- a/semconv/stable/src/main/scala/org/typelevel/otel4s/semconv/attributes/ExceptionAttributes.scala
+++ b/semconv/stable/src/main/scala/org/typelevel/otel4s/semconv/attributes/ExceptionAttributes.scala
@@ -21,15 +21,6 @@ package attributes
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/attributes/SemanticAttributes.scala.j2
 object ExceptionAttributes {
 
-  /** Indicates that the exception is escaping the scope of the span.
-    */
-  @deprecated(
-    "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span.",
-    ""
-  )
-  val ExceptionEscaped: AttributeKey[Boolean] =
-    AttributeKey("exception.escaped")
-
   /** The exception message.
     */
   val ExceptionMessage: AttributeKey[String] =


### PR DESCRIPTION
The `exception.escaped` attribute is deprecated: 
- https://opentelemetry.io/docs/specs/semconv/attributes-registry/exception/#deprecated-exception-attributes
- https://github.com/open-telemetry/semantic-conventions/pull/1716

Also, OpenTelemetry Java doesn't use this attribute too: https://github.com/open-telemetry/opentelemetry-java/blob/v1.47.0/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpan.java#L469-L504.

