### PR TITLE
Rename most `mapK` methods to `liftTo`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,8 +248,17 @@ lazy val `core-trace` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scodec" %%% "scodec-bits" % ScodecVersion,
       "org.typelevel" %%% "cats-laws" % CatsVersion % Test,
       "org.typelevel" %%% "discipline-munit" % MUnitDisciplineVersion % Test,
-      "org.typelevel" %%% "scalacheck-effect-munit" % MUnitScalaCheckEffectVersion % Test
-    )
+      "org.typelevel" %%% "scalacheck-effect-munit" % MUnitScalaCheckEffectVersion % Test,
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      // # 1002
+      // all of these classes are private (and not serializable), so this is safe
+      ProblemFilters.exclude[MissingClassProblem]("org.typelevel.otel4s.trace.SpanBuilder$MappedK"),
+      ProblemFilters.exclude[MissingClassProblem]("org.typelevel.otel4s.trace.SpanOps$MappedK"),
+      ProblemFilters.exclude[MissingClassProblem]("org.typelevel.otel4s.trace.Tracer$MappedK"),
+      ProblemFilters.exclude[MissingClassProblem]("org.typelevel.otel4s.trace.TracerBuilder$MappedK"),
+      ProblemFilters.exclude[MissingClassProblem]("org.typelevel.otel4s.trace.TracerProvider$MappedK"),
+    ),
   )
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)

--- a/core/common/src/main/scala/org/typelevel/otel4s/baggage/BaggageManager.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/baggage/BaggageManager.scala
@@ -42,7 +42,7 @@ trait BaggageManager[F[_]] {
   /** @return the current scope's `Baggage` */
   def current: F[Baggage]
 
-  @deprecated("BaggageManager no longer extends Local. Use `current` instead", since = "0.13.0")
+  @deprecated("BaggageManager no longer extends Local. Use `current` instead", since = "otel4s 0.13.0")
   final def ask[E2 >: Baggage]: F[E2] = applicative.widen(current)
 
   /** @return
@@ -60,14 +60,14 @@ trait BaggageManager[F[_]] {
   /** Creates a new scope in which a modified version of the current `Baggage` is used. */
   def local[A](modify: Baggage => Baggage)(fa: F[A]): F[A]
 
-  @deprecated("BaggageManager no longer extends Local. Reverse parameter list order", since = "0.13.0")
+  @deprecated("BaggageManager no longer extends Local. Reverse parameter list order", since = "otel4s 0.13.0")
   final def local[A](fa: F[A])(modify: Baggage => Baggage): F[A] =
     local(modify)(fa)
 
   /** Creates a new scope in which the given `Baggage` is used. */
   def scope[A](baggage: Baggage)(fa: F[A]): F[A]
 
-  @deprecated("BaggageManager no longer extends Local. Reverse parameter list order", since = "0.13.0")
+  @deprecated("BaggageManager no longer extends Local. Reverse parameter list order", since = "otel4s 0.13.0")
   final def scope[A](fa: F[A])(baggage: Baggage): F[A] =
     scope(baggage)(fa)
 }
