### PR TITLE
sdk-metrics: flush PeriodicMetricReader upon finalization

### DIFF
--- a/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReader.scala
+++ b/sdk/metrics/src/main/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReader.scala
@@ -158,6 +158,7 @@ private object PeriodicMetricReader {
         exporter,
         Config(interval, timeout)
       )
+      _ <- Resource.onFinalize(reader.forceFlush)
       _ <- reader.worker.background
     } yield reader
 

--- a/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReaderSuite.scala
+++ b/sdk/metrics/src/test/scala/org/typelevel/otel4s/sdk/metrics/exporter/PeriodicMetricReaderSuite.scala
@@ -63,6 +63,9 @@ class PeriodicMetricReaderSuite extends CatsEffectSuite with ScalaCheckEffectSui
             } yield ()
           }
 
+          // should export metrics upon finalization
+          _ <- exporter.exportedMetrics.assertEquals(metrics)
+
           // outside of the periodic reader lifecycle, should be empty
           _ <- IO.sleep(15.seconds)
           _ <- exporter.exportedMetrics.assertEquals(Nil)


### PR DESCRIPTION
Without this fix, the metrics aren't exported in short-lived applications. For example:
```scala
def run: IO[Unit] =
  OpenTelemetrySdk
    .autoConfigured[IO](_.addExportersConfigurer(OtlpExportersAutoConfigure[IO]))
    .use { otel4s =>
      otel4s.sdk.meterProvider.get("meter").flatMap { m =>
        m.counter[Long]("my_service_counter").create.flatMap(_.inc())
      }
    }
```