### PR TITLE
oteljava-context-storage: update agent instrumentation direction

### DIFF
--- a/oteljava/context-storage/src/main/scala/org/typelevel/otel4s/oteljava/context/IOLocalContextStorage.scala
+++ b/oteljava/context-storage/src/main/scala/org/typelevel/otel4s/oteljava/context/IOLocalContextStorage.scala
@@ -97,7 +97,7 @@ object IOLocalContextStorage {
                 F.raiseError(
                   new IllegalStateException(
                     "IOLocalContextStorage is not configured for use as the ContextStorageProvider. " +
-                      s"The current storage: ${other.getClass.getName}."
+                      s"The current ContextStorage is: ${other.getClass.getName}"
                   )
                 )
             }


### PR DESCRIPTION
Eventually, we will instrument `getAgentLocalContext` by the OTeL Agent. 

That's how it is supposed to work: https://github.com/iRevive/opentelemetry-java-instrumentation/blob/b2f6501ec980194d0cb56f36d6bcc83c1d1b3b0b/instrumentation/otel4s/otel4s-0.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otel4s/v0_12/IoLocalContextStorageInstrumentation.java#L27-L42.