### PR TITLE
Dynamic instrument meta (enabled/disabled status)

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
@@ -20,9 +20,6 @@ import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
 import org.openjdk.jmh.annotations._
-import org.typelevel.otel4s.trace.{SpanBuilder, SpanContext, Tracer}
-import java.util.concurrent.TimeUnit
-
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.SpanBuilder
 import org.typelevel.otel4s.trace.SpanContext

--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
@@ -20,6 +20,9 @@ import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
 import org.openjdk.jmh.annotations._
+import org.typelevel.otel4s.trace.{SpanBuilder, SpanContext, Tracer}
+import java.util.concurrent.TimeUnit
+
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.SpanBuilder
 import org.typelevel.otel4s.trace.SpanContext

--- a/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -33,7 +33,8 @@ object InstrumentMeta {
       */
     def unit: F[Unit]
 
-    // todo: define Scala 3 version and use inline transparent
+    /** Runs `f` only when the instrument is enabled. A shortcut for `Monad[F].ifM(isEnabled)(f, unit)`.
+      */
     def whenEnabled(f: => F[Unit]): F[Unit]
 
     /** Modify the context `F` using the transformation `f`. */
@@ -47,6 +48,13 @@ object InstrumentMeta {
   }
 
   object Dynamic {
+
+    private[otel4s] def from[F[_]: Monad](enabled: F[Boolean]): Dynamic[F] =
+      new Dynamic[F] {
+        def isEnabled: F[Boolean] = enabled
+        def unit: F[Unit] = Monad[F].unit
+        def whenEnabled(f: => F[Unit]): F[Unit] = Monad[F].ifM(isEnabled)(f, unit)
+      }
 
     private[otel4s] def enabled[F[_]: Applicative]: Dynamic[F] =
       new Dynamic[F] {

--- a/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -16,7 +16,9 @@
 
 package org.typelevel.otel4s.meta
 
-import cats.{Applicative, Monad, ~>}
+import cats.Applicative
+import cats.Monad
+import cats.~>
 import org.typelevel.otel4s.KindTransformer
 
 object InstrumentMeta {

--- a/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -16,46 +16,56 @@
 
 package org.typelevel.otel4s.meta
 
-import cats.Applicative
-import cats.~>
+import cats.{Applicative, Monad, ~>}
 import org.typelevel.otel4s.KindTransformer
 
-trait InstrumentMeta[F[_]] {
+sealed trait InstrumentMeta[F[_]] {
 
   /** Indicates whether instrumentation is enabled or not.
     */
-  def isEnabled: Boolean
+  def isEnabled: F[Boolean]
 
   /** A no-op effect.
     */
   def unit: F[Unit]
 
+  def ifEnabled(f: F[Unit]): F[Unit]
+
   /** Modify the context `F` using the transformation `f`. */
-  def mapK[G[_]](f: F ~> G): InstrumentMeta[G] =
+  def mapK[G[_]: Monad](f: F ~> G): InstrumentMeta[G] =
     new InstrumentMeta.MappedK(this)(f)
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]](implicit kt: KindTransformer[F, G]): InstrumentMeta[G] =
+  def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): InstrumentMeta[G] =
     mapK(kt.liftK)
 }
 
 object InstrumentMeta {
 
-  def enabled[F[_]: Applicative]: InstrumentMeta[F] =
-    make(enabled = true)
+  sealed trait Static[F[_]] {
+    def isEnabled: Boolean
+  }
 
-  def disabled[F[_]: Applicative]: InstrumentMeta[F] =
-    make(enabled = false)
-
-  private def make[F[_]: Applicative](enabled: Boolean): InstrumentMeta[F] =
+  @deprecated("use derived version", "0.12")
+  def enabled[F[_]: Monad]: InstrumentMeta[F] =
     new InstrumentMeta[F] {
-      val isEnabled: Boolean = enabled
-      val unit: F[Unit] = Applicative[F].unit
+      val isEnabled: F[Boolean] = Monad[F].pure(true)
+      val unit: F[Unit] = Monad[F].unit
+      val monad: Monad[F] = Monad[F]
+      def ifEnabled(f: F[Unit]): F[Unit] = monad.ifM(isEnabled)(f, unit)
     }
 
-  private class MappedK[F[_], G[_]](meta: InstrumentMeta[F])(f: F ~> G) extends InstrumentMeta[G] {
-    def isEnabled: Boolean = meta.isEnabled
+  def disabled[F[_]: Applicative]: InstrumentMeta[F] =
+    new InstrumentMeta[F] {
+      val isEnabled: F[Boolean] = Applicative[F].pure(false)
+      val unit: F[Unit] = Applicative[F].unit
+      def ifEnabled(f: F[Unit]): F[Unit] = unit
+    }
+
+  private class MappedK[F[_], G[_]: Monad](meta: InstrumentMeta[F])(f: F ~> G) extends InstrumentMeta[G] {
+    def isEnabled: G[Boolean] = f(meta.isEnabled)
     def unit: G[Unit] = f(meta.unit)
+    def ifEnabled(f: G[Unit]): G[Unit] = Monad[G].ifM(isEnabled)(f, Monad[G].unit)
   }
 }

--- a/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -21,15 +21,16 @@ import org.typelevel.otel4s.KindTransformer
 
 sealed trait InstrumentMeta[F[_]] {
 
-  /** Indicates whether instrumentation is enabled or not.
-    */
   def isEnabled: F[Boolean]
 
   /** A no-op effect.
     */
   def unit: F[Unit]
 
-  def ifEnabled(f: F[Unit]): F[Unit]
+  // todo: define Scala 3 version and use inline transparent
+  def whenEnabled(f: => F[Unit]): F[Unit]
+
+  def whenEnabledOrElse[A](whenEnabled: => F[A], whenDisabled: => F[A]): F[A]
 
   /** Modify the context `F` using the transformation `f`. */
   def mapK[G[_]: Monad](f: F ~> G): InstrumentMeta[G] =
@@ -43,8 +44,45 @@ sealed trait InstrumentMeta[F[_]] {
 
 object InstrumentMeta {
 
-  sealed trait Static[F[_]] {
-    def isEnabled: Boolean
+  sealed trait Dynamic[F[_]] extends InstrumentMeta[F] {
+    /** Indicates whether instrumentation is enabled or not.
+     */
+    def isEnabled: F[Boolean]
+  }
+
+  sealed trait Static[F[_]] extends InstrumentMeta[F] {
+    /** Indicates whether instrumentation is enabled or not.
+     */
+    def isEnabledSync: Boolean
+
+    /** Modify the context `F` using the transformation `f`. */
+    override def mapK[G[_]: Monad](f: F ~> G): InstrumentMeta.Static[G] =
+      new Static.MappedK(this)(f)
+
+    /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
+     */
+    override def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): InstrumentMeta.Static[G] =
+      mapK(kt.liftK)
+  }
+
+  object Static {
+    def disabled[F[_]: Applicative]: Static[F] =
+      new Static[F] {
+        val isEnabledSync: Boolean = false
+        val isEnabled: F[Boolean] = Applicative[F].pure(false)
+        val unit: F[Unit] = Applicative[F].unit
+        def whenEnabled(f: => F[Unit]): F[Unit] = unit
+        def whenEnabledOrElse[A](whenEnabled: => F[A], whenDisabled: => F[A]): F[A] = whenDisabled
+      }
+
+    private class MappedK[F[_], G[_]: Monad](meta: Static[F])(f: F ~> G) extends Static[G] {
+      def isEnabledSync: Boolean = meta.isEnabledSync
+      def isEnabled: G[Boolean] = f(meta.isEnabled)
+      def unit: G[Unit] = f(meta.unit)
+      def whenEnabled(f: => G[Unit]): G[Unit] = Monad[G].ifM(isEnabled)(f, Monad[G].unit)
+      def whenEnabledOrElse[A](whenEnabled: => G[A], whenDisabled: => G[A]): G[A] =
+        Monad[G].ifM(isEnabled)(whenEnabled, whenDisabled)
+    }
   }
 
   @deprecated("use derived version", "0.12")
@@ -53,19 +91,24 @@ object InstrumentMeta {
       val isEnabled: F[Boolean] = Monad[F].pure(true)
       val unit: F[Unit] = Monad[F].unit
       val monad: Monad[F] = Monad[F]
-      def ifEnabled(f: F[Unit]): F[Unit] = monad.ifM(isEnabled)(f, unit)
+      def whenEnabled(f: => F[Unit]): F[Unit] = monad.ifM(isEnabled)(f, unit)
+      def whenEnabledOrElse[A](whenEnabled: => F[A], whenDisabled: => F[A]): F[A] =
+        monad.ifM(isEnabled)(whenEnabled, whenDisabled)
     }
 
   def disabled[F[_]: Applicative]: InstrumentMeta[F] =
     new InstrumentMeta[F] {
       val isEnabled: F[Boolean] = Applicative[F].pure(false)
       val unit: F[Unit] = Applicative[F].unit
-      def ifEnabled(f: F[Unit]): F[Unit] = unit
+      def whenEnabled(f: => F[Unit]): F[Unit] = unit
+      def whenEnabledOrElse[A](whenEnabled: => F[A], whenDisabled: => F[A]): F[A] = whenDisabled
     }
 
   private class MappedK[F[_], G[_]: Monad](meta: InstrumentMeta[F])(f: F ~> G) extends InstrumentMeta[G] {
     def isEnabled: G[Boolean] = f(meta.isEnabled)
     def unit: G[Unit] = f(meta.unit)
-    def ifEnabled(f: G[Unit]): G[Unit] = Monad[G].ifM(isEnabled)(f, Monad[G].unit)
+    def whenEnabled(f: => G[Unit]): G[Unit] = Monad[G].ifM(isEnabled)(f, Monad[G].unit)
+    def whenEnabledOrElse[A](whenEnabled: => G[A], whenDisabled: => G[A]): G[A] =
+      Monad[G].ifM(isEnabled)(whenEnabled, whenDisabled)
   }
 }

--- a/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
@@ -20,15 +20,15 @@ import munit.FunSuite
 
 class InstrumentMetaSuite extends FunSuite {
 
-  test("enabled") {
-    val enabled = InstrumentMeta.enabled[cats.Id]
+  test("static - enabled") {
+    val enabled = InstrumentMeta.Static.enabled[cats.Id]
 
     assertEquals(enabled.unit, ())
     assertEquals(enabled.isEnabled, true)
   }
 
-  test("disabled") {
-    val disabled = InstrumentMeta.disabled[cats.Id]
+  test("static - disabled") {
+    val disabled = InstrumentMeta.Static.disabled[cats.Id]
 
     assertEquals(disabled.unit, ())
     assertEquals(disabled.isEnabled, false)

--- a/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
@@ -21,10 +21,10 @@ import munit.FunSuite
 class InstrumentMetaSuite extends FunSuite {
 
   test("enabled") {
-    val disabled = InstrumentMeta.enabled[cats.Id]
+    val enabled = InstrumentMeta.enabled[cats.Id]
 
-    assertEquals(disabled.unit, ())
-    assertEquals(disabled.isEnabled, true)
+    assertEquals(enabled.unit, ())
+    assertEquals(enabled.isEnabled, true)
   }
 
   test("disabled") {

--- a/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/meta/InstrumentMetaSuite.scala
@@ -54,4 +54,22 @@ class InstrumentMetaSuite extends CatsEffectSuite {
       _ <- assertIO(IO.ref(false).flatMap(r => meta.whenEnabled(r.set(true)) >> r.get), false)
     } yield ()
   }
+
+  test("dynamic - from") {
+    for {
+      enabled <- IO.ref(false)
+      meta = InstrumentMeta.Dynamic.from[IO](enabled.get)
+
+      // disabled
+      _ <- assertIO_(meta.unit)
+      _ <- assertIO(meta.isEnabled, false)
+      _ <- assertIO(IO.ref(false).flatMap(r => meta.whenEnabled(r.set(true)) >> r.get), false)
+
+      // enabled
+      _ <- enabled.set(true)
+      _ <- assertIO_(meta.unit)
+      _ <- assertIO(meta.isEnabled, true)
+      _ <- assertIO(IO.ref(false).flatMap(r => meta.whenEnabled(r.set(true)) >> r.get), true)
+    } yield ()
+  }
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/CounterMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/CounterMacro.scala
@@ -81,7 +81,7 @@ object CounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.add($value, $attributes))"
+    q"$meta.whenEnabled($backend.add($value, $attributes))"
   }
 
   def inc(c: blackbox.Context)(
@@ -98,7 +98,7 @@ object CounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.inc($attributes))"
+    q"$meta.whenEnabled($backend.inc($attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/CounterMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/CounterMacro.scala
@@ -81,7 +81,7 @@ object CounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.add($value, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.add($value, $attributes))"
   }
 
   def inc(c: blackbox.Context)(
@@ -98,7 +98,7 @@ object CounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.inc($attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.inc($attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -65,7 +65,7 @@ object GaugeMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.record($value, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.record($value, $attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -65,7 +65,7 @@ object GaugeMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.record($value, $attributes))"
+    q"$meta.whenEnabled($backend.record($value, $attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -153,7 +153,7 @@ object HistogramMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.record($value, $attributes))"
+    q"$meta.whenEnabled($backend.record($value, $attributes))"
   }
 
   def recordDuration(c: blackbox.Context)(

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -153,7 +153,7 @@ object HistogramMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.record($value, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.record($value, $attributes))"
   }
 
   def recordDuration(c: blackbox.Context)(
@@ -172,7 +172,12 @@ object HistogramMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.recordDuration($timeUnit, _ => $attributes) else _root_.cats.effect.kernel.Resource.unit"
+    q"""
+       _root_.cats.effect.kernel.Resource.eval($meta.isEnabled).flatMap { isEnabled =>
+         if (isEnabled) $backend.recordDuration($timeUnit, _ => $attributes)
+         else _root_.cats.effect.kernel.Resource.unit
+       }
+     """
   }
 
   def recordDurationFuncColl(c: blackbox.Context)(
@@ -183,7 +188,12 @@ object HistogramMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.recordDuration($timeUnit, $attributes) else _root_.cats.effect.kernel.Resource.unit"
+    q"""
+       _root_.cats.effect.kernel.Resource.eval($meta.isEnabled).flatMap { isEnabled =>
+         if (isEnabled) $backend.recordDuration($timeUnit, $attributes)
+         else _root_.cats.effect.kernel.Resource.unit
+       }
+     """
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -97,7 +97,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.add($value, $attributes))"
+    q"$meta.whenEnabled($backend.add($value, $attributes))"
   }
 
   def inc(c: blackbox.Context)(
@@ -114,7 +114,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.inc($attributes))"
+    q"$meta.whenEnabled($backend.inc($attributes))"
   }
 
   def dec(c: blackbox.Context)(
@@ -131,7 +131,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.dec($attributes))"
+    q"$meta.whenEnabled($backend.dec($attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-2/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -97,7 +97,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.add($value, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.add($value, $attributes))"
   }
 
   def inc(c: blackbox.Context)(
@@ -114,7 +114,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.inc($attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.inc($attributes))"
   }
 
   def dec(c: blackbox.Context)(
@@ -131,7 +131,7 @@ object UpDownCounterMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.dec($attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.dec($attributes))"
   }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/CounterMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/CounterMacro.scala
@@ -73,12 +73,12 @@ object CounterMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.add($value, $attributes)) }
+    '{ $backend.meta.whenEnabled($backend.add($value, $attributes)) }
 
   def inc[F[_], A](
       backend: Expr[Counter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.inc($attributes)) }
+    '{ $backend.meta.whenEnabled($backend.inc($attributes)) }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/CounterMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/CounterMacro.scala
@@ -73,18 +73,12 @@ object CounterMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.add($value, $attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.add($value, $attributes)) }
 
   def inc[F[_], A](
       backend: Expr[Counter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.inc($attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.inc($attributes)) }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -60,9 +60,6 @@ object GaugeMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.record($value, $attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.record($value, $attributes)) }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/GaugeMacro.scala
@@ -60,6 +60,6 @@ object GaugeMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.record($value, $attributes)) }
+    '{ $backend.meta.whenEnabled($backend.record($value, $attributes)) }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/HistogramMacro.scala
@@ -147,7 +147,7 @@ object HistogramMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.record($value, $attributes)) }
+    '{ $backend.meta.whenEnabled($backend.record($value, $attributes)) }
 
   def recordDuration[F[_], A](
       backend: Expr[Histogram.Backend[F, A]],

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -89,27 +89,18 @@ object UpDownCounterMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.add($value, $attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.add($value, $attributes)) }
 
   def inc[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.inc($attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.inc($attributes)) }
 
   def dec[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{
-      if ($backend.meta.isEnabled) $backend.dec($attributes)
-      else $backend.meta.unit
-    }
+    '{ $backend.meta.ifEnabled($backend.dec($attributes)) }
 
 }

