### PR TITLE
SpanBuilder: chain modifyState functions

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/SpanBuilderBenchmark.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.benchmarks
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.annotations._
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.SpanBuilder
+import org.typelevel.otel4s.trace.SpanContext
+import org.typelevel.otel4s.trace.Tracer
+
+import java.util.concurrent.TimeUnit
+
+// benchmarks/Jmh/run org.typelevel.otel4s.benchmarks.SpanBuilderBenchmark -prof gc
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Measurement(iterations = 40, time = 1)
+@Warmup(iterations = 5, time = 1)
+class SpanBuilderBenchmark {
+  import SpanBuilderBenchmark._
+
+  @Param(Array("noop", "oteljava", "sdk"))
+  var backend: String = _
+  var tracer: Tracer[IO] = _
+  var finalizer: IO[Unit] = _
+
+  @Benchmark
+  def createSpanBuilder(): SpanBuilder[IO] =
+    tracer.spanBuilder("name")
+
+  @Benchmark
+  def addParams(): SpanBuilder[IO] =
+    tracer
+      .spanBuilder("name")
+      .addAttribute(Attribute("key", "value"))
+      .addAttribute(Attribute("k", "v"))
+      .addLink(SpanContext.invalid, Attribute("1", "2"))
+
+  @Benchmark
+  def addParamsAndUse(): Unit =
+    tracer
+      .spanBuilder("name")
+      .addAttribute(Attribute("key", "value"))
+      .addAttribute(Attribute("k", "v"))
+      .addLink(SpanContext.invalid, Attribute("1", "2"))
+      .build
+      .use_
+      .unsafeRunSync()
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    backend match {
+      case "noop" =>
+        tracer = noopTracer
+        finalizer = IO.unit
+
+      case "oteljava" =>
+        val (t, release) = otelJavaTracer.allocated.unsafeRunSync()
+
+        tracer = t
+        finalizer = release
+
+      case "sdk" =>
+        val (t, release) = sdkTracer.allocated.unsafeRunSync()
+
+        tracer = t
+        finalizer = release
+
+      case other =>
+        sys.error(s"unknown backend [$other]")
+    }
+
+  @TearDown(Level.Trial)
+  def cleanup(): Unit =
+    finalizer.unsafeRunSync()
+
+}
+
+object SpanBuilderBenchmark {
+
+  private def otelJavaTracer: Resource[IO, Tracer[IO]] = {
+    import io.opentelemetry.sdk.OpenTelemetrySdk
+    import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+    import io.opentelemetry.sdk.trace.SdkTracerProvider
+    import io.opentelemetry.sdk.trace.`export`.BatchSpanProcessor
+    import org.typelevel.otel4s.oteljava.OtelJava
+
+    def exporter = InMemorySpanExporter.create()
+
+    def builder = SdkTracerProvider
+      .builder()
+      .addSpanProcessor(BatchSpanProcessor.builder(exporter).build())
+
+    def tracerProvider: SdkTracerProvider =
+      builder.build()
+
+    def otel = OpenTelemetrySdk
+      .builder()
+      .setTracerProvider(tracerProvider)
+      .build()
+
+    OtelJava
+      .resource[IO](IO(otel))
+      .evalMap(_.tracerProvider.tracer("trace-benchmark").get)
+  }
+
+  private def sdkTracer: Resource[IO, Tracer[IO]] = {
+    import cats.effect.std.Random
+    import org.typelevel.otel4s.context.LocalProvider
+    import org.typelevel.otel4s.sdk.context.Context
+    import org.typelevel.otel4s.sdk.testkit.trace.InMemorySpanExporter
+    import org.typelevel.otel4s.sdk.trace.SdkTracerProvider
+    import org.typelevel.otel4s.sdk.trace.processor.BatchSpanProcessor
+
+    Resource.eval(InMemorySpanExporter.create[IO](None)).flatMap { exporter =>
+      BatchSpanProcessor.builder(exporter).build.evalMap { processor =>
+        Random.scalaUtilRandom[IO].flatMap { implicit random =>
+          LocalProvider[IO, Context].local.flatMap { implicit local =>
+            for {
+              tracerProvider <- SdkTracerProvider.builder[IO].addSpanProcessor(processor).build
+              tracer <- tracerProvider.get("trace-benchmark")
+            } yield tracer
+          }
+        }
+      }
+    }
+  }
+
+  private def noopTracer: Tracer[IO] =
+    Tracer.noop
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.12"
+ThisBuild / tlBaseVersion := "0.13"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
+++ b/oteljava/trace/src/main/scala/org/typelevel/otel4s/oteljava/trace/TracerImpl.scala
@@ -66,7 +66,7 @@ private[oteljava] class TracerImpl[F[_]](
     }.flatten
 
   def spanBuilder(name: String): SpanBuilder[F] =
-    SpanBuilderImpl[F](jTracer, name, runner, traceScope)
+    SpanBuilderImpl[F](jTracer, name, meta, runner, traceScope)
 
   def childScope[A](parent: SpanContext)(fa: F[A]): F[A] =
     traceScope.childScope(parent).flatMap(trace => trace(fa))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracer.scala
@@ -41,7 +41,7 @@ private final class SdkTracer[F[_]: Temporal: Console] private[trace] (
     traceScope: TraceScope[F, Context]
 ) extends Tracer[F] {
 
-  val meta: InstrumentMeta[F] = InstrumentMeta.enabled[F]
+  def meta: InstrumentMeta[F] = sharedState.meta
 
   def currentSpanContext: F[Option[SpanContext]] =
     traceScope.current.map(current => current.filter(_.isValid))

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -24,6 +24,7 @@ import cats.effect.std.Random
 import cats.syntax.functor._
 import org.typelevel.otel4s.context.propagation.ContextPropagators
 import org.typelevel.otel4s.context.propagation.TextMapPropagator
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.sdk.context.Context
 import org.typelevel.otel4s.sdk.context.LocalContext
 import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
@@ -50,7 +51,8 @@ private class SdkTracerProvider[F[_]: Temporal: Parallel: Console](
       spanLimits,
       sampler,
       SpanProcessor.of(spanProcessors: _*),
-      storage
+      storage,
+      InstrumentMeta.enabled
     )
 
   def tracer(name: String): TracerBuilder[F] =

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/TracerSharedState.scala
@@ -17,6 +17,7 @@
 package org.typelevel.otel4s.sdk
 package trace
 
+import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
 import org.typelevel.otel4s.sdk.trace.samplers.Sampler
 
@@ -26,5 +27,6 @@ private final case class TracerSharedState[F[_]](
     spanLimits: SpanLimits,
     sampler: Sampler[F],
     spanProcessor: SpanProcessor[F],
-    spanStorage: SpanStorage[F]
+    spanStorage: SpanStorage[F],
+    meta: InstrumentMeta[F]
 )


### PR DESCRIPTION
Some changes decoupled from https://github.com/typelevel/otel4s/pull/963. 

The changes:
- chain functions
- reuse `InstrumentMeta` instance
- add benchmark

## Benchmark

`addParamsAndUse` is the most relevant benchmark. The throughput is roughly the same, and the normalized memory usage is slightly lower. But realistically, there is no difference. 

### Baseline

```
#### baseline with build use

Benchmark                             (backend)  Mode  Cnt      Score      Error   Units
addParams                                  noop  avgt   80      1.177 ±    0.010   ns/op
addParams:gc.alloc.rate.norm               noop  avgt   80     ≈ 10⁻³               B/op
addParams                              oteljava  avgt   80     61.681 ±    0.221   ns/op
addParams:gc.alloc.rate.norm           oteljava  avgt   80    672.001 ±    9.229    B/op
addParams                                   sdk  avgt   80     71.809 ±    0.275   ns/op
addParams:gc.alloc.rate.norm                sdk  avgt   80    712.002 ±    0.002    B/op
addParamsAndUse                            noop  avgt   80   5673.401 ±  170.063   ns/op
addParamsAndUse:gc.alloc.rate.norm         noop  avgt   80   1004.033 ±    4.615    B/op
addParamsAndUse                        oteljava  avgt   80  11622.442 ± 1421.261   ns/op
addParamsAndUse:gc.alloc.rate.norm     oteljava  avgt   80   7659.956 ±    4.587    B/op
addParamsAndUse                             sdk  avgt   80  22796.905 ±  302.181   ns/op
addParamsAndUse:gc.alloc.rate.norm          sdk  avgt   80  46600.915 ±  628.481    B/op
createSpanBuilder                          noop  avgt   80      0.724 ±    0.008   ns/op
createSpanBuilder:gc.alloc.rate.norm       noop  avgt   80     ≈ 10⁻⁴               B/op
createSpanBuilder                      oteljava  avgt   80      3.884 ±    0.013   ns/op
createSpanBuilder:gc.alloc.rate.norm   oteljava  avgt   80     64.000 ±    0.001    B/op
createSpanBuilder                           sdk  avgt   80     11.018 ±    0.138   ns/op
createSpanBuilder:gc.alloc.rate.norm        sdk  avgt   80     72.000 ±    0.001    B/op
```

### This branch

```
Benchmark                             (backend)  Mode  Cnt      Score      Error   Units
addParams                                  noop  avgt   80      1.159 ±    0.022   ns/op
addParams:gc.alloc.rate.norm               noop  avgt   80     ≈ 10⁻³               B/op
addParams                              oteljava  avgt   80      9.614 ±    0.163   ns/op
addParams:gc.alloc.rate.norm           oteljava  avgt   80    112.000 ±    0.001    B/op
addParams                                   sdk  avgt   80      9.706 ±    0.130   ns/op
addParams:gc.alloc.rate.norm                sdk  avgt   80    112.000 ±    0.001    B/op
addParamsAndUse                            noop  avgt   80   5863.874 ±  112.985   ns/op
addParamsAndUse:gc.alloc.rate.norm         noop  avgt   80   1015.977 ±    0.227    B/op
addParamsAndUse                        oteljava  avgt   80  11447.127 ± 1114.902   ns/op
addParamsAndUse:gc.alloc.rate.norm     oteljava  avgt   80   7744.387 ±    0.337    B/op
addParamsAndUse                             sdk  avgt   80  22802.965 ±  282.893   ns/op
addParamsAndUse:gc.alloc.rate.norm          sdk  avgt   80  45765.508 ±  615.943    B/op
createSpanBuilder                          noop  avgt   80      0.750 ±    0.014   ns/op
createSpanBuilder:gc.alloc.rate.norm       noop  avgt   80     ≈ 10⁻⁴               B/op
createSpanBuilder                      oteljava  avgt   80      2.439 ±    0.011   ns/op
createSpanBuilder:gc.alloc.rate.norm   oteljava  avgt   80     40.000 ±    0.001    B/op
createSpanBuilder                           sdk  avgt   80      2.458 ±    0.010   ns/op
createSpanBuilder:gc.alloc.rate.norm        sdk  avgt   80     40.000 ±    0.001    B/op
```

