### PR TITLE
sdk-trace: use `TracerProvider.noop` when span processors aren't configured

### DIFF
--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProvider.scala
@@ -203,17 +203,20 @@ object SdkTracerProvider {
       copy(spanProcessors = this.spanProcessors :+ processor)
 
     def build: F[TracerProvider[F]] =
-      SpanStorage.create[F].map { storage =>
-        new SdkTracerProvider[F](
-          idGenerator,
-          resource,
-          spanLimits,
-          sampler,
-          ContextPropagators.of(propagators: _*),
-          spanProcessors,
-          SdkTraceScope.fromLocal[F],
-          storage
-        )
-      }
+      if (spanProcessors.isEmpty)
+        Temporal[F].pure(TracerProvider.noop)
+      else
+        SpanStorage.create[F].map { storage =>
+          new SdkTracerProvider[F](
+            idGenerator,
+            resource,
+            spanLimits,
+            sampler,
+            ContextPropagators.of(propagators: _*),
+            spanProcessors,
+            SdkTraceScope.fromLocal[F],
+            storage
+          )
+        }
   }
 }

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/BatchSpanProcessor.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/processor/BatchSpanProcessor.scala
@@ -45,6 +45,9 @@ import scala.concurrent.duration._
   * @see
   *   [[https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor]]
   *
+  * @see
+  *   [[https://opentelemetry.io/docs/languages/java/configuration/#properties-traces]]
+  *
   * @tparam F
   *   the higher-kinded type of a polymorphic effect
   */

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProviderSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerProviderSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.trace
+
+import cats.effect.IO
+import cats.effect.IOLocal
+import munit.CatsEffectSuite
+import org.typelevel.otel4s.sdk.context.Context
+
+class SdkTracerProviderSuite extends CatsEffectSuite {
+
+  test("use noop TracerProvider when span processors aren't configured") {
+    IOLocal(Context.root).map(_.asLocal).flatMap { implicit local =>
+      for {
+        provider <- SdkTracerProvider.builder[IO].build
+      } yield assertEquals(provider.toString, "TracerProvider.Noop")
+    }
+  }
+
+}


### PR DESCRIPTION
For the sake of consistency with oteljava.