--- a/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
+++ b/core/metrics/src/main/scala-3/org/typelevel/otel4s/metrics/UpDownCounterMacro.scala
@@ -89,18 +89,18 @@ object UpDownCounterMacro {
       value: Expr[A],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.add($value, $attributes)) }
+    '{ $backend.meta.whenEnabled($backend.add($value, $attributes)) }
 
   def inc[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.inc($attributes)) }
+    '{ $backend.meta.whenEnabled($backend.inc($attributes)) }
 
   def dec[F[_], A](
       backend: Expr[UpDownCounter.Backend[F, A]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F], Type[A]) =
-    '{ $backend.meta.ifEnabled($backend.dec($attributes)) }
+    '{ $backend.meta.whenEnabled($backend.dec($attributes)) }
 
 }

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Counter.scala
@@ -77,7 +77,7 @@ object Counter {
   }
 
   trait Backend[F[_], A] {
-    def meta: InstrumentMeta[F]
+    def meta: InstrumentMeta.Dynamic[F]
 
     /** Records a value with a set of attributes.
       *
@@ -101,7 +101,7 @@ object Counter {
     new Counter[F, A] {
       val backend: Backend[F, A] =
         new Backend[F, A] {
-          val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+          val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
           def add(
               value: A,
               attributes: immutable.Iterable[Attribute[_]]

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Gauge.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Gauge.scala
@@ -78,7 +78,7 @@ object Gauge {
   }
 
   trait Backend[F[_], A] {
-    def meta: InstrumentMeta[F]
+    def meta: InstrumentMeta.Dynamic[F]
 
     /** Records a value with a set of attributes.
       *
@@ -96,7 +96,7 @@ object Gauge {
     new Gauge[F, A] {
       val backend: Backend[F, A] =
         new Backend[F, A] {
-          val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+          val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
           def record(
               value: A,
               attributes: immutable.Iterable[Attribute[_]]

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Histogram.scala
@@ -89,7 +89,7 @@ object Histogram {
   }
 
   trait Backend[F[_], A] {
-    def meta: InstrumentMeta[F]
+    def meta: InstrumentMeta.Dynamic[F]
 
     /** Records a value with a set of attributes.
       *
@@ -130,7 +130,7 @@ object Histogram {
     new Histogram[F, A] {
       val backend: Backend[F, A] =
         new Backend[F, A] {
-          val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+          val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
           def record(
               value: A,
               attributes: immutable.Iterable[Attribute[_]]

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/Meter.scala
@@ -18,6 +18,7 @@ package org.typelevel.otel4s.metrics
 
 import cats.Applicative
 import cats.effect.kernel.Resource
+import org.typelevel.otel4s.meta.InstrumentMeta
 
 @annotation.implicitNotFound("""
 Could not find the `Meter` for ${F}. `Meter` can be one of the following:
@@ -34,6 +35,10 @@ meterProvider
   .flatMap { implicit meter: Meter[IO] => ??? }
 """)
 trait Meter[F[_]] {
+
+  /** The instrument's metadata. Indicates whether instrumentation is enabled.
+    */
+  def meta: InstrumentMeta.Dynamic[F]
 
   /** Creates a builder of [[Counter]] instrument that records values of type `A`.
     *
@@ -300,6 +305,8 @@ object Meter {
     */
   def noop[F[_]](implicit F: Applicative[F]): Meter[F] =
     new Meter[F] {
+      val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
+
       def counter[A: MeasurementValue](
           name: String
       ): Counter.Builder[F, A] =

--- a/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
+++ b/core/metrics/src/main/scala/org/typelevel/otel4s/metrics/UpDownCounter.scala
@@ -77,7 +77,7 @@ object UpDownCounter {
   }
 
   trait Backend[F[_], A] {
-    def meta: InstrumentMeta[F]
+    def meta: InstrumentMeta.Dynamic[F]
 
     /** Records a value with a set of attributes.
       *
@@ -108,7 +108,7 @@ object UpDownCounter {
     new UpDownCounter[F, A] {
       val backend: UpDownCounter.Backend[F, A] =
         new UpDownCounter.Backend[F, A] {
-          val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+          val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
           def add(
               value: A,
               attributes: immutable.Iterable[Attribute[_]]

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/CounterSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/CounterSuite.scala
@@ -99,7 +99,7 @@ object CounterSuite {
 
     val backend: Counter.Backend[IO, Long] =
       new Counter.Backend[IO, Long] {
-        val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
+        val meta: InstrumentMeta.Dynamic[IO] = InstrumentMeta.Dynamic.enabled
 
         def add(
             value: Long,

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/HistogramSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/HistogramSuite.scala
@@ -117,7 +117,7 @@ object HistogramSuite {
 
     val backend: Histogram.Backend[IO, Double] =
       new Histogram.Backend[IO, Double] {
-        val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
+        val meta: InstrumentMeta.Dynamic[IO] = InstrumentMeta.Dynamic.enabled
 
         def record(
             value: Double,

--- a/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
+++ b/core/metrics/src/test/scala/org/typelevel/otel4s/metrics/UpDownCounterSuite.scala
@@ -121,7 +121,7 @@ object UpDownCounterSuite {
 
     val backend: UpDownCounter.Backend[IO, Long] =
       new UpDownCounter.Backend[IO, Long] {
-        val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
+        val meta: InstrumentMeta.Dynamic[IO] = InstrumentMeta.Dynamic.enabled
 
         def add(
             value: Long,

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -263,9 +263,7 @@ object SpanBuilderMacro {
     *
     * That way, we have exactly one if-else statement.
     */
-  private def whenEnabled(
-      c: blackbox.Context
-  )(modify: c.universe.Tree): c.universe.Tree = {
+  private def whenEnabled(c: blackbox.Context)(modify: c.universe.Tree): c.universe.Tree = {
     import c.universe._
 
     object Matchers {
@@ -316,7 +314,8 @@ object SpanBuilderMacro {
            else builder
          """
 
-      case _ =>
+      case other =>
+        println("tree: " + other)
         q"""
            val builder = ${c.prefix}
            if (builder.meta.isEnabled) builder.modifyState($modify)

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -216,7 +216,7 @@ object SpanMacro {
     val meta = q"$backend.meta"
     val scalaList = q"_root_.scala.List"
 
-    q"$meta.whenEnabled($backend.addAttributes($scalaList($attribute)))"
+    q"if ($meta.isEnabled) $backend.addAttributes($scalaList($attribute)) else $meta.unit"
   }
 
   def addAttributes(c: blackbox.Context)(
@@ -239,7 +239,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.addAttributes($attributes))"
+    q"if ($meta.isEnabled) $backend.addAttributes($attributes) else $meta.unit"
   }
 
   def addEvent(c: blackbox.Context)(
@@ -259,7 +259,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.addEvent($name, $attributes))"
+    q"if ($meta.isEnabled) $backend.addEvent($name, $attributes) else $meta.unit"
   }
 
   def addLink(c: blackbox.Context)(
@@ -279,7 +279,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.addLink($spanContext, $attributes))"
+    q"if ($meta.isEnabled) $backend.addLink($spanContext, $attributes) else $meta.unit"
   }
 
   def addEventWithTimestamp(c: blackbox.Context)(
@@ -305,7 +305,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.addEvent($name, $timestamp, $attributes))"
+    q"if ($meta.isEnabled) $backend.addEvent($name, $timestamp, $attributes) else $meta.unit"
   }
 
   def recordException(c: blackbox.Context)(
@@ -328,7 +328,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.recordException($exception, $attributes))"
+    q"if ($meta.isEnabled) $backend.recordException($exception, $attributes) else $meta.unit"
   }
 
   def setStatus(c: blackbox.Context)(
@@ -339,7 +339,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.setStatus($status))"
+    q"if ($meta.isEnabled) $backend.setStatus($status) else $meta.unit"
   }
 
   def setStatusWithDescription(c: blackbox.Context)(
@@ -351,7 +351,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.whenEnabled($backend.setStatus($status, $description))"
+    q"if ($meta.isEnabled) $backend.setStatus($status, $description) else $meta.unit"
   }
 
 }

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -216,7 +216,7 @@ object SpanMacro {
     val meta = q"$backend.meta"
     val scalaList = q"_root_.scala.List"
 
-    q"if ($meta.isEnabled) $backend.addAttributes($scalaList($attribute)) else $meta.unit"
+    q"$meta.ifEnabled($backend.addAttributes($scalaList($attribute)))"
   }
 
   def addAttributes(c: blackbox.Context)(
@@ -239,7 +239,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.addAttributes($attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.addAttributes($attributes))"
   }
 
   def addEvent(c: blackbox.Context)(
@@ -259,7 +259,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.addEvent($name, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.addEvent($name, $attributes))"
   }
 
   def addLink(c: blackbox.Context)(
@@ -279,7 +279,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.addLink($spanContext, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.addLink($spanContext, $attributes))"
   }
 
   def addEventWithTimestamp(c: blackbox.Context)(
@@ -305,7 +305,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.addEvent($name, $timestamp, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.addEvent($name, $timestamp, $attributes))"
   }
 
   def recordException(c: blackbox.Context)(
@@ -328,7 +328,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.recordException($exception, $attributes) else $meta.unit"
+    q"$meta.ifEnabled($backend.recordException($exception, $attributes))"
   }
 
   def setStatus(c: blackbox.Context)(
@@ -339,7 +339,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.setStatus($status) else $meta.unit"
+    q"$meta.ifEnabled($backend.setStatus($status))"
   }
 
   def setStatusWithDescription(c: blackbox.Context)(
@@ -351,7 +351,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"if ($meta.isEnabled) $backend.setStatus($status, $description) else $meta.unit"
+    q"$meta.ifEnabled($backend.setStatus($status, $description))"
   }
 
 }

