### PR TITLE
Redesign `BaggageManager`

### DIFF
--- a/core/common/src/main/scala/org/typelevel/otel4s/baggage/BaggageManager.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/baggage/BaggageManager.scala
@@ -16,7 +16,10 @@
 
 package org.typelevel.otel4s.baggage
 
+import cats.Applicative
 import cats.mtl.Local
+
+import scala.language.implicitConversions
 
 /** A utility for accessing and modifying [[`Baggage`]].
   *
@@ -30,29 +33,55 @@ import cats.mtl.Local
   *     _  <- Console[F].println("user_id: " + id)
   *   } yield ()
   *
-  * BaggageManager[F].local(io)(_.updated("user_id", "uid"))
+  * BaggageManager[F].modifiedScope(_.updated("user_id", "uid"))(io)
   *   }}}
   */
-trait BaggageManager[F[_]] extends Local[F, Baggage] {
+trait BaggageManager[F[_]] {
 
-  /** @return the current `Baggage` */
-  final def current: F[Baggage] = ask[Baggage]
+  // TODO: remove after finishing migrating away from Local
+  protected[BaggageManager] def applicative: Applicative[F]
+
+  /** @return the current scope's `Baggage` */
+  def current: F[Baggage]
 
   /** @return
     *   the [[Baggage.Entry entry]] to which the specified key is mapped, or `None` if the current `Baggage` contains no
     *   mapping for the key
     */
-  def get(key: String): F[Option[Baggage.Entry]] =
-    reader(_.get(key))
+  def get(key: String): F[Option[Baggage.Entry]]
 
   /** @return
     *   the value (without [[Baggage.Metadata metadata]]) to which the specified key is mapped, or `None` if the current
     *   `Baggage` contains no mapping for the key
     */
-  def getValue(key: String): F[Option[String]] =
-    reader(_.get(key).map(_.value))
+  def getValue(key: String): F[Option[String]]
+
+  /** Creates a new scope in which a modified version of the current `Baggage` is used. */
+  def modifiedScope[A](modify: Baggage => Baggage)(fa: F[A]): F[A]
+
+  /** Creates a new scope in which the given `Baggage` is used. */
+  def replacedScope[A](baggage: Baggage)(fa: F[A]): F[A]
 }
 
 object BaggageManager {
   def apply[F[_]](implicit ev: BaggageManager[F]): BaggageManager[F] = ev
+
+  private[this] def asLocal[F[_]](bm: BaggageManager[F]): Local[F, Baggage] =
+    new Local[F, Baggage] {
+      def applicative: Applicative[F] = bm.applicative
+      def ask[E2 >: Baggage]: F[E2] = applicative.widen(bm.current)
+      def local[A](fa: F[A])(f: Baggage => Baggage): F[A] =
+        bm.modifiedScope(f)(fa)
+    }
+
+  @deprecated(
+    "BaggageManager no longer extends Local. Use `current`, `modifiedScope` and `replacedScope`",
+    since = "1.13.0"
+  )
+  implicit def bmAsExplicitLocal[F[_]](bm: BaggageManager[F]): Local[F, Baggage] =
+    asLocal(bm)
+
+  @deprecated("BaggageManager no longer extends Local", since = "1.13.0")
+  implicit def bmAsImplicitLocal[F[_]](implicit bm: BaggageManager[F]): Local[F, Baggage] =
+    asLocal(bm)
 }

--- a/core/common/src/test/scala/org/typelevel/otel4s/baggage/BaggageManagerSuite.scala
+++ b/core/common/src/test/scala/org/typelevel/otel4s/baggage/BaggageManagerSuite.scala
@@ -25,16 +25,16 @@ abstract class BaggageManagerSuite extends CatsEffectSuite {
   protected final def testManager(name: String)(f: BaggageManager[IO] => IO[Unit]): Unit =
     test(name)(baggageManager.flatMap(f))
 
-  testManager(".ask consistent with .scope") { m =>
+  testManager(".current consistent with .replacedScope") { m =>
     val b1 = Baggage.empty
       .updated("key", "value")
       .updated("foo", "bar", "baz")
-    m.scope(m.ask[Baggage].map(assertEquals(_, b1)))(b1)
+    m.replacedScope(b1)(m.current.map(assertEquals(_, b1)))
   }
 
-  testManager(".ask consistent with .local") { m =>
-    m.local {
-      for (baggage <- m.ask[Baggage])
+  testManager(".current consistent with .modifiedScope") { m =>
+    m.modifiedScope(_.updated("key", "value").updated("foo", "bar", "baz")) {
+      for (baggage <- m.current)
         yield {
           assertEquals(baggage.get("key"), Some(Baggage.Entry("value", None)))
           assertEquals(
@@ -42,35 +42,20 @@ abstract class BaggageManagerSuite extends CatsEffectSuite {
             Some(Baggage.Entry("bar", Some(Baggage.Metadata("baz"))))
           )
         }
-    }(_.updated("key", "value").updated("foo", "bar", "baz"))
+    }
   }
 
-  testManager(".current is equivalent to .ask") { m =>
-    val check = m.scope {
+  testManager(".get consistent with .current") { m =>
+    val check = m.replacedScope(_) {
       for {
-        a <- m.ask[Baggage]
-        b <- m.current
-      } yield assertEquals(a, b)
-    }(_)
-    check(Baggage.empty)
-    check(
-      Baggage.empty
-        .updated("key", "value")
-        .updated("foo", "bar", "baz")
-    )
-  }
-
-  testManager(".get consistent with .ask") { m =>
-    val check = m.scope {
-      for {
-        baggage <- m.ask[Baggage]
+        baggage <- m.current
         v1 <- m.get("key")
         v2 <- m.get("foo")
       } yield {
         assertEquals(v1, baggage.get("key"))
         assertEquals(v2, baggage.get("foo"))
       }
-    }(_)
+    }
     check(Baggage.empty)
     check(
       Baggage.empty
@@ -79,17 +64,17 @@ abstract class BaggageManagerSuite extends CatsEffectSuite {
     )
   }
 
-  testManager(".getValue consistent with .ask") { m =>
-    val check = m.scope {
+  testManager(".getValue consistent with .current") { m =>
+    val check = m.replacedScope(_) {
       for {
-        baggage <- m.ask[Baggage]
+        baggage <- m.current
         v1 <- m.getValue("key")
         v2 <- m.getValue("foo")
       } yield {
         assertEquals(v1, baggage.get("key").map(_.value))
         assertEquals(v2, baggage.get("foo").map(_.value))
       }
-    }(_)
+    }
     check(Baggage.empty)
     check(
       Baggage.empty

--- a/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/baggage/BaggageManagerImpl.scala
+++ b/oteljava/common/src/main/scala/org/typelevel/otel4s/oteljava/baggage/BaggageManagerImpl.scala
@@ -26,31 +26,34 @@ import org.typelevel.otel4s.oteljava.context.LocalContext
 
 private final class BaggageManagerImpl[F[_]] private (implicit localContext: LocalContext[F])
     extends BaggageManager[F] {
-  def applicative: Applicative[F] = localContext.applicative
-  def ask[E2 >: Baggage]: F[E2] =
-    localContext.reader { ctx =>
-      Option(JBaggage.fromContextOrNull(ctx.underlying))
-        .fold(Baggage.empty)(_.toScala)
-    }
-  def local[A](fa: F[A])(f: Baggage => Baggage): F[A] =
+  import BaggageManagerImpl.jBaggageFromContext
+
+  protected[BaggageManager] def applicative: Applicative[F] = localContext.applicative
+  def current: F[Baggage] =
+    localContext.reader(jBaggageFromContext(_).toScala)
+  def modifiedScope[A](f: Baggage => Baggage)(fa: F[A]): F[A] =
     localContext.local(fa) { ctx =>
       val jCtx = ctx.underlying
-      val jBaggage = JBaggage.fromContext(jCtx)
-      val updated = f(jBaggage.toScala).toJava
+      val updated = f(JBaggage.fromContext(jCtx).toScala).toJava
       Context.wrap(jCtx.`with`(updated))
     }
+  def replacedScope[A](baggage: Baggage)(fa: F[A]): F[A] =
+    localContext.local(fa)(_.map(_.`with`(baggage.toJava)))
   override def get(key: String): F[Option[Baggage.Entry]] =
     localContext.reader { ctx =>
-      Option(JBaggage.fromContext(ctx.underlying).getEntry(key))
+      Option(jBaggageFromContext(ctx).getEntry(key))
         .map(_.toScala)
     }
   override def getValue(key: String): F[Option[String]] =
     localContext.reader { ctx =>
-      Option(JBaggage.fromContext(ctx.underlying).getEntryValue(key))
+      Option(jBaggageFromContext(ctx).getEntryValue(key))
     }
 }
 
 private[oteljava] object BaggageManagerImpl {
+  private def jBaggageFromContext(context: Context): JBaggage =
+    JBaggage.fromContext(context.underlying)
+
   def fromLocal[F[_]: LocalContext]: BaggageManager[F] =
     new BaggageManagerImpl[F]
 }

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/baggage/SdkBaggageManager.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/baggage/SdkBaggageManager.scala
@@ -26,13 +26,20 @@ import org.typelevel.otel4s.sdk.context.LocalContext
 private final class SdkBaggageManager[F[_]](implicit localContext: LocalContext[F]) extends BaggageManager[F] {
   import SdkBaggageManager._
 
-  def applicative: Applicative[F] = localContext.applicative
-  def ask[E2 >: Baggage]: F[E2] =
+  protected[BaggageManager] def applicative: Applicative[F] =
+    localContext.applicative
+  def current: F[Baggage] =
     localContext.reader(baggageFromContext)
-  def local[A](fa: F[A])(f: Baggage => Baggage): F[A] =
+  def modifiedScope[A](f: Baggage => Baggage)(fa: F[A]): F[A] =
     localContext.local(fa) { ctx =>
       ctx.updated(BaggageKey, f(baggageFromContext(ctx)))
     }
+  def replacedScope[A](baggage: Baggage)(fa: F[A]): F[A] =
+    localContext.local(fa)(_.updated(BaggageKey, baggage))
+  def get(key: String): F[Option[Baggage.Entry]] =
+    localContext.reader(baggageFromContext(_).get(key))
+  def getValue(key: String): F[Option[String]] =
+    localContext.reader(baggageFromContext(_).get(key).map(_.value))
 }
 
 private[sdk] object SdkBaggageManager {


### PR DESCRIPTION
Change `BaggageManager` to no longer extend `cats.mtl.Local`, and rename some of its methods. Add deprecated implicit conversions to `Local` for migratory purposes.