### PR TITLE
Metrics SDK: Ignore empty and annotations unit

### DIFF
--- a/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusWriter.scala
+++ b/sdk-exporter/prometheus/src/main/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusWriter.scala
@@ -295,9 +295,9 @@ object PrometheusWriter {
       F.fromEither {
         metric.unit
           .filter(_ => !config.unitSuffixDisabled)
-          .map(convertUnitName)
+          .flatMap(convertUnitName)
           .fold(convertName(metric.name)) {
-            _.flatMap(convertName(metric.name, _))
+            convertName(metric.name, _)
           }
       }.flatMap { prometheusName =>
         val prometheusType = resolvePrometheusType(metric)

--- a/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusConverterSuite.scala
+++ b/sdk-exporter/prometheus/src/test/scala/org/typelevel/otel4s/sdk/exporter/prometheus/PrometheusConverterSuite.scala
@@ -118,12 +118,13 @@ class PrometheusConverterSuite extends FunSuite {
       ("g/x", "grams_per_x"),
       ("watts_W", "watts_W")
     ).foreach { case (unit, expected) =>
-      assertEquals(convertUnitName(unit), Right(expected))
+      assertEquals(convertUnitName(unit), Some(expected))
     }
   }
 
-  test("fail to convert an empty unit name") {
-    assertEquals(convertUnitName("").leftMap(_.getMessage), "Empty string is not a valid unit name".asLeft[String])
+  test("return None when convert an empty or only annotation unit name") {
+    assertEquals(convertUnitName(""), None)
+    assertEquals(convertUnitName("{thread}"), None)
   }
 
 }


### PR DESCRIPTION
before this commit, if an unit is an annotation (for example {thread}) convertUnitName("{thread}") returns Right("") therefore we add an extra underscore at the end of prometheus name.

This commit is fixing this issue and also change the semantic of convertUnitName to ignore empty or an annotation unit instead of throw exception

Fix #1088 