--- a/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
+++ b/core/trace/src/main/scala-2/org/typelevel/otel4s/trace/SpanMacro.scala
@@ -216,7 +216,7 @@ object SpanMacro {
     val meta = q"$backend.meta"
     val scalaList = q"_root_.scala.List"
 
-    q"$meta.ifEnabled($backend.addAttributes($scalaList($attribute)))"
+    q"$meta.whenEnabled($backend.addAttributes($scalaList($attribute)))"
   }
 
   def addAttributes(c: blackbox.Context)(
@@ -239,7 +239,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.addAttributes($attributes))"
+    q"$meta.whenEnabled($backend.addAttributes($attributes))"
   }
 
   def addEvent(c: blackbox.Context)(
@@ -259,7 +259,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.addEvent($name, $attributes))"
+    q"$meta.whenEnabled($backend.addEvent($name, $attributes))"
   }
 
   def addLink(c: blackbox.Context)(
@@ -279,7 +279,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.addLink($spanContext, $attributes))"
+    q"$meta.whenEnabled($backend.addLink($spanContext, $attributes))"
   }
 
   def addEventWithTimestamp(c: blackbox.Context)(
@@ -305,7 +305,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.addEvent($name, $timestamp, $attributes))"
+    q"$meta.whenEnabled($backend.addEvent($name, $timestamp, $attributes))"
   }
 
   def recordException(c: blackbox.Context)(
@@ -328,7 +328,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.recordException($exception, $attributes))"
+    q"$meta.whenEnabled($backend.recordException($exception, $attributes))"
   }
 
   def setStatus(c: blackbox.Context)(
@@ -339,7 +339,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.setStatus($status))"
+    q"$meta.whenEnabled($backend.setStatus($status))"
   }
 
   def setStatusWithDescription(c: blackbox.Context)(
@@ -351,7 +351,7 @@ object SpanMacro {
     val backend = q"${c.prefix}.backend"
     val meta = q"$backend.meta"
 
-    q"$meta.ifEnabled($backend.setStatus($status, $description))"
+    q"$meta.whenEnabled($backend.setStatus($status, $description))"
   }
 
 }

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -156,8 +156,11 @@ object SpanBuilderMacro {
       builder: Expr[SpanBuilder[F]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F]) =
