### PR TITLE
sdk: move `LimitedData` to sdk-common

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/BatchSpanProcessorBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/BatchSpanProcessorBenchmark.scala
@@ -150,7 +150,8 @@ object BatchSpanProcessorBenchmark {
       import org.typelevel.otel4s.sdk.TelemetryResource
       import org.typelevel.otel4s.sdk.common.InstrumentationScope
       import org.typelevel.otel4s.sdk.trace.IdGenerator
-      import org.typelevel.otel4s.sdk.trace.data.{LimitedData, SpanData, StatusData}
+      import org.typelevel.otel4s.sdk.data.LimitedData
+      import org.typelevel.otel4s.sdk.trace.data.{SpanData, StatusData}
       import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter
       import org.typelevel.otel4s.sdk.trace.processor.BatchSpanProcessor
 
@@ -174,8 +175,8 @@ object BatchSpanProcessorBenchmark {
           endTimestamp = None,
           status = StatusData.Ok,
           attributes = LimitedData.attributes(Int.MaxValue, 1024),
-          events = LimitedData.events(Int.MaxValue),
-          links = LimitedData.links(Int.MaxValue),
+          events = LimitedData.vector(Int.MaxValue),
+          links = LimitedData.vector(Int.MaxValue),
           instrumentationScope = InstrumentationScope.empty,
           resource = TelemetryResource.empty
         )

--- a/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MultiSpanProcessorBenchmark.scala
+++ b/benchmarks/src/main/scala/org/typelevel/otel4s/benchmarks/MultiSpanProcessorBenchmark.scala
@@ -105,7 +105,8 @@ object MultiSpanProcessorBenchmark {
       import org.typelevel.otel4s.trace.{SpanContext, SpanKind}
       import org.typelevel.otel4s.sdk.TelemetryResource
       import org.typelevel.otel4s.sdk.common.InstrumentationScope
-      import org.typelevel.otel4s.sdk.trace.data.{LimitedData, SpanData, StatusData}
+      import org.typelevel.otel4s.sdk.data.LimitedData
+      import org.typelevel.otel4s.sdk.trace.data.{SpanData, StatusData}
       import org.typelevel.otel4s.sdk.trace.processor.SpanProcessor
 
       val processor: SpanProcessor[IO] = new SpanProcessor[IO] {
@@ -124,8 +125,8 @@ object MultiSpanProcessorBenchmark {
         endTimestamp = None,
         status = StatusData.Ok,
         attributes = LimitedData.attributes(Int.MaxValue, 1024),
-        events = LimitedData.events(Int.MaxValue),
-        links = LimitedData.links(Int.MaxValue),
+        events = LimitedData.vector(Int.MaxValue),
+        links = LimitedData.vector(Int.MaxValue),
         instrumentationScope = InstrumentationScope.empty,
         resource = TelemetryResource.empty
       )

--- a/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansProtoEncoderSuite.scala
+++ b/sdk-exporter/trace/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/trace/SpansProtoEncoderSuite.scala
@@ -26,8 +26,8 @@ import munit._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.scalacheck.Test
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.EventData
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.data.StatusData

--- a/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
+++ b/sdk/all/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkTracerSuite.scala
@@ -23,10 +23,10 @@ import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.context.propagation.TextMapPropagator
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
 import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.testkit.trace.TracesTestkit
 import org.typelevel.otel4s.sdk.trace.context.propagation.W3CTraceContextPropagator
 import org.typelevel.otel4s.sdk.trace.data.EventData
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.StatusData
 import org.typelevel.otel4s.sdk.trace.samplers.Sampler
 import org.typelevel.otel4s.trace.BaseTracerSuite

--- a/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/data/LimitedData.scala
+++ b/sdk/common/shared/src/main/scala/org/typelevel/otel4s/sdk/data/LimitedData.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.sdk.trace.data
+package org.typelevel.otel4s.sdk.data
 
 import cats.Hash
 import cats.Semigroup
@@ -135,26 +135,13 @@ object LimitedData {
     )
   }
 
-  /** Created [[LimitedData]] with the vector of [[LinkData]] inside.
+  /** Created [[LimitedData]] with the vector of `A` inside.
     *
     * @param sizeLimit
     *   The limit for container elements
     */
-  def links(sizeLimit: Int): LimitedData[LinkData, Vector[LinkData]] =
-    Impl[LinkData, Vector[LinkData]](
-      sizeLimit,
-      Vector.empty,
-      _ splitAt _,
-      Vector(_)
-    )
-
-  /** Created [[LimitedData]] with the vector of [[EventData]] inside.
-    *
-    * @param sizeLimit
-    *   The limit for container elements
-    */
-  def events(sizeLimit: Int): LimitedData[EventData, Vector[EventData]] =
-    Impl[EventData, Vector[EventData]](
+  def vector[A](sizeLimit: Int): LimitedData[A, Vector[A]] =
+    Impl[A, Vector[A]](
       sizeLimit,
       Vector.empty,
       _ splitAt _,

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/data/LimitedDataSuite.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/data/LimitedDataSuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.typelevel.otel4s.sdk.trace.data
+package org.typelevel.otel4s.sdk.data
 
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
@@ -22,7 +22,7 @@ import org.scalacheck.Prop
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.AttributeKey
 import org.typelevel.otel4s.Attributes
-import org.typelevel.otel4s.trace.scalacheck.Gens
+import org.typelevel.otel4s.sdk.scalacheck.Gens
 
 class LimitedDataSuite extends ScalaCheckSuite {
 

--- a/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/scalacheck/Gens.scala
+++ b/sdk/common/shared/src/test/scala/org/typelevel/otel4s/sdk/scalacheck/Gens.scala
@@ -17,8 +17,11 @@
 package org.typelevel.otel4s.sdk.scalacheck
 
 import org.scalacheck.Gen
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.sdk.TelemetryResource
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.data.LimitedData
 
 import scala.concurrent.duration._
 
@@ -40,6 +43,15 @@ trait Gens extends org.typelevel.otel4s.scalacheck.Gens {
       schemaUrl <- Gen.option(nonEmptyString)
       attributes <- Gens.attributes
     } yield InstrumentationScope(name, version, schemaUrl, attributes)
+
+  val limitedAttributes: Gen[LimitedData[Attribute[_], Attributes]] =
+    for {
+      attributes <- Gens.nonEmptyVector(Gens.attribute)
+      extraAttributes <- Gens.nonEmptyVector(Gens.attribute)
+      valueLengthLimit <- Gen.posNum[Int]
+    } yield LimitedData
+      .attributes(attributes.length, valueLengthLimit)
+      .appendAll((attributes ++: extraAttributes).toVector.to(Attributes))
 
 }
 

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackend.scala
@@ -28,9 +28,9 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.SdkSpanBackend.MutableState
 import org.typelevel.otel4s.sdk.trace.data.EventData
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.data.StatusData
@@ -317,7 +317,7 @@ private object SdkSpanBackend {
       status = StatusData.Unset,
       attributes = attributes,
       links = links,
-      events = LimitedData.events(spanLimits.maxNumberOfEvents),
+      events = LimitedData.vector[EventData](spanLimits.maxNumberOfEvents),
       endTimestamp = None
     )
 

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilder.scala
@@ -29,7 +29,7 @@ import cats.~>
 import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
 import org.typelevel.otel4s.sdk.context.Context
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.samplers.SamplingResult
 import org.typelevel.otel4s.trace.Span
@@ -124,7 +124,7 @@ private final case class SdkSpanBuilder[F[_]: Temporal: Console] private (
       }
 
       LimitedData
-        .links(tracerSharedState.spanLimits.maxNumberOfLinks)
+        .vector[LinkData](tracerSharedState.spanLimits.maxNumberOfLinks)
         .appendAll(links)
     }
 

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/EventData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/EventData.scala
@@ -21,6 +21,7 @@ package trace.data
 import cats.Hash
 import cats.Show
 import cats.syntax.show._
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.semconv.attributes.ExceptionAttributes
 
 import java.io.PrintWriter

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LinkData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/LinkData.scala
@@ -22,6 +22,7 @@ package data
 import cats.Hash
 import cats.Show
 import cats.syntax.show._
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.trace.SpanContext
 
 /** Data representation of a link.

--- a/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
+++ b/sdk/trace/src/main/scala/org/typelevel/otel4s/sdk/trace/data/SpanData.scala
@@ -24,6 +24,7 @@ import cats.Show
 import cats.syntax.foldable._
 import cats.syntax.show._
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.trace.SpanContext
 import org.typelevel.otel4s.trace.SpanKind
 

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBackendSuite.scala
@@ -30,9 +30,9 @@ import munit.internal.PlatformCompat
 import org.scalacheck.Test
 import org.scalacheck.effect.PropF
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.test.NoopConsole
 import org.typelevel.otel4s.sdk.trace.data.EventData
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.data.StatusData
@@ -372,8 +372,8 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
                 spanLimits.maxAttributeValueLength
               )
               .appendAll(attributes),
-            events = LimitedData.events(spanLimits.maxNumberOfEvents),
-            links = LimitedData.links(spanLimits.maxNumberOfLinks).appendAll(links),
+            events = LimitedData.vector[EventData](spanLimits.maxNumberOfEvents),
+            links = LimitedData.vector[LinkData](spanLimits.maxNumberOfLinks).appendAll(links),
             instrumentationScope = scope,
             resource = Defaults.resource
           )
@@ -397,7 +397,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
                   spanLimits.maxAttributeValueLength
                 )
                 .appendAll(attributes),
-              LimitedData.links(spanLimits.maxNumberOfLinks).appendAll(links),
+              LimitedData.vector[LinkData](spanLimits.maxNumberOfLinks).appendAll(links),
               userStartTimestamp
             )
             _ <- assertIO(span.toSpanData, expected(None))
@@ -454,8 +454,8 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
               spanLimits.maxAttributeValueLength
             )
             .appendAll(Defaults.attributes),
-          events = LimitedData.events(spanLimits.maxNumberOfEvents),
-          links = LimitedData.links(spanLimits.maxNumberOfLinks),
+          events = LimitedData.vector[EventData](spanLimits.maxNumberOfEvents),
+          links = LimitedData.vector[LinkData](spanLimits.maxNumberOfLinks),
           instrumentationScope = Defaults.scope,
           resource = Defaults.resource
         )
@@ -526,7 +526,7 @@ class SdkSpanBackendSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           spanLimits.maxAttributeValueLength
         )
         .appendAll(attributes),
-      links = LimitedData.links(spanLimits.maxNumberOfLinks).appendAll(links),
+      links = LimitedData.vector[LinkData](spanLimits.maxNumberOfLinks).appendAll(links),
       userStartTimestamp = userStartTimestamp
     )
   }

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/SdkSpanBuilderSuite.scala
@@ -30,8 +30,8 @@ import org.typelevel.otel4s.meta.InstrumentMeta
 import org.typelevel.otel4s.sdk.TelemetryResource
 import org.typelevel.otel4s.sdk.common.InstrumentationScope
 import org.typelevel.otel4s.sdk.context.Context
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.SdkSpanBuilderSuite.LinkDataInput
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.exporter.InMemorySpanExporter
 import org.typelevel.otel4s.sdk.trace.exporter.SpanExporter

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/data/EventDataSuite.scala
@@ -25,6 +25,7 @@ import cats.syntax.show._
 import munit.DisciplineSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.scalacheck.Arbitraries
 import org.typelevel.otel4s.sdk.trace.scalacheck.Cogens
 import org.typelevel.otel4s.sdk.trace.scalacheck.Gens

--- a/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/scalacheck/Gens.scala
+++ b/sdk/trace/src/test/scala/org/typelevel/otel4s/sdk/trace/scalacheck/Gens.scala
@@ -17,10 +17,8 @@
 package org.typelevel.otel4s.sdk.trace.scalacheck
 
 import org.scalacheck.Gen
-import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.Attributes
+import org.typelevel.otel4s.sdk.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.EventData
-import org.typelevel.otel4s.sdk.trace.data.LimitedData
 import org.typelevel.otel4s.sdk.trace.data.LinkData
 import org.typelevel.otel4s.sdk.trace.data.SpanData
 import org.typelevel.otel4s.sdk.trace.data.StatusData
@@ -41,15 +39,6 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens with org.typelevel.o
       decision <- Gens.samplingDecision
       attributes <- Gens.attributes
     } yield SamplingResult(decision, attributes)
-
-  val limitedAttributes: Gen[LimitedData[Attribute[_], Attributes]] =
-    for {
-      attributes <- Gens.nonEmptyVector(Gens.attribute)
-      extraAttributes <- Gens.nonEmptyVector(Gens.attribute)
-      valueLengthLimit <- Gen.posNum[Int]
-    } yield LimitedData
-      .attributes(attributes.length, valueLengthLimit)
-      .appendAll((attributes ++: extraAttributes).toVector.to(Attributes))
 
   val eventData: Gen[EventData] =
     for {
@@ -79,7 +68,7 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens with org.typelevel.o
       events <- Gens.nonEmptyVector(Gens.eventData)
       extraEvents <- Gens.nonEmptyVector(Gens.eventData)
     } yield LimitedData
-      .events(events.length)
+      .vector[EventData](events.length)
       .appendAll((events ++: extraEvents).toVector)
 
   val limitedLinks: Gen[LimitedData[LinkData, Vector[LinkData]]] =
@@ -87,7 +76,7 @@ trait Gens extends org.typelevel.otel4s.sdk.scalacheck.Gens with org.typelevel.o
       links <- Gens.nonEmptyVector(Gens.linkData)
       extraLinks <- Gens.nonEmptyVector(Gens.linkData)
     } yield LimitedData
-      .links(links.length)
+      .vector[LinkData](links.length)
       .appendAll((links ++: extraLinks).toVector)
 
   val spanData: Gen[SpanData] =


### PR DESCRIPTION
A preparation for https://github.com/iRevive/otel4s/pull/7. The `LimitedData` will be used by the `LogRecordData`. 
We may also use `LimitedData` in the sdk-metrics module eventually. 