@@ -75,7 +75,7 @@ trait BaggageManager[F[_]] {
 object BaggageManager {
   def apply[F[_]](implicit ev: BaggageManager[F]): BaggageManager[F] = ev
 
-  @deprecated("BaggageManager no longer extends Local", since = "0.13.0")
+  @deprecated("BaggageManager no longer extends Local", since = "otel4s 0.13.0")
   implicit def asExplicitLocal[F[_]](bm: BaggageManager[F]): Local[F, Baggage] =
     new Local[F, Baggage] {
       def applicative: Applicative[F] = bm.applicative

--- a/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
+++ b/core/common/src/main/scala/org/typelevel/otel4s/meta/InstrumentMeta.scala
@@ -43,8 +43,11 @@ object InstrumentMeta {
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): InstrumentMeta.Dynamic[G] =
+    def liftTo[G[_]: Monad](implicit kt: KindTransformer[F, G]): InstrumentMeta.Dynamic[G] =
       mapK(kt.liftK)
+
+    @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+    def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): InstrumentMeta.Dynamic[G] = liftTo[G]
   }
 
   object Dynamic {
@@ -93,8 +96,11 @@ object InstrumentMeta {
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    def mapK[G[_]](implicit kt: KindTransformer[F, G]): InstrumentMeta.Static[G] =
+    def liftTo[G[_]](implicit kt: KindTransformer[F, G]): InstrumentMeta.Static[G] =
       mapK(kt.liftK)
+
+    @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+    def mapK[G[_]](implicit kt: KindTransformer[F, G]): InstrumentMeta.Static[G] = liftTo[G]
   }
 
   object Static {

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
@@ -178,7 +178,7 @@ object LogRecordBuilder {
   )(implicit kt: KindTransformer[F, G])
       extends LogRecordBuilder[G, Ctx] {
 
-    val meta: InstrumentMeta.Dynamic[G] = builder.meta.mapK[G]
+    val meta: InstrumentMeta.Dynamic[G] = builder.meta.liftTo[G]
 
     def withTimestamp(timestamp: FiniteDuration): LogRecordBuilder[G, Ctx] =
       builder.withTimestamp(timestamp).liftTo

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
@@ -148,7 +148,7 @@ trait LogRecordBuilder[F[_], Ctx] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]](implicit G: Monad[G], kt: KindTransformer[F, G]): LogRecordBuilder[G, Ctx] =
+  def liftTo[G[_]](implicit G: Monad[G], kt: KindTransformer[F, G]): LogRecordBuilder[G, Ctx] =
     new LogRecordBuilder.MappedK(this)
 
 }
@@ -181,40 +181,40 @@ object LogRecordBuilder {
     val meta: InstrumentMeta.Dynamic[G] = builder.meta.mapK[G]
 
     def withTimestamp(timestamp: FiniteDuration): LogRecordBuilder[G, Ctx] =
-      builder.withTimestamp(timestamp).mapK
+      builder.withTimestamp(timestamp).liftTo
 
     def withTimestamp(timestamp: Instant): LogRecordBuilder[G, Ctx] =
-      builder.withTimestamp(timestamp).mapK
+      builder.withTimestamp(timestamp).liftTo
 
     def withObservedTimestamp(timestamp: FiniteDuration): LogRecordBuilder[G, Ctx] =
-      builder.withObservedTimestamp(timestamp).mapK
+      builder.withObservedTimestamp(timestamp).liftTo
 
     def withObservedTimestamp(timestamp: Instant): LogRecordBuilder[G, Ctx] =
-      builder.withObservedTimestamp(timestamp).mapK
+      builder.withObservedTimestamp(timestamp).liftTo
 
     def withContext(context: Ctx): LogRecordBuilder[G, Ctx] =
-      builder.withContext(context).mapK
+      builder.withContext(context).liftTo
 
     def withSeverity(severity: Severity): LogRecordBuilder[G, Ctx] =
-      builder.withSeverity(severity).mapK
+      builder.withSeverity(severity).liftTo
 
     def withSeverityText(severityText: String): LogRecordBuilder[G, Ctx] =
-      builder.withSeverityText(severityText).mapK
+      builder.withSeverityText(severityText).liftTo
 
     def withBody(body: AnyValue): LogRecordBuilder[G, Ctx] =
-      builder.withBody(body).mapK
+      builder.withBody(body).liftTo
 
     def withEventName(eventName: String): LogRecordBuilder[G, Ctx] =
-      builder.withEventName(eventName).mapK
+      builder.withEventName(eventName).liftTo
 
     def addAttribute[A](attribute: Attribute[A]): LogRecordBuilder[G, Ctx] =
-      builder.addAttribute(attribute).mapK
+      builder.addAttribute(attribute).liftTo
 
     def addAttributes(attributes: Attribute[_]*): LogRecordBuilder[G, Ctx] =
-      builder.addAttributes(attributes).mapK
+      builder.addAttributes(attributes).liftTo
 
     def addAttributes(attributes: immutable.Iterable[Attribute[_]]): LogRecordBuilder[G, Ctx] =
-      builder.addAttributes(attributes).mapK
+      builder.addAttributes(attributes).liftTo
 
     def emit: G[Unit] =
       kt.liftK(builder.emit)

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
@@ -71,8 +71,8 @@ object Logger {
       logger: Logger[F, Ctx]
   )(implicit kt: KindTransformer[F, G])
       extends Logger[G, Ctx] {
-    val meta: InstrumentMeta.Dynamic[G] = logger.meta.mapK[G]
-    def logRecordBuilder: LogRecordBuilder[G, Ctx] = logger.logRecordBuilder.liftTo
+    val meta: InstrumentMeta.Dynamic[G] = logger.meta.liftTo[G]
+    def logRecordBuilder: LogRecordBuilder[G, Ctx] = logger.logRecordBuilder.liftTo[G]
   }
 
   object Implicits {

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
@@ -46,7 +46,7 @@ trait Logger[F[_], Ctx] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Logger[G, Ctx] =
+  def liftTo[G[_]: Monad](implicit kt: KindTransformer[F, G]): Logger[G, Ctx] =
     new Logger.MappedK(this)
 }
 
@@ -66,13 +66,13 @@ object Logger {
       val logRecordBuilder: LogRecordBuilder[F, Ctx] = LogRecordBuilder.noop[F, Ctx]
     }
 
-  /** Implementation for [[Logger.mapK]]. */
+  /** Implementation for [[Logger.liftTo]]. */
   private class MappedK[F[_], G[_]: Monad, Ctx](
       logger: Logger[F, Ctx]
   )(implicit kt: KindTransformer[F, G])
       extends Logger[G, Ctx] {
     val meta: InstrumentMeta.Dynamic[G] = logger.meta.mapK[G]
-    def logRecordBuilder: LogRecordBuilder[G, Ctx] = logger.logRecordBuilder.mapK
+    def logRecordBuilder: LogRecordBuilder[G, Ctx] = logger.logRecordBuilder.liftTo
   }
 
   object Implicits {

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerBuilder.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerBuilder.scala
@@ -49,7 +49,7 @@ trait LoggerBuilder[F[_], Ctx] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerBuilder[G, Ctx] =
+  def liftTo[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerBuilder[G, Ctx] =
     new LoggerBuilder.MappedK(this)
 }
 
@@ -78,6 +78,6 @@ object LoggerBuilder {
     def withSchemaUrl(schemaUrl: String): LoggerBuilder[G, Ctx] =
       new MappedK(builder.withSchemaUrl(schemaUrl))
     def get: G[Logger[G, Ctx]] =
-      kt.liftK(builder.get.map(_.mapK[G]))
+      kt.liftK(builder.get.map(_.liftTo[G]))
   }
 }

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerProvider.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerProvider.scala
@@ -64,7 +64,7 @@ trait LoggerProvider[F[_], Ctx] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerProvider[G, Ctx] =
+  def liftTo[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerProvider[G, Ctx] =
     new LoggerProvider.MappedK(this)
 }
 
@@ -92,8 +92,8 @@ object LoggerProvider {
   )(implicit kt: KindTransformer[F, G])
       extends LoggerProvider[G, Ctx] {
     override def get(name: String): G[Logger[G, Ctx]] =
-      kt.liftK(provider.get(name).map(_.mapK[G]))
+      kt.liftK(provider.get(name).map(_.liftTo[G]))
     def logger(name: String): LoggerBuilder[G, Ctx] =
-      provider.logger(name).mapK[G]
+      provider.logger(name).liftTo[G]
   }
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Span.scala
@@ -111,8 +111,11 @@ trait Span[F[_]] extends SpanMacro[F] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Span[G] =
+  final def liftTo[G[_]](implicit kt: KindTransformer[F, G]): Span[G] =
     mapK(kt.liftK)
+
+  @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+  final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Span[G] = liftTo[G]
 }
 
 object Span {
@@ -156,8 +159,11 @@ object Span {
 
     /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
       */
-    final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Backend[G] =
+    final def liftTo[G[_]](implicit kt: KindTransformer[F, G]): Backend[G] =
       mapK(kt.liftK)
+
+    @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+    final def mapK[G[_]](implicit kt: KindTransformer[F, G]): Backend[G] = liftTo[G]
   }
 
   object Backend {
@@ -204,7 +210,7 @@ object Span {
         def end(timestamp: FiniteDuration): F[Unit] = unit
       }
 
-    /** Implementation for [[Backend.mapK]]. */
+    /** Implementation for [[Backend.liftTo]]. */
     private class MappedK[F[_], G[_]](backend: Backend[F])(f: F ~> G) extends Backend[G] {
       val meta: InstrumentMeta.Static[G] =
         backend.meta.mapK(f)

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/SpanBuilder.scala
@@ -52,11 +52,17 @@ trait SpanBuilder[F[_]] extends SpanBuilderMacro[F] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]: MonadCancelThrow](implicit
+  def liftTo[G[_]: MonadCancelThrow](implicit
       F: MonadCancelThrow[F],
       kt: KindTransformer[F, G]
   ): SpanBuilder[G] =
-    new SpanBuilder.MappedK(this)
+    new SpanBuilder.Lifted(this)
+
+  @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+  def mapK[G[_]: MonadCancelThrow](implicit
+      F: MonadCancelThrow[F],
+      kt: KindTransformer[F, G]
+  ): SpanBuilder[G] = liftTo[G]
 }
 
 object SpanBuilder {
@@ -248,18 +254,16 @@ object SpanBuilder {
       }
     }
 
-  /** Implementation for [[SpanBuilder.mapK]]. */
-  private class MappedK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](
+  /** Implementation for [[SpanBuilder.liftTo]]. */
+  private class Lifted[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](
       builder: SpanBuilder[F]
   )(implicit kt: KindTransformer[F, G])
       extends SpanBuilder[G] {
     val meta: InstrumentMeta.Dynamic[G] =
-      builder.meta.mapK[G]
-
+      builder.meta.liftTo[G]
     def modifyState(f: State => State): SpanBuilder[G] =
-      builder.modifyState(f).mapK[G]
-
+      builder.modifyState(f).liftTo[G]
     def build: SpanOps[G] =
-      builder.build.mapK[G]
+      builder.build.liftTo[G]
   }
 }

--- a/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
+++ b/core/trace/src/main/scala/org/typelevel/otel4s/trace/Tracer.scala
@@ -199,11 +199,17 @@ trait Tracer[F[_]] extends TracerMacro[F] {
 
   /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
     */
-  def mapK[G[_]: MonadCancelThrow](implicit
+  def liftTo[G[_]: MonadCancelThrow](implicit
       F: MonadCancelThrow[F],
       kt: KindTransformer[F, G]
   ): Tracer[G] =
-    new Tracer.MappedK(this)
+    new Tracer.Lifted(this)
+
+  @deprecated("use `liftTo` instead", since = "otel4s 0.14.0")
+  def mapK[G[_]: MonadCancelThrow](implicit
+      F: MonadCancelThrow[F],
+      kt: KindTransformer[F, G]
+  ): Tracer[G] = liftTo[G]
 }
 
 object Tracer {
@@ -239,20 +245,20 @@ object Tracer {
         Applicative[F].pure(carrier)
     }
 
-  /** Implementation for [[Tracer.mapK]]. */
-  private class MappedK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](
+  /** Implementation for [[Tracer.liftTo]]. */
+  private class Lifted[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](
       tracer: Tracer[F]
   )(implicit kt: KindTransformer[F, G])
       extends Tracer[G] {
-    val meta: InstrumentMeta.Dynamic[G] = tracer.meta.mapK[G]
+    val meta: InstrumentMeta.Dynamic[G] = tracer.meta.liftTo[G]
     def currentSpanContext: G[Option[SpanContext]] =
       kt.liftK(tracer.currentSpanContext)
     def currentSpanOrNoop: G[Span[G]] =
-      kt.liftK(tracer.currentSpanOrNoop.map(_.mapK[G]))
+      kt.liftK(tracer.currentSpanOrNoop.map(_.liftTo[G]))
     def currentSpanOrThrow: G[Span[G]] =
-      kt.liftK(tracer.currentSpanOrThrow.map(_.mapK[G]))
+      kt.liftK(tracer.currentSpanOrThrow.map(_.liftTo[G]))
     def spanBuilder(name: String): SpanBuilder[G] =
-      tracer.spanBuilder(name).mapK[G]
+      tracer.spanBuilder(name).liftTo[G]
     def childScope[A](parent: SpanContext)(ga: G[A]): G[A] =
       kt.limitedMapK(ga)(new (F ~> F) {
         def apply[B](fb: F[B]): F[B] = tracer.childScope(parent)(fb)

--- a/core/trace/src/test/scala/org/typelevel/otel4s/trace/BaseTracerSuite.scala
+++ b/core/trace/src/test/scala/org/typelevel/otel4s/trace/BaseTracerSuite.scala
@@ -847,12 +847,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[IO]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[IO]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[IO]
+        tracer = tracerIO.liftTo[IO]
         _ <- tracer
           .span("outer")
           .surround {
@@ -872,12 +872,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[OptionT[IO, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[OptionT[IO, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[OptionT[IO, *]]
+        tracer = tracerIO.liftTo[OptionT[IO, *]]
         _ <- tracer
           .span("outer")
           .surround {
@@ -898,12 +898,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[EitherT[IO, String, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[EitherT[IO, String, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[EitherT[IO, String, *]]
+        tracer = tracerIO.liftTo[EitherT[IO, String, *]]
         _ <- tracer
           .span("outer")
           .surround {
@@ -924,12 +924,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[IorT[IO, String, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[IorT[IO, String, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[IorT[IO, String, *]]
+        tracer = tracerIO.liftTo[IorT[IO, String, *]]
         _ <- tracer
           .span("outer")
           .surround {
@@ -950,12 +950,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[Kleisli[IO, String, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[Kleisli[IO, String, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[Kleisli[IO, String, *]]
+        tracer = tracerIO.liftTo[Kleisli[IO, String, *]]
         _ <- tracer
           .span("outer")
           .surround {
@@ -976,12 +976,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[WriterT[IO, Int, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[WriterT[IO, Int, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[WriterT[IO, Int, *]]
+        tracer = tracerIO.liftTo[WriterT[IO, Int, *]]
         _ <- tracer
           .span("outer")
           .surround {
@@ -1002,12 +1002,12 @@ abstract class BaseTracerSuite[Ctx, K[X] <: Key[X]](implicit
     }
   }
 
-  sdkTest("nested SpanOps#surround for mapK[Resource[IO, *]]") { sdk =>
+  sdkTest("nested SpanOps#surround for liftTo[Resource[IO, *]]") { sdk =>
     TestControl.executeEmbed {
       for {
         now <- IO.monotonic.delayBy(1.second) // otherwise returns 0
         tracerIO <- sdk.provider.get("tracer")
-        tracer = tracerIO.mapK[Resource[IO, *]]
+        tracer = tracerIO.liftTo[Resource[IO, *]]
         _ <- tracer
           .span("outer")
           .surround {


### PR DESCRIPTION
Rename `mapK` methods that take a `KindTransformer` to `liftTo`.

This change is preparation for #1001