### PR TITLE
semconv: fix semconv generation

### DIFF
--- a/buildscripts/semantic-convention/templates/registry/otel4s/attributes/SemanticAttributes.scala.j2
+++ b/buildscripts/semantic-convention/templates/registry/otel4s/attributes/SemanticAttributes.scala.j2
@@ -35,7 +35,7 @@ package attributes
 // DO NOT EDIT, this is an Auto-generated file from buildscripts/templates/registry/otel4s/attributes/SemanticAttributes.scala.j2
 object {{ object_name }} {
 
-  {% for attribute in ctx.attributes | rejectattr("name", "in", params.excluded_attributes) %}{% if params.stable_only == false or attribute is stable %}
+  {% for attribute in ctx.attributes | rejectattr("name", "in", params.excluded_attributes) | rejectattr("type", "eq", "any") %}{% if params.stable_only == false or attribute is stable %}
   {{ [attribute.brief, concat_if("\n\n@note\n\n", attribute.note)] | comment(indent=2) | replace('$', "$$") }}
   {%- if attribute is deprecated %}
   @deprecated("{{ attribute.deprecated.note | replace('"', "'") | trim }}", "")

--- a/project/SemanticConventionsGenerator.scala
+++ b/project/SemanticConventionsGenerator.scala
@@ -3,7 +3,7 @@ import scala.sys.process._
 
 object SemanticConventionsGenerator {
 
-  private val generatorVersion = "v0.15.1"
+  private val generatorVersion = "v0.17.1"
 
   // generates semantic conventions by using `otel/weaver` in docker
   def generate(version: String, rootDir: File): Unit = {

--- a/semconv/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/attributes/FeatureFlagExperimentalAttributes.scala
+++ b/semconv/experimental/src/main/scala/org/typelevel/otel4s/semconv/experimental/attributes/FeatureFlagExperimentalAttributes.scala
@@ -26,8 +26,9 @@ object FeatureFlagExperimentalAttributes {
   val FeatureFlagContextId: AttributeKey[String] =
     AttributeKey("feature_flag.context.id")
 
-  /** A message explaining the nature of an error occurring during flag evaluation.
+  /** Deprecated, use `error.message` instead.
     */
+  @deprecated("Replaced by `error.message`.", "")
   val FeatureFlagEvaluationErrorMessage: AttributeKey[String] =
     AttributeKey("feature_flag.evaluation.error.message")
 
@@ -45,7 +46,7 @@ object FeatureFlagExperimentalAttributes {
   /** Identifies the feature flag provider.
     */
   val FeatureFlagProviderName: AttributeKey[String] =
-    AttributeKey("feature_flag.provider_name")
+    AttributeKey("feature_flag.provider.name")
 
   /** The reason code which shows how a feature flag value was determined.
     */


### PR DESCRIPTION
The gen job was failing with the following error:
```
Diagnostic report:

  × Template evaluation error -> cannot deserialize: Expected simple type,
  │ template type, or enum type, found any (in SemanticAttributes.scala.j2:2)
  │ 
```

Some entries have `any` type for unknown reason. 

oteljava fixed the issue in a similar manner: https://github.com/open-telemetry/semantic-conventions-java/pull/217/files