### PR TITLE
core-logs: add `LoggerProvider`, `LoggerBuilder`, and `Logger`

### DIFF
--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LogRecordBuilder.scala
@@ -146,6 +146,8 @@ trait LogRecordBuilder[F[_], Ctx] {
     */
   def emit: F[Unit]
 
+  /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
+    */
   def mapK[G[_]](implicit G: Monad[G], kt: KindTransformer[F, G]): LogRecordBuilder[G, Ctx] =
     new LogRecordBuilder.MappedK(this)
 

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/Logger.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package logs
+
+import cats.Applicative
+import cats.Monad
+import org.typelevel.otel4s.meta.InstrumentMeta
+
+/** The entry point into a log pipeline.
+  *
+  * @note
+  *   the `Logger` is intended to be used only for bridging logs from other log frameworks into OpenTelemetry and is
+  *   '''NOT a replacement''' for logging API.
+  */
+trait Logger[F[_], Ctx] {
+
+  /** The instrument's metadata. Indicates whether instrumentation is enabled.
+    */
+  def meta: InstrumentMeta.Dynamic[F]
+
+  /** Returns a [[LogRecordBuilder]] to emit a log record.
+    *
+    * Construct the log record using [[LogRecordBuilder]], then emit the record via [[LogRecordBuilder.emit]].
+    *
+    * @note
+    *   this method is intended for use in appenders that bridge logs from existing logging frameworks, it is '''NOT a
+    *   replacement''' for a full-featured application logging framework and should not be used directly by application
+    *   developers
+    */
+  def logRecordBuilder: LogRecordBuilder[F, Ctx]
+
+  /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
+    */
+  def mapK[G[_]: Monad](implicit kt: KindTransformer[F, G]): Logger[G, Ctx] =
+    new Logger.MappedK(this)
+}
+
+object Logger {
+  def apply[F[_], Ctx](implicit ev: Logger[F, Ctx]): Logger[F, Ctx] = ev
+
+  /** Creates a no-op implementation of the [[Logger]].
+    *
+    * All logging operations are no-op.
+    *
+    * @tparam F
+    *   the higher-kinded type of polymorphic effect
+    */
+  def noop[F[_]: Applicative, Ctx]: Logger[F, Ctx] =
+    new Logger[F, Ctx] {
+      val meta: InstrumentMeta.Dynamic[F] = InstrumentMeta.Dynamic.disabled
+      val logRecordBuilder: LogRecordBuilder[F, Ctx] = LogRecordBuilder.noop[F, Ctx]
+    }
+
+  /** Implementation for [[Logger.mapK]]. */
+  private class MappedK[F[_], G[_]: Monad, Ctx](
+      logger: Logger[F, Ctx]
+  )(implicit kt: KindTransformer[F, G])
+      extends Logger[G, Ctx] {
+    val meta: InstrumentMeta.Dynamic[G] = logger.meta.mapK[G]
+    def logRecordBuilder: LogRecordBuilder[G, Ctx] = logger.logRecordBuilder.mapK
+  }
+
+  object Implicits {
+    implicit def noop[F[_]: Applicative, Ctx]: Logger[F, Ctx] = Logger.noop
+  }
+}

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerBuilder.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerBuilder.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package logs
+
+import cats.Applicative
+import cats.Functor
+import cats.Monad
+import cats.syntax.functor._
+
+/** A builder of the [[Logger]].
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/logs/api/#get-a-logger]]
+  */
+trait LoggerBuilder[F[_], Ctx] {
+
+  /** Assigns a version to the resulting Logger.
+    *
+    * @param version
+    *   the version of the instrumentation scope
+    */
+  def withVersion(version: String): LoggerBuilder[F, Ctx]
+
+  /** Assigns an OpenTelemetry schema URL to the resulting Logger.
+    *
+    * @param schemaUrl
+    *   the URL of the OpenTelemetry schema
+    */
+  def withSchemaUrl(schemaUrl: String): LoggerBuilder[F, Ctx]
+
+  /** Creates a [[Logger]] with the given `version` and `schemaUrl` (if any).
+    */
+  def get: F[Logger[F, Ctx]]
+
+  /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
+    */
+  def mapK[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerBuilder[G, Ctx] =
+    new LoggerBuilder.MappedK(this)
+}
+
+object LoggerBuilder {
+
+  /** Creates a no-op implementation of the [[LoggerBuilder]].
+    *
+    * A [[Logger]] has no-op implementation too.
+    *
+    * @tparam F
+    *   the higher-kinded type of polymorphic effect
+    */
+  def noop[F[_], Ctx](implicit F: Applicative[F]): LoggerBuilder[F, Ctx] =
+    new LoggerBuilder[F, Ctx] {
+      def withVersion(version: String): LoggerBuilder[F, Ctx] = this
+      def withSchemaUrl(schemaUrl: String): LoggerBuilder[F, Ctx] = this
+      def get: F[Logger[F, Ctx]] = F.pure(Logger.noop)
+    }
+
+  private class MappedK[F[_]: Functor, G[_]: Monad, Ctx](
+      builder: LoggerBuilder[F, Ctx]
+  )(implicit kt: KindTransformer[F, G])
+      extends LoggerBuilder[G, Ctx] {
+    def withVersion(version: String): LoggerBuilder[G, Ctx] =
+      new MappedK(builder.withVersion(version))
+    def withSchemaUrl(schemaUrl: String): LoggerBuilder[G, Ctx] =
+      new MappedK(builder.withSchemaUrl(schemaUrl))
+    def get: G[Logger[G, Ctx]] =
+      kt.liftK(builder.get.map(_.mapK[G]))
+  }
+}

--- a/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerProvider.scala
+++ b/core/logs/src/main/scala/org/typelevel/otel4s/logs/LoggerProvider.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s
+package logs
+
+import cats.Applicative
+import cats.Functor
+import cats.Monad
+import cats.syntax.functor._
+
+/** The entry point of the logging API. Provides access to [[Logger]].
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/otel/logs/api/#loggerprovider]]
+  */
+trait LoggerProvider[F[_], Ctx] {
+
+  /** Creates a named [[Logger]].
+    *
+    * @example
+    *   {{{
+    * val loggerProvider: LoggerProvider[IO] = ???
+    * val logger: IO[Logger[IO]] = loggerProvider.get("com.service.runtime")
+    *   }}}
+    *
+    * @param name
+    *   the name of the instrumentation scope, such as the instrumentation library, package, or fully qualified class
+    *   name
+    */
+  def get(name: String): F[Logger[F, Ctx]] =
+    logger(name).get
+
+  /** Creates a [[LoggerBuilder]] for a named [[Logger]] instance.
+    *
+    * @example
+    *   {{{
+    * val loggerProvider: LoggerProvider[IO] = ???
+    * val logger: IO[Logger[IO]] = loggerProvider
+    *   .logger("com.service.runtime")
+    *   .withVersion("1.0.0")
+    *   .withSchemaUrl("https://opentelemetry.io/schema/v1.1.0")
+    *   .get
+    *   }}}
+    *
+    * @param name
+    *   the name of the instrumentation scope, such as the instrumentation library, package, or fully qualified class
+    *   name
+    */
+  def logger(name: String): LoggerBuilder[F, Ctx]
+
+  /** Modify the context `F` using an implicit [[KindTransformer]] from `F` to `G`.
+    */
+  def mapK[G[_]](implicit F: Functor[F], G: Monad[G], kt: KindTransformer[F, G]): LoggerProvider[G, Ctx] =
+    new LoggerProvider.MappedK(this)
+}
+
+object LoggerProvider {
+
+  def apply[F[_], Ctx](implicit ev: LoggerProvider[F, Ctx]): LoggerProvider[F, Ctx] = ev
+
+  /** Creates a no-op implementation of the [[LoggerProvider]].
+    *
+    * A [[LoggerBuilder]] has no-op implementation too.
+    *
+    * @tparam F
+    *   the higher-kinded type of a polymorphic effect
+    */
+  def noop[F[_]: Applicative, Ctx]: LoggerProvider[F, Ctx] =
+    new LoggerProvider[F, Ctx] {
+      def logger(name: String): LoggerBuilder[F, Ctx] =
+        LoggerBuilder.noop
+      override def toString: String =
+        "LoggerProvider.Noop"
+    }
+
+  private class MappedK[F[_]: Functor, G[_]: Monad, Ctx](
+      provider: LoggerProvider[F, Ctx]
+  )(implicit kt: KindTransformer[F, G])
+      extends LoggerProvider[G, Ctx] {
+    override def get(name: String): G[Logger[G, Ctx]] =
+      kt.liftK(provider.get(name).map(_.mapK[G]))
+    def logger(name: String): LoggerBuilder[G, Ctx] =
+      provider.logger(name).mapK[G]
+  }
+}


### PR DESCRIPTION
The spec: https://opentelemetry.io/docs/specs/otel/logs/api/#get-a-logger.