### PR TITLE
add fromInMemory on Testkits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1004,6 +1004,7 @@ lazy val docs = project
   .dependsOn(
     oteljava,
     `oteljava-context-storage`,
+    `oteljava-context-storage-testkit`,
     `oteljava-testkit`,
     `instrumentation-metrics`.jvm,
     sdk.jvm,

--- a/docs/oteljava/testkit.md
+++ b/docs/oteljava/testkit.md
@@ -368,7 +368,7 @@ def program[F[_]: FlatMap: Tracer](
 for {
   inMemorySpanExporter <- IO.delay(InMemorySpanExporter.create()).toResource
   // create your OpenTelemetry with the InMemorySpanExporter created above
-  (openTelemetry: OpenTelemetry) = ???
+  (openTelemetry: OpenTelemetry) = null
 
   localProvider = IOLocalTestContextStorage.localProvider[IO]
   local <- {


### PR DESCRIPTION
Tell me if the `fromInMemory` in the inner Testkits is too much and I should just do a big one factory in the `OtelJavaTestkit`

Should I add an entry to the doc with an example of this?