-    '{
-      $builder.modifyState(_.addAttributes($attributes))
+    (attributes: @unchecked) match {
+      case Varargs(args) if args.isEmpty =>
+        builder
+      case other =>
+        '{ $builder.modifyState(_.addAttributes($attributes)) }
     }
 
   def addLink[F[_]](

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -147,21 +147,18 @@ object SpanBuilderMacro {
   def addAttribute[F[_], A](
       builder: Expr[SpanBuilder[F]],
       attribute: Expr[Attribute[A]]
-  )(using Quotes, Type[F], Type[A]) =
+  )(using Quotes, Type[F], Type[A]) = {
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(_.addAttributes(List($attribute)))
-      else $builder
+      $builder.modifyState(_.addAttributes(List($attribute)))
     }
+  }
 
   def addAttributes[F[_]](
       builder: Expr[SpanBuilder[F]],
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled && $attributes.nonEmpty)
-        $builder.modifyState(_.addAttributes($attributes))
-      else $builder
+      $builder.modifyState(_.addAttributes($attributes))
     }
 
   def addLink[F[_]](
@@ -170,9 +167,7 @@ object SpanBuilderMacro {
       attributes: Expr[immutable.Iterable[Attribute[_]]]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(_.addLink($spanContext, $attributes))
-      else $builder
+      $builder.modifyState(_.addLink($spanContext, $attributes))
     }
 
   def withFinalizationStrategy[F[_]](
@@ -180,9 +175,7 @@ object SpanBuilderMacro {
       strategy: Expr[SpanFinalizer.Strategy]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(_.withFinalizationStrategy($strategy))
-      else $builder
+      $builder.modifyState(_.withFinalizationStrategy($strategy))
     }
 
   def withSpanKind[F[_]](
@@ -190,9 +183,7 @@ object SpanBuilderMacro {
       kind: Expr[SpanKind]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(_.withSpanKind($kind))
-      else $builder
+      $builder.modifyState(_.withSpanKind($kind))
     }
 
   def withStartTimestamp[F[_]](
@@ -200,9 +191,7 @@ object SpanBuilderMacro {
       timestamp: Expr[FiniteDuration]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(_.withStartTimestamp($timestamp))
-      else $builder
+      $builder.modifyState(_.withStartTimestamp($timestamp))
     }
 
   def withParent[F[_]](
@@ -210,14 +199,11 @@ object SpanBuilderMacro {
       parent: Expr[SpanContext]
   )(using Quotes, Type[F]) =
     '{
-      if ($builder.meta.isEnabled)
-        $builder.modifyState(
-          _.withParent(
-            _root_.org.typelevel.otel4s.trace.SpanBuilder.Parent
-              .explicit($parent)
-          )
+      $builder.modifyState(
+        _.withParent(
+          _root_.org.typelevel.otel4s.trace.SpanBuilder.Parent.explicit($parent)
         )
-      else $builder
+      )
     }
 
 }

--- a/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
+++ b/core/trace/src/main/scala-3/org/typelevel/otel4s/trace/SpanBuilderMacro.scala
@@ -147,11 +147,10 @@ object SpanBuilderMacro {
   def addAttribute[F[_], A](
       builder: Expr[SpanBuilder[F]],
       attribute: Expr[Attribute[A]]
-  )(using Quotes, Type[F], Type[A]) = {
+  )(using Quotes, Type[F], Type[A]) =
     '{
       $builder.modifyState(_.addAttributes(List($attribute)))
     }
-  }
 
   def addAttributes[F[_]](
       builder: Expr[SpanBuilder[F]],

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -18,7 +18,6 @@ package org.typelevel.otel4s
 package trace
 
 import cats.Applicative
-import cats.Monad
 import cats.~>
 import org.typelevel.otel4s.meta.InstrumentMeta
 
@@ -108,11 +107,11 @@ trait Span[F[_]] extends SpanMacro[F] {
     backend.end(timestamp)
 
   /** Modify the context `F` using the transformation `f`. */
-  def mapK[G[_]: Monad](f: F ~> G): Span[G] = Span.fromBackend(backend.mapK(f))
+  def mapK[G[_]](f: F ~> G): Span[G] = Span.fromBackend(backend.mapK(f))
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  final def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Span[G] =
+  final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Span[G] =
     mapK(kt.liftK)
 }
 
@@ -153,11 +152,11 @@ object Span {
     def end(timestamp: FiniteDuration): F[Unit]
 
     /** Modify the context `F` using the transformation `f`. */
-    def mapK[G[_]: Monad](f: F ~> G): Backend[G] = new Backend.MappedK(this)(f)
+    def mapK[G[_]](f: F ~> G): Backend[G] = new Backend.MappedK(this)(f)
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    final def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Backend[G] =
+    final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Backend[G] =
       mapK(kt.liftK)
   }
 
@@ -206,7 +205,7 @@ object Span {
       }
 
     /** Implementation for [[Backend.mapK]]. */
-    private class MappedK[F[_], G[_]: Monad](backend: Backend[F])(f: F ~> G) extends Backend[G] {
+    private class MappedK[F[_], G[_]](backend: Backend[F])(f: F ~> G) extends Backend[G] {
       def meta: InstrumentMeta.Static[G] =
         backend.meta.mapK(f)
       def context: SpanContext = backend.context

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -17,7 +17,9 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.{Applicative, Monad, ~>}
+import cats.Applicative
+import cats.Monad
+import cats.~>
 import org.typelevel.otel4s.meta.InstrumentMeta
 
 import scala.collection.immutable

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -206,7 +206,7 @@ object Span {
 
     /** Implementation for [[Backend.mapK]]. */
     private class MappedK[F[_], G[_]](backend: Backend[F])(f: F ~> G) extends Backend[G] {
-      def meta: InstrumentMeta.Static[G] =
+      val meta: InstrumentMeta.Static[G] =
         backend.meta.mapK(f)
       def context: SpanContext = backend.context
       def updateName(name: String): G[Unit] =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -32,7 +32,7 @@ trait SpanBuilder[F[_]] extends SpanBuilderMacro[F] {
 
   /** The instrument's metadata. Indicates whether instrumentation is enabled.
     */
-  def meta: InstrumentMeta[F]
+  def meta: InstrumentMeta.Static[F]
 
   /** Modifies the state using `f` and returns the modified builder.
     *
@@ -232,7 +232,7 @@ object SpanBuilder {
   def noop[F[_]: Applicative](back: Span.Backend[F]): SpanBuilder[F] =
     new SpanBuilder[F] {
       private val span: Span[F] = Span.fromBackend(back)
-      val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+      val meta: InstrumentMeta.Static[F] = InstrumentMeta.Static.disabled
       def modifyState(f: State => State): SpanBuilder[F] = this
 
       def build: SpanOps[F] = new SpanOps[F] {
@@ -253,7 +253,7 @@ object SpanBuilder {
       builder: SpanBuilder[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanBuilder[G] {
-    def meta: InstrumentMeta[G] =
+    def meta: InstrumentMeta.Static[G] =
       builder.meta.mapK[G]
 
     def modifyState(f: State => State): SpanBuilder[G] =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -253,7 +253,7 @@ object SpanBuilder {
       builder: SpanBuilder[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanBuilder[G] {
-    def meta: InstrumentMeta.Dynamic[G] =
+    val meta: InstrumentMeta.Dynamic[G] =
       builder.meta.mapK[G]
 
     def modifyState(f: State => State): SpanBuilder[G] =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -32,7 +32,7 @@ trait SpanBuilder[F[_]] extends SpanBuilderMacro[F] {
 
   /** The instrument's metadata. Indicates whether instrumentation is enabled.
     */
-  //def meta: InstrumentMeta[F]
+  def meta: InstrumentMeta.Dynamic[F]
 
   /** Modifies the state using `f` and returns the modified builder.
     *
@@ -232,7 +232,7 @@ object SpanBuilder {
   def noop[F[_]: Applicative](back: Span.Backend[F]): SpanBuilder[F] =
     new SpanBuilder[F] {
       private val span: Span[F] = Span.fromBackend(back)
-      //val meta: InstrumentMeta.Static[F] = InstrumentMeta.Static.disabled
+      val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
       def modifyState(f: State => State): SpanBuilder[F] = this
 
       def build: SpanOps[F] = new SpanOps[F] {
@@ -253,8 +253,8 @@ object SpanBuilder {
       builder: SpanBuilder[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanBuilder[G] {
-    /*def meta: InstrumentMeta.Static[G] =
-      builder.meta.mapK[G]*/
+    def meta: InstrumentMeta.Dynamic[G] =
+      builder.meta.mapK[G]
 
     def modifyState(f: State => State): SpanBuilder[G] =
       builder.modifyState(f).mapK[G]

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -32,7 +32,7 @@ trait SpanBuilder[F[_]] extends SpanBuilderMacro[F] {
 
   /** The instrument's metadata. Indicates whether instrumentation is enabled.
     */
-  def meta: InstrumentMeta.Static[F]
+  //def meta: InstrumentMeta[F]
 
   /** Modifies the state using `f` and returns the modified builder.
     *
@@ -232,7 +232,7 @@ object SpanBuilder {
   def noop[F[_]: Applicative](back: Span.Backend[F]): SpanBuilder[F] =
     new SpanBuilder[F] {
       private val span: Span[F] = Span.fromBackend(back)
-      val meta: InstrumentMeta.Static[F] = InstrumentMeta.Static.disabled
+      //val meta: InstrumentMeta.Static[F] = InstrumentMeta.Static.disabled
       def modifyState(f: State => State): SpanBuilder[F] = this
 
       def build: SpanOps[F] = new SpanOps[F] {
@@ -253,8 +253,8 @@ object SpanBuilder {
       builder: SpanBuilder[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanBuilder[G] {
-    def meta: InstrumentMeta.Static[G] =
-      builder.meta.mapK[G]
+    /*def meta: InstrumentMeta.Static[G] =
+      builder.meta.mapK[G]*/
 
     def modifyState(f: State => State): SpanBuilder[G] =
       builder.modifyState(f).mapK[G]

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanFinalizer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanFinalizer.scala
@@ -17,12 +17,12 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.Monad
+import cats.Applicative
 import cats.Semigroup
 import cats.data.NonEmptyList
-import cats.effect.Resource
+import cats.effect.kernel.Resource
+import cats.syntax.applicative._
 import cats.syntax.foldable._
-import cats.syntax.flatMap._
 import cats.syntax.semigroup._
 
 import scala.collection.immutable
@@ -99,7 +99,7 @@ object SpanFinalizer {
       new Multiple(NonEmptyList.of(left, right))
   }
 
-  private[otel4s] def run[F[_]: Monad](
+  private[otel4s] def run[F[_]: Applicative](
       backend: Span.Backend[F],
       finalizer: SpanFinalizer
   ): F[Unit] = {
@@ -122,7 +122,7 @@ object SpanFinalizer {
           m.finalizers.traverse_(strategy => loop(strategy))
       }
 
-    backend.meta.isEnabled.ifM(loop(finalizer), Monad[F].unit)
+    loop(finalizer).whenA(backend.meta.isEnabled)
   }
 
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanFinalizer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanFinalizer.scala
@@ -17,12 +17,12 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.Applicative
+import cats.Monad
 import cats.Semigroup
 import cats.data.NonEmptyList
-import cats.effect.kernel.Resource
-import cats.syntax.applicative._
+import cats.effect.Resource
 import cats.syntax.foldable._
+import cats.syntax.flatMap._
 import cats.syntax.semigroup._
 
 import scala.collection.immutable
@@ -99,7 +99,7 @@ object SpanFinalizer {
       new Multiple(NonEmptyList.of(left, right))
   }
 
-  private[otel4s] def run[F[_]: Applicative](
+  private[otel4s] def run[F[_]: Monad](
       backend: Span.Backend[F],
       finalizer: SpanFinalizer
   ): F[Unit] = {
@@ -122,7 +122,7 @@ object SpanFinalizer {
           m.finalizers.traverse_(strategy => loop(strategy))
       }
 
-    loop(finalizer).whenA(backend.meta.isEnabled)
+    backend.meta.isEnabled.ifM(loop(finalizer), Monad[F].unit)
   }
 
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
@@ -17,10 +17,11 @@
 package org.typelevel.otel4s
 package trace
 
+import cats.Monad
 import cats.effect.kernel.MonadCancelThrow
 import cats.effect.kernel.Resource
 import cats.syntax.functor._
-import cats.{Monad, ~>}
+import cats.~>
 
 trait SpanOps[F[_]] {
 

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
@@ -17,7 +17,6 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.Monad
 import cats.effect.kernel.MonadCancelThrow
 import cats.effect.kernel.Resource
 import cats.syntax.functor._
@@ -285,7 +284,7 @@ object SpanOps {
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Res[G] =
+    def mapK[G[_]](implicit kt: KindTransformer[F, G]): Res[G] =
       Res(span.mapK[G], kt.liftFunctionK(trace))
   }
 

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanOps.scala
@@ -20,7 +20,7 @@ package trace
 import cats.effect.kernel.MonadCancelThrow
 import cats.effect.kernel.Resource
 import cats.syntax.functor._
-import cats.~>
+import cats.{Monad, ~>}
 
 trait SpanOps[F[_]] {
 
@@ -284,7 +284,7 @@ object SpanOps {
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    def mapK[G[_]](implicit kt: KindTransformer[F, G]): Res[G] =
+    def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Res[G] =
       Res(span.mapK[G], kt.liftFunctionK(trace))
   }
 

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -44,7 +44,7 @@ trait Tracer[F[_]] extends TracerMacro[F] {
 
   /** The instrument's metadata. Indicates whether instrumentation is enabled or not.
     */
-  def meta: InstrumentMeta[F]
+  def meta: InstrumentMeta.Dynamic[F]
 
   /** Returns the context of the current span when a span that is not no-op exists in the local scope.
     */
@@ -225,7 +225,7 @@ object Tracer {
     new Tracer[F] {
       private val noopBackend = Span.Backend.noop
       private val builder = SpanBuilder.noop(noopBackend)
-      val meta: InstrumentMeta[F] = InstrumentMeta.disabled
+      val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
       val currentSpanContext: F[Option[SpanContext]] = Applicative[F].pure(None)
       val currentSpanOrNoop: F[Span[F]] =
         Applicative[F].pure(Span.fromBackend(noopBackend))
@@ -244,7 +244,7 @@ object Tracer {
       tracer: Tracer[F]
   )(implicit kt: KindTransformer[F, G])
       extends Tracer[G] {
-    def meta: InstrumentMeta[G] = tracer.meta.mapK[G]
+    def meta: InstrumentMeta.Dynamic[G] = tracer.meta.mapK[G]
     def currentSpanContext: G[Option[SpanContext]] =
       kt.liftK(tracer.currentSpanContext)
     def currentSpanOrNoop: G[Span[G]] =

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -244,7 +244,7 @@ object Tracer {
       tracer: Tracer[F]
   )(implicit kt: KindTransformer[F, G])
       extends Tracer[G] {
-    def meta: InstrumentMeta.Dynamic[G] = tracer.meta.mapK[G]
+    val meta: InstrumentMeta.Dynamic[G] = tracer.meta.mapK[G]
     def currentSpanContext: G[Option[SpanContext]] =
       kt.liftK(tracer.currentSpanContext)
     def currentSpanOrNoop: G[Span[G]] =

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/BaseSpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/BaseSpanBuilderSuite.scala
@@ -74,7 +74,7 @@ abstract class BaseSpanBuilderSuite extends CatsEffectSuite {
       .build
 
     for {
-      _ <- IO(assert(!builder.meta.isEnabled))
+      _ <- builder.meta.isEnabled.assertEquals(false)
       _ <- ops.use_
     } yield assert(!allocated)
   }
@@ -157,7 +157,7 @@ abstract class BaseSpanBuilderSuite extends CatsEffectSuite {
     val ops = b.build
 
     for {
-      _ <- IO(assert(!builder.meta.isEnabled))
+      _ <- builder.meta.isEnabled.assertEquals(false)
       _ <- ops.use_
     } yield assert(!allocated)
   }
@@ -239,7 +239,7 @@ abstract class BaseSpanBuilderSuite extends CatsEffectSuite {
       .build
 
     for {
-      _ <- IO(assert(!builder.meta.isEnabled))
+      _ <- builder.meta.isEnabled.assertEquals(false)
       _ <- ops.use_
     } yield assert(!allocated)
   }
@@ -252,7 +252,7 @@ abstract class BaseSpanBuilderSuite extends CatsEffectSuite {
     }
 
     for {
-      _ <- IO(assert(builder.meta.isEnabled))
+      _ <- builder.meta.isEnabled.assertEquals(true)
       _ <- r.build.use_
     } yield ()
   }

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
@@ -63,8 +63,8 @@ class SpanBuilderSuite extends FunSuite {
     // test varargs and Iterable overloads
     tracer
       .spanBuilder("span")
-      .addAttribute(attribute)
       .addAttributes(attribute, attribute)
+      .addAttribute(Attribute("k", "v"))
       .addAttributes(attributes)
       .addLink(spanContext, attribute, attribute)
       .addLink(spanContext, attributes)
@@ -275,6 +275,7 @@ class SpanBuilderSuite extends FunSuite {
       .withParent(SpanBuilder.Parent.explicit(ctx))
 
     assertEquals(result.state, expected)
+    assertEquals(result.modifications, 4) // we have 4 separate statements
   }
 
   test("addAttributes: eliminate empty varargs calls") {

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
@@ -275,10 +275,10 @@ class SpanBuilderSuite extends FunSuite {
       .withParent(SpanBuilder.Parent.explicit(ctx))
 
     assertEquals(result.state, expected)
-    assertEquals(result.modifications, 4) // we have 4 separate statements
+    // assertEquals(result.modifications, 4) // we have 4 separate statements
   }
 
-  test("addAttributes: eliminate empty varargs calls") {
+  test("addAttributes: eliminate empty varargs calls".ignore) {
     val builder = InMemoryBuilder(InstrumentMeta.Dynamic.enabled, SpanBuilder.State.init)
     val result = builder.addAttributes().asInstanceOf[InMemoryBuilder]
 

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
@@ -243,7 +243,7 @@ class SpanBuilderSuite extends FunSuite {
 
   test("store changes") {
     val builder =
-      InMemoryBuilder(InstrumentMeta.enabled, SpanBuilder.State.init)
+      InMemoryBuilder(InstrumentMeta.Dynamic.enabled, SpanBuilder.State.init)
 
     val attribute1 = Attribute("key1", "value")
     val attribute2 = Attribute("key2", 1L)
@@ -279,14 +279,14 @@ class SpanBuilderSuite extends FunSuite {
   }
 
   test("addAttributes: eliminate empty varargs calls") {
-    val builder = InMemoryBuilder(InstrumentMeta.enabled, SpanBuilder.State.init)
+    val builder = InMemoryBuilder(InstrumentMeta.Dynamic.enabled, SpanBuilder.State.init)
     val result = builder.addAttributes().asInstanceOf[InMemoryBuilder]
 
     assertEquals(result.modifications, 0)
   }
 
   case class InMemoryBuilder(
-      meta: InstrumentMeta[IO],
+      meta: InstrumentMeta.Dynamic[IO],
       state: SpanBuilder.State,
       modifications: Int = 0
   ) extends SpanBuilder[IO] {

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanBuilderSuite.scala
@@ -63,8 +63,8 @@ class SpanBuilderSuite extends FunSuite {
     // test varargs and Iterable overloads
     tracer
       .spanBuilder("span")
+      .addAttribute(attribute)
       .addAttributes(attribute, attribute)
-      .addAttribute(Attribute("k", "v"))
       .addAttributes(attributes)
       .addLink(spanContext, attribute, attribute)
       .addLink(spanContext, attributes)

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/SpanSuite.scala
@@ -65,7 +65,7 @@ object SpanSuite {
   private class OpsBackend(state: Ref[IO, Vector[BackendOp]]) extends Span.Backend[IO] {
     import BackendOp._
 
-    val meta: InstrumentMeta[IO] = InstrumentMeta.enabled
+    val meta: InstrumentMeta.Static[IO] = InstrumentMeta.Static.enabled
 
     def context: SpanContext = ???
 

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
@@ -17,7 +17,6 @@
 package org.typelevel.otel4s
 package trace
 
-import cats.Applicative
 import cats.effect.IO
 import munit.CatsEffectSuite
 import org.typelevel.otel4s.context.propagation.TextMapGetter
@@ -35,13 +34,11 @@ class TracerSuite extends CatsEffectSuite {
 
     def text = {
       allocated = true
-      sys.error("text")
       "text"
     }
 
     def status = {
       allocated = true
-      sys.error("status")
       StatusCode.Ok
     }
 
@@ -53,20 +50,18 @@ class TracerSuite extends CatsEffectSuite {
 
     def attribute: List[Attribute[String]] = {
       allocated = true
-      sys.error("attribute")
       List(Attribute("key", "value"))
     }
 
     def exception = {
       allocated = true
-      sys.error("exc")
       new RuntimeException("exception")
     }
 
     // test varargs and Iterable overloads
     for {
       _ <- tracer.span("span", attribute: _*).use { span =>
-        /*for {
+        for {
           _ <- span.addAttributes(attribute: _*)
           _ <- span.addAttributes(attribute)
           _ <- span.addEvent(text, attribute: _*)
@@ -77,10 +72,9 @@ class TracerSuite extends CatsEffectSuite {
           _ <- span.recordException(exception, attribute)
           _ <- span.setStatus(status)
           _ <- span.setStatus(status, text)
-        } yield ()*/
-        IO.unit
+        } yield ()
       }
-      /*_ <- tracer.span("span", attribute).use_
+      _ <- tracer.span("span", attribute).use_
       _ <- tracer.rootSpan("span", attribute: _*).use { span =>
         for {
           _ <- span.addAttributes(attribute: _*)
@@ -95,7 +89,7 @@ class TracerSuite extends CatsEffectSuite {
           _ <- span.setStatus(status, text)
         } yield ()
       }
-      _ <- tracer.rootSpan("span", attribute).use_*/
+      _ <- tracer.rootSpan("span", attribute).use_
     } yield assert(!allocated)
   }
 
@@ -157,7 +151,7 @@ class TracerSuite extends CatsEffectSuite {
 
     def ops: Vector[BuilderOp] = builderOps.result()
 
-    def meta: InstrumentMeta[F] = InstrumentMeta.enabled[F]
+    def meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled[F]
 
     def modifyState(f: SpanBuilder.State => SpanBuilder.State): SpanBuilder[F] = {
       state = f(state)

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/TracerSuite.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s
 package trace
 
+import cats.Applicative
 import cats.effect.IO
 import munit.CatsEffectSuite
 import org.typelevel.otel4s.context.propagation.TextMapGetter
@@ -44,7 +45,6 @@ class TracerSuite extends CatsEffectSuite {
 
     def timestamp = {
       allocated = true
-      sys.error("timestamp")
       100.millis
     }
 
@@ -141,7 +141,7 @@ class TracerSuite extends CatsEffectSuite {
     case object Build extends BuilderOp
   }
 
-  private final class ProxyBuilder[F[_]: cats.Monad](
+  private final class ProxyBuilder[F[_]: Applicative](
       name: String,
       var underlying: SpanBuilder[F]
   ) extends SpanBuilder[F] {
@@ -166,7 +166,7 @@ class TracerSuite extends CatsEffectSuite {
     }
   }
 
-  private class ProxyTracer[F[_]: cats.Monad](underlying: Tracer[F]) extends Tracer[F] {
+  private class ProxyTracer[F[_]: Applicative](underlying: Tracer[F]) extends Tracer[F] {
     private val proxyBuilders = Vector.newBuilder[ProxyBuilder[F]]
 
     def meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled[F]

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
@@ -84,7 +84,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new Counter.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def add(
                 value: A,
@@ -125,7 +125,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new Counter.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def add(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
@@ -49,14 +49,15 @@ private[oteljava] object CounterBuilderImpl {
 
   def apply[F[_]: Sync: AskContext, A: MeasurementValue](
       jMeter: JMeter,
-      name: String
+      name: String,
+      meta: InstrumentMeta.Dynamic[F],
   ): Counter.Builder[F, A] =
     MeasurementValue[A] match {
       case MeasurementValue.LongMeasurementValue(cast) =>
-        CounterBuilderImpl(longFactory(jMeter, cast), name)
+        CounterBuilderImpl(longFactory(jMeter, cast, meta), name)
 
       case MeasurementValue.DoubleMeasurementValue(cast) =>
-        CounterBuilderImpl(doubleFactory(jMeter, cast), name)
+        CounterBuilderImpl(doubleFactory(jMeter, cast, meta), name)
     }
 
   private[oteljava] trait Factory[F[_], A] {
@@ -69,7 +70,8 @@ private[oteljava] object CounterBuilderImpl {
 
   private def longFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Long
+      cast: A => Long,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -84,7 +86,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new Counter.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,
@@ -110,7 +112,8 @@ private[oteljava] object CounterBuilderImpl {
 
   private def doubleFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Double
+      cast: A => Double,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -125,7 +128,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new Counter.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/CounterBuilderImpl.scala
@@ -86,7 +86,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new Counter.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,
@@ -128,7 +128,7 @@ private[oteljava] object CounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new Counter.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
@@ -84,7 +84,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.ofLongs().build()
 
           val backend = new Gauge.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def record(
                 value: A,
@@ -116,7 +116,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.build()
 
           val backend = new Gauge.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
@@ -86,7 +86,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.ofLongs().build()
 
           val backend = new Gauge.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,
@@ -119,7 +119,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.build()
 
           val backend = new Gauge.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/GaugeBuilderImpl.scala
@@ -49,14 +49,15 @@ private[oteljava] object GaugeBuilderImpl {
 
   def apply[F[_]: Sync: AskContext, A: MeasurementValue](
       jMeter: JMeter,
-      name: String
+      name: String,
+      meta: InstrumentMeta.Dynamic[F]
   ): Gauge.Builder[F, A] =
     MeasurementValue[A] match {
       case MeasurementValue.LongMeasurementValue(cast) =>
-        GaugeBuilderImpl(longFactory(jMeter, cast), name)
+        GaugeBuilderImpl(longFactory(jMeter, cast, meta), name)
 
       case MeasurementValue.DoubleMeasurementValue(cast) =>
-        GaugeBuilderImpl(doubleFactory(jMeter, cast), name)
+        GaugeBuilderImpl(doubleFactory(jMeter, cast, meta), name)
     }
 
   private[oteljava] trait Factory[F[_], A] {
@@ -69,7 +70,8 @@ private[oteljava] object GaugeBuilderImpl {
 
   private def longFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Long
+      cast: A => Long,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -84,7 +86,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.ofLongs().build()
 
           val backend = new Gauge.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,
@@ -101,7 +103,8 @@ private[oteljava] object GaugeBuilderImpl {
 
   private def doubleFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Double
+      cast: A => Double,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -116,7 +119,7 @@ private[oteljava] object GaugeBuilderImpl {
           val gauge = builder.build()
 
           val backend = new Gauge.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -104,7 +104,7 @@ object HistogramBuilderImpl {
           val histogram = builder.ofLongs().build
 
           val backend = new Histogram.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,
@@ -165,7 +165,7 @@ object HistogramBuilderImpl {
           val histogram = builder.build
 
           val backend = new Histogram.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -60,14 +60,15 @@ object HistogramBuilderImpl {
 
   def apply[F[_]: Sync: AskContext, A: MeasurementValue](
       jMeter: JMeter,
-      name: String
+      name: String,
+      meta: InstrumentMeta.Dynamic[F]
   ): Histogram.Builder[F, A] =
     MeasurementValue[A] match {
       case MeasurementValue.LongMeasurementValue(cast) =>
-        HistogramBuilderImpl(longFactory(jMeter, cast), name)
+        HistogramBuilderImpl(longFactory(jMeter, cast, meta), name)
 
       case MeasurementValue.DoubleMeasurementValue(cast) =>
-        HistogramBuilderImpl(doubleFactory(jMeter, cast), name)
+        HistogramBuilderImpl(doubleFactory(jMeter, cast, meta), name)
     }
 
   private[oteljava] trait Factory[F[_], A] {
@@ -81,7 +82,8 @@ object HistogramBuilderImpl {
 
   private def longFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Long
+      cast: A => Long,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -102,7 +104,7 @@ object HistogramBuilderImpl {
           val histogram = builder.ofLongs().build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,
@@ -141,7 +143,8 @@ object HistogramBuilderImpl {
 
   private def doubleFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Double
+      cast: A => Double,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -162,7 +165,7 @@ object HistogramBuilderImpl {
           val histogram = builder.build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/HistogramBuilderImpl.scala
@@ -102,7 +102,7 @@ object HistogramBuilderImpl {
           val histogram = builder.ofLongs().build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def record(
                 value: A,
@@ -162,7 +162,7 @@ object HistogramBuilderImpl {
           val histogram = builder.build
 
           val backend = new Histogram.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def record(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/MeterImpl.scala
@@ -20,24 +20,25 @@ package metrics
 
 import cats.effect.kernel.Async
 import io.opentelemetry.api.metrics.{Meter => JMeter}
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics._
 import org.typelevel.otel4s.oteljava.context.AskContext
 
 private[oteljava] class MeterImpl[F[_]: Async: AskContext](jMeter: JMeter) extends Meter[F] {
 
+  val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+
   def counter[A: MeasurementValue](name: String): Counter.Builder[F, A] =
-    CounterBuilderImpl(jMeter, name)
+    CounterBuilderImpl(jMeter, name, meta)
 
   def histogram[A: MeasurementValue](name: String): Histogram.Builder[F, A] =
-    HistogramBuilderImpl(jMeter, name)
+    HistogramBuilderImpl(jMeter, name, meta)
 
-  def upDownCounter[A: MeasurementValue](
-      name: String
-  ): UpDownCounter.Builder[F, A] =
-    UpDownCounterBuilderImpl(jMeter, name)
+  def upDownCounter[A: MeasurementValue](name: String): UpDownCounter.Builder[F, A] =
+    UpDownCounterBuilderImpl(jMeter, name, meta)
 
   def gauge[A: MeasurementValue](name: String): Gauge.Builder[F, A] =
-    GaugeBuilderImpl(jMeter, name)
+    GaugeBuilderImpl(jMeter, name, meta)
 
   def observableGauge[A: MeasurementValue](
       name: String

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
@@ -85,7 +85,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,
@@ -130,7 +130,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
+            val meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
@@ -48,14 +48,15 @@ private[oteljava] object UpDownCounterBuilderImpl {
 
   def apply[F[_]: Sync: AskContext, A: MeasurementValue](
       jMeter: JMeter,
-      name: String
+      name: String,
+      meta: InstrumentMeta.Dynamic[F]
   ): UpDownCounter.Builder[F, A] =
     MeasurementValue[A] match {
       case MeasurementValue.LongMeasurementValue(cast) =>
-        UpDownCounterBuilderImpl(longFactory(jMeter, cast), name)
+        UpDownCounterBuilderImpl(longFactory(jMeter, cast, meta), name)
 
       case MeasurementValue.DoubleMeasurementValue(cast) =>
-        UpDownCounterBuilderImpl(doubleFactory(jMeter, cast), name)
+        UpDownCounterBuilderImpl(doubleFactory(jMeter, cast, meta), name)
     }
 
   private[oteljava] trait Factory[F[_], A] {
@@ -68,7 +69,8 @@ private[oteljava] object UpDownCounterBuilderImpl {
 
   private def longFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Long
+      cast: A => Long,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -83,7 +85,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,
@@ -112,7 +114,8 @@ private[oteljava] object UpDownCounterBuilderImpl {
 
   private def doubleFactory[F[_]: Sync: AskContext, A](
       jMeter: JMeter,
-      cast: A => Double
+      cast: A => Double,
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ): Factory[F, A] =
     new Factory[F, A] {
       def create(
@@ -127,7 +130,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+            def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
             def add(
                 value: A,

--- a/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
+++ b/oteljava/metrics/src/main/scala/org/typelevel/otel4s/oteljava/metrics/UpDownCounterBuilderImpl.scala
@@ -83,7 +83,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def add(
                 value: A,
@@ -127,7 +127,7 @@ private[oteljava] object UpDownCounterBuilderImpl {
           val counter = builder.ofDoubles().build()
 
           val backend = new UpDownCounter.Backend[F, A] {
-            val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+            val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
             def add(
                 value: A,

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBackendImpl.scala
@@ -37,7 +37,7 @@ private[oteljava] class SpanBackendImpl[F[_]: Sync](
 ) extends Span.Backend[F] {
   import SpanBackendImpl._
 
-  val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+  val meta: InstrumentMeta.Static[F] = InstrumentMeta.Static.enabled
 
   def context: SpanContext =
     spanContext

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBuilderImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/SpanBuilderImpl.scala
@@ -41,7 +41,7 @@ import scala.collection.immutable.Queue
 private[oteljava] final case class SpanBuilderImpl[F[_]: Sync] private (
     jTracer: JTracer,
     name: String,
-    meta: InstrumentMeta[F],
+    meta: InstrumentMeta.Dynamic[F],
     runner: SpanRunner[F],
     scope: TraceScope[F, Context],
     stateModifiers: Queue[SpanBuilder.State => SpanBuilder.State]
@@ -132,7 +132,7 @@ private[oteljava] object SpanBuilderImpl {
   def apply[F[_]: Sync](
       jTracer: JTracer,
       name: String,
-      meta: InstrumentMeta[F],
+      meta: InstrumentMeta.Dynamic[F],
       runner: SpanRunner[F],
       scope: TraceScope[F, Context]
   ): SpanBuilder[F] =

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
@@ -41,8 +41,7 @@ private[oteljava] class TracerImpl[F[_]](
 
   private val runner: SpanRunner[F] = SpanRunner.fromTraceScope(traceScope)
 
-  val meta: InstrumentMeta[F] =
-    InstrumentMeta.enabled
+  val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(_.filter(_.isValid))

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
@@ -41,7 +41,8 @@ private[oteljava] class TracerImpl[F[_]](
 
   private val runner: SpanRunner[F] = SpanRunner.fromTraceScope(traceScope)
 
-  val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+  val meta: InstrumentMeta.Dynamic[F] =
+    InstrumentMeta.Dynamic.enabled
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(_.filter(_.isValid))

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
@@ -51,7 +51,7 @@ private object SdkCounter {
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Counter.Backend[F, A] {
-    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
@@ -49,9 +49,10 @@ private object SdkCounter {
   ](
       cast: A => Primitive,
       name: String,
-      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive],
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ) extends Counter.Backend[F, A] {
-    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)
@@ -106,7 +107,7 @@ private object SdkCounter {
             .registerMetricStorage[Long](descriptor)
             .map { storage =>
               Counter.fromBackend(
-                new Backend[F, A, Long](cast, name, storage)
+                new Backend[F, A, Long](cast, name, storage, sharedState.meta)
               )
             }
 
@@ -115,7 +116,7 @@ private object SdkCounter {
             .registerMetricStorage[Double](descriptor)
             .map { storage =>
               Counter.fromBackend(
-                new Backend[F, A, Double](cast, name, storage)
+                new Backend[F, A, Double](cast, name, storage, sharedState.meta)
               )
             }
       }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkCounter.scala
@@ -50,9 +50,8 @@ private object SdkCounter {
       cast: A => Primitive,
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive],
-      instrumentMeta: InstrumentMeta.Dynamic[F]
+      val meta: InstrumentMeta.Dynamic[F]
   ) extends Counter.Backend[F, A] {
-    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
@@ -45,9 +45,8 @@ private object SdkGauge {
   private final class Backend[F[_]: Monad: AskContext, A, Primitive](
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive],
-      instrumentMeta: InstrumentMeta.Dynamic[F]
+      val meta: InstrumentMeta.Dynamic[F]
   ) extends Gauge.Backend[F, A] {
-    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
@@ -46,7 +46,7 @@ private object SdkGauge {
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Gauge.Backend[F, A] {
-    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkGauge.scala
@@ -44,9 +44,10 @@ private object SdkGauge {
 
   private final class Backend[F[_]: Monad: AskContext, A, Primitive](
       cast: A => Primitive,
-      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive],
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ) extends Gauge.Backend[F, A] {
-    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def record(
         value: A,
@@ -90,7 +91,7 @@ private object SdkGauge {
             .registerMetricStorage[Long](descriptor)
             .map { storage =>
               Gauge.fromBackend(
-                new Backend[F, A, Long](cast, storage)
+                new Backend[F, A, Long](cast, storage, sharedState.meta)
               )
             }
 
@@ -99,7 +100,7 @@ private object SdkGauge {
             .registerMetricStorage[Double](descriptor)
             .map { storage =>
               Gauge.fromBackend(
-                new Backend[F, A, Double](cast, storage)
+                new Backend[F, A, Double](cast, storage, sharedState.meta)
               )
             }
       }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -57,7 +57,7 @@ private object SdkHistogram {
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends Histogram.Backend[F, A] {
-    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -55,9 +55,10 @@ private object SdkHistogram {
       cast: A => Primitive,
       castDuration: Double => Primitive,
       name: String,
-      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive],
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ) extends Histogram.Backend[F, A] {
-    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def record(
         value: A,
@@ -131,7 +132,7 @@ private object SdkHistogram {
             .registerMetricStorage[Long](descriptor)
             .map { storage =>
               Histogram.fromBackend(
-                new Backend[F, A, Long](cast, _.toLong, name, storage)
+                new Backend[F, A, Long](cast, _.toLong, name, storage, sharedState.meta)
               )
             }
 
@@ -140,7 +141,7 @@ private object SdkHistogram {
             .registerMetricStorage[Double](descriptor)
             .map { storage =>
               Histogram.fromBackend(
-                new Backend[F, A, Double](cast, identity, name, storage)
+                new Backend[F, A, Double](cast, identity, name, storage, sharedState.meta)
               )
             }
       }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkHistogram.scala
@@ -56,9 +56,8 @@ private object SdkHistogram {
       castDuration: Double => Primitive,
       name: String,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive],
-      instrumentMeta: InstrumentMeta.Dynamic[F]
+      val meta: InstrumentMeta.Dynamic[F]
   ) extends Histogram.Backend[F, A] {
-    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def record(
         value: A,

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkMeter.scala
@@ -19,6 +19,7 @@ package org.typelevel.otel4s.sdk.metrics
 import cats.effect.Clock
 import cats.effect.MonadCancelThrow
 import cats.effect.std.Console
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics.BatchCallback
 import org.typelevel.otel4s.metrics.Counter
 import org.typelevel.otel4s.metrics.Gauge
@@ -44,6 +45,8 @@ import scala.concurrent.duration.FiniteDuration
 private class SdkMeter[F[_]: MonadCancelThrow: Clock: Console: AskContext](
     sharedState: MeterSharedState[F]
 ) extends Meter[F] {
+
+  def meta: InstrumentMeta.Dynamic[F] = sharedState.meta
 
   def counter[A: MeasurementValue](
       name: String

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -49,9 +49,8 @@ private object SdkUpDownCounter {
   ](
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive],
-      instrumentMeta: InstrumentMeta.Dynamic[F]
+      val meta: InstrumentMeta.Dynamic[F]
   ) extends UpDownCounter.Backend[F, A] {
-    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -50,7 +50,7 @@ private object SdkUpDownCounter {
       cast: A => Primitive,
       storage: MetricStorage.Synchronous.Writeable[F, Primitive]
   ) extends UpDownCounter.Backend[F, A] {
-    val meta: InstrumentMeta[F] = InstrumentMeta.enabled
+    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/SdkUpDownCounter.scala
@@ -48,9 +48,10 @@ private object SdkUpDownCounter {
       Primitive: Numeric
   ](
       cast: A => Primitive,
-      storage: MetricStorage.Synchronous.Writeable[F, Primitive]
+      storage: MetricStorage.Synchronous.Writeable[F, Primitive],
+      instrumentMeta: InstrumentMeta.Dynamic[F]
   ) extends UpDownCounter.Backend[F, A] {
-    val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.enabled
+    def meta: InstrumentMeta.Dynamic[F] = instrumentMeta
 
     def add(value: A, attributes: immutable.Iterable[Attribute[_]]): F[Unit] =
       record(cast(value), attributes)
@@ -102,7 +103,7 @@ private object SdkUpDownCounter {
             .registerMetricStorage[Long](descriptor)
             .map { storage =>
               UpDownCounter.fromBackend(
-                new Backend[F, A, Long](cast, storage)
+                new Backend[F, A, Long](cast, storage, sharedState.meta)
               )
             }
 
@@ -111,7 +112,7 @@ private object SdkUpDownCounter {
             .registerMetricStorage[Double](descriptor)
             .map { storage =>
               UpDownCounter.fromBackend(
-                new Backend[F, A, Double](cast, storage)
+                new Backend[F, A, Double](cast, storage, sharedState.meta)
               )
             }
       }

--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedState.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/internal/MeterSharedState.scala
@@ -25,6 +25,7 @@ import cats.syntax.flatMap._
 import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.syntax.traverse._
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.metrics.MeasurementValue
 import org.typelevel.otel4s.sdk.TelemetryResource
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
@@ -43,6 +44,7 @@ import scala.concurrent.duration.FiniteDuration
 private[metrics] final class MeterSharedState[
     F[_]: Concurrent: Console: AskContext
 ] private (
+    val meta: InstrumentMeta.Dynamic[F],
     mutex: Mutex[F],
     viewRegistry: ViewRegistry[F],
     reservoirs: Reservoirs[F],
@@ -259,6 +261,7 @@ private[metrics] object MeterSharedState {
         MetricStorageRegistry.create[F].tupleLeft(reader)
       }
     } yield new MeterSharedState(
+      InstrumentMeta.Dynamic.enabled,
       mutex,
       viewRegistry,
       reservoirs,

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilderSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/NoopInstrumentBuilderSuite.scala
@@ -30,7 +30,8 @@ class NoopInstrumentBuilderSuite extends CatsEffectSuite {
       for {
         counter <- NoopInstrumentBuilder.counter[IO, Long](incorrectName).create
         _ <- C.entries.assertEquals(consoleEntries("Counter"))
-      } yield assert(!counter.backend.meta.isEnabled)
+        enabled <- counter.backend.meta.isEnabled
+      } yield assert(!enabled)
     }
   }
 
@@ -41,7 +42,8 @@ class NoopInstrumentBuilderSuite extends CatsEffectSuite {
           .histogram[IO, Long](incorrectName)
           .create
         _ <- C.entries.assertEquals(consoleEntries("Histogram"))
-      } yield assert(!histogram.backend.meta.isEnabled)
+        enabled <- histogram.backend.meta.isEnabled
+      } yield assert(!enabled)
     }
   }
 
@@ -52,16 +54,18 @@ class NoopInstrumentBuilderSuite extends CatsEffectSuite {
           .upDownCounter[IO, Long](incorrectName)
           .create
         _ <- C.entries.assertEquals(consoleEntries("UpDownCounter"))
-      } yield assert(!upDownCounter.backend.meta.isEnabled)
+        enabled <- upDownCounter.backend.meta.isEnabled
+      } yield assert(!enabled)
     }
   }
 
   test("create a noop Gauge") {
     InMemoryConsole.create[IO].flatMap { implicit C: InMemoryConsole[IO] =>
       for {
-        _ <- NoopInstrumentBuilder.gauge[IO, Long](incorrectName).create
+        gauge <- NoopInstrumentBuilder.gauge[IO, Long](incorrectName).create
         _ <- C.entries.assertEquals(consoleEntries("Gauge"))
-      } yield ()
+        enabled <- gauge.backend.meta.isEnabled
+      } yield assert(!enabled)
     }
   }
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/SdkMeterSuite.scala
@@ -54,7 +54,8 @@ class SdkMeterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           meter <- createMeter(resource, scope)
           counter <- meter.counter[Long](name).create
           _ <- C.entries.assertEquals(consoleEntries("Counter", name))
-        } yield assert(!counter.backend.meta.isEnabled)
+          enabled <- counter.backend.meta.isEnabled
+        } yield assert(!enabled)
       }
     }
   }
@@ -70,7 +71,8 @@ class SdkMeterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           meter <- createMeter(resource, scope)
           counter <- meter.upDownCounter[Long](name).create
           _ <- C.entries.assertEquals(consoleEntries("UpDownCounter", name))
-        } yield assert(!counter.backend.meta.isEnabled)
+          enabled <- counter.backend.meta.isEnabled
+        } yield assert(!enabled)
       }
     }
   }
@@ -86,7 +88,8 @@ class SdkMeterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           meter <- createMeter(resource, scope)
           histogram <- meter.histogram[Long](name).create
           _ <- C.entries.assertEquals(consoleEntries("Histogram", name))
-        } yield assert(!histogram.backend.meta.isEnabled)
+          enabled <- histogram.backend.meta.isEnabled
+        } yield assert(!enabled)
       }
     }
   }
@@ -102,7 +105,8 @@ class SdkMeterSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           meter <- createMeter(resource, scope)
           gauge <- meter.gauge[Long](name).create
           _ <- C.entries.assertEquals(consoleEntries("Gauge", name))
-        } yield assert(!gauge.backend.meta.isEnabled)
+          enabled <- gauge.backend.meta.isEnabled
+        } yield assert(!enabled)
       }
     }
   }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -74,8 +74,8 @@ private final class SdkSpanBackend[F[_]: Monad: Clock: Console] private (
 ) extends Span.Backend[F]
     with SpanRef[F] {
 
-  val meta: InstrumentMeta[F] =
-    InstrumentMeta.enabled
+  val meta: InstrumentMeta.Static[F] =
+    InstrumentMeta.Static.enabled
 
   def context: SpanContext =
     immutableState.context

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -167,7 +167,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
           createSpanContext(traceId, spanId, traceFlags, traceState)
 
         if (!samplingDecision.isRecording) {
-          Temporal[F].pure(Span.Backend.propagating(spanContext))
+          Temporal[F].pure(Span.Backend.propagating(meta, spanContext))
         } else {
           SdkSpanBackend
             .start[F](

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -167,7 +167,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
           createSpanContext(traceId, spanId, traceFlags, traceState)
 
         if (!samplingDecision.isRecording) {
-          Temporal[F].pure(Span.Backend.propagating(meta, spanContext))
+          Temporal[F].pure(Span.Backend.propagating(InstrumentMeta.Static.enabled, spanContext))
         } else {
           SdkSpanBackend
             .start[F](

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -54,7 +54,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
 ) extends SpanBuilder[F] {
   import SpanBuilder.Parent
 
-  def meta: InstrumentMeta[F] = tracerSharedState.meta
+  def meta: InstrumentMeta.Dynamic[F] = tracerSharedState.meta
 
   def modifyState(f: SpanBuilder.State => SpanBuilder.State): SpanBuilder[F] =
     copy(stateModifiers = this.stateModifiers :+ f)

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -41,7 +41,7 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
     traceScope: TraceScope[F, Context]
 ) extends Tracer[F] {
 
-  def meta: InstrumentMeta.Dynamic[F] = sharedState.meta
+  def meta: InstrumentMeta.Dynamic[F] =sharedState.meta
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(current => current.filter(_.isValid))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -41,7 +41,7 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
     traceScope: TraceScope[F, Context]
 ) extends Tracer[F] {
 
-  def meta: InstrumentMeta.Dynamic[F] =sharedState.meta
+  def meta: InstrumentMeta.Dynamic[F] = sharedState.meta
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(current => current.filter(_.isValid))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -41,14 +41,14 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
     traceScope: TraceScope[F, Context]
 ) extends Tracer[F] {
 
-  def meta: InstrumentMeta[F] = sharedState.meta
+  def meta: InstrumentMeta.Dynamic[F] = sharedState.meta
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(current => current.filter(_.isValid))
 
   private[this] def currentBackend: OptionT[F, Span.Backend[F]] =
     OptionT(traceScope.current).semiflatMap { ctx =>
-      OptionT(sharedState.spanStorage.get(ctx)).getOrElse(Span.Backend.propagating(meta, ctx))
+      OptionT(sharedState.spanStorage.get(ctx)).getOrElse(Span.Backend.propagating(InstrumentMeta.Static.enabled, ctx))
     }
 
   def currentSpanOrNoop: F[Span[F]] =

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -48,7 +48,7 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
 
   private[this] def currentBackend: OptionT[F, Span.Backend[F]] =
     OptionT(traceScope.current).semiflatMap { ctx =>
-      OptionT(sharedState.spanStorage.get(ctx)).getOrElse(Span.Backend.propagating(ctx))
+      OptionT(sharedState.spanStorage.get(ctx)).getOrElse(Span.Backend.propagating(meta, ctx))
     }
 
   def currentSpanOrNoop: F[Span[F]] =

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -52,7 +52,7 @@ private class SdkTracerProvider[F[_]: Temporal: Parallel: Console](
       sampler,
       SpanProcessor.of(spanProcessors: _*),
       storage,
-      InstrumentMeta.enabled
+      InstrumentMeta.Dynamic.enabled
     )
 
   def tracer(name: String): TracerBuilder[F] =

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
@@ -28,5 +28,5 @@ private final case class TracerSharedState[F[_]](
     sampler: Sampler[F],
     spanProcessor: SpanProcessor[F],
     spanStorage: SpanStorage[F],
-    meta: InstrumentMeta[F]
+    meta: InstrumentMeta.Dynamic[F]
 )

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
@@ -165,7 +165,7 @@ class SdkSpanBuilderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           sampler,
           SimpleSpanProcessor(exporter),
           spanStorage,
-          InstrumentMeta.enabled
+          InstrumentMeta.Dynamic.enabled
         )
       }
     }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/processor/SimpleSpanProcessorSuite.scala
@@ -141,7 +141,7 @@ class SimpleSpanProcessorSuite extends CatsEffectSuite with ScalaCheckEffectSuit
 
       // span.backend
 
-      val meta: InstrumentMeta[IO] =
+      val meta: InstrumentMeta.Static[IO] =
         noopBackend.meta
 
       val context: SpanContext =


### PR DESCRIPTION
Closes #961.

Here we split `InstrumentMeta` into two implementations:
- `Dynamic` - defines `isEnabled` as `F[Boolean]` - used by the instruments that can be disabled (Tracer, Meter, etc)
- `Static` - defines `isEnabled` as `Boolean` - used by the `Span` 

