### PR TITLE
sdk-exporter: try to address flaky tests

### DIFF
--- a/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/DockerUtils.scala
+++ b/sdk-exporter/common/src/test/scala/org/typelevel/otel4s/sdk/exporter/otlp/DockerUtils.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.otel4s.sdk.exporter.otlp
+
+import cats.effect.Async
+import cats.effect.Temporal
+import cats.effect.std.Console
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import com.comcast.ip4s._
+import com.comcast.ip4s.Port
+import fs2.io.net.Network
+import fs2.io.process.ProcessBuilder
+import fs2.io.process.Processes
+import org.http4s.ember.client.EmberClientBuilder
+
+import scala.concurrent.duration._
+
+object DockerUtils {
+
+  final case class CollectorPortMappings(
+      health: Port,
+      otlpGrpc: Port,
+      otlpHttp: Port
+  )
+
+  def getCollectorPortMappings[F[_]: Async: Console: Network: Processes](
+      container: String
+  ): F[CollectorPortMappings] = {
+    val getPortMappings =
+      for {
+        health <- getPortMapping[F](container, port"13133")
+        otlpGrpc <- getPortMapping[F](container, port"4317")
+        otlpHttp <- getPortMapping[F](container, port"4318")
+      } yield CollectorPortMappings(health, otlpGrpc, otlpHttp)
+
+    val portMappings: F[CollectorPortMappings] = retry(20, 500.millis)(getPortMappings) {
+      case Right(_)    => Right(())
+      case Left(error) => Left(s"Cannot get collector ports: $error")
+    }
+
+    def awaitHealthy(collector: CollectorPortMappings): F[Unit] =
+      EmberClientBuilder.default[F].build.use { client =>
+        val url = s"http://localhost:${collector.health}/health"
+
+        retry(20, 500.millis)(client.expect[String](url)) {
+          case Right(content) =>
+            Either.cond(content.contains("Server available"), (), s"Collector is not healthy: $content")
+
+          case Left(e) =>
+            Left(s"Collector is not health: ${e.getMessage}")
+        }.void
+      }
+
+    for {
+      mappings <- portMappings
+      _ <- awaitHealthy(mappings)
+    } yield mappings
+  }
+
+  def getPortMapping[F[_]: Async: Processes](container: String, port: Port): F[Port] = {
+    val format = s"{{ (index (index .NetworkSettings.Ports \"$port/tcp\") 0).HostPort }}"
+
+    def tryParsePort(text: String): F[Port] =
+      Async[F].fromOption(
+        Port.fromString(text.trim),
+        new RuntimeException(s"Cannot parse [$text] as port")
+      )
+
+    def failure(exitCode: Int, stdout: String, stderr: String): F[Port] =
+      Async[F].raiseError(
+        new RuntimeException(
+          s"Cannot retrieve port number. Exit code [$exitCode]. stdout: $stdout. stderr: $stderr"
+        )
+      )
+
+    ProcessBuilder("docker", "inspect", "-f", format, container).spawn[F].use { process =>
+      val stdoutF = process.stdout.through(fs2.text.utf8.decode).compile.string
+      val stderrF = process.stderr.through(fs2.text.utf8.decode).compile.string
+      val exitCodeF = process.exitValue
+
+      stdoutF.both(stderrF).both(exitCodeF).flatMap { case ((stdout, stderr), exitCode) =>
+        if (exitCode == 0) tryParsePort(stdout) else failure(exitCode, stdout, stderr)
+      }
+    }
+  }
+
+  private def retry[F[_]: Temporal: Console, A](
+      maxAttempts: Int,
+      delay: FiniteDuration
+  )(fa: F[A])(checkResult: Either[Throwable, A] => Either[String, Unit]): F[A] = {
+    def loop(attempt: Int): F[A] = {
+      val step = s"${attempt + 1}/$maxAttempts"
+
+      def retry(message: String, cause: Option[Throwable]): F[A] =
+        if (attempt < maxAttempts)
+          Console[F].errorln(s"[$step] $message") *> loop(attempt + 1).delayBy(delay)
+        else
+          Temporal[F].raiseError(new RuntimeException(s"[$step] $message", cause.orNull))
+
+      fa.attempt.flatMap {
+        case Right(result) =>
+          checkResult(Right(result)).fold(violation => retry(violation, None), _ => Temporal[F].pure(result))
+
+        case Left(e) =>
+          checkResult(Left(e)).fold(violation => retry(violation, Some(e)), _ => Temporal[F].raiseError(e))
+      }
+    }
+
+    loop(0)
+  }
+
+}

--- a/sdk-exporter/logs/docker/config/otel-collector-config.yaml
+++ b/sdk-exporter/logs/docker/config/otel-collector-config.yaml
@@ -2,19 +2,25 @@ receivers:
   otlp:
     protocols: # enable OpenTelemetry Protocol receiver, both gRPC and HTTP
       grpc:
-        endpoint: 0.0.0.0:54317
+        endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:54318
+        endpoint: 0.0.0.0:4318
 
 exporters:
   otlphttp:
     endpoint: "http://loki:3100/otlp"
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: "/health"
 
 processors:
   batch:
     timeout: 0 # send data immediately
 
 service:
+  extensions: [health_check]
   pipelines:
     logs:
       receivers: [otlp]

--- a/sdk-exporter/logs/docker/docker-compose.yml
+++ b/sdk-exporter/logs/docker/docker-compose.yml
@@ -1,21 +1,24 @@
 version: '3.7'
 services:
   collector: # receives application metrics and traces via gRPC or HTTP protocol
-    image: otel/opentelemetry-collector-contrib:0.134.1
+    container_name: otel4s-it--sdk-exporter-logs--otel-collector
+    image: otel/opentelemetry-collector-contrib:0.137.0
     command: [ --config=/etc/otel-collector-config.yaml ]
     volumes:
       - "./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
     ports:
-      - "54317:54317" # OTLP gRPC receiver
-      - "54318:54318" # OTLP http receiver
+      - "4317" # OTLP gRPC receiver
+      - "4318" # OTLP http receiver
+      - "13133" # health check
     depends_on:
       loki:
         condition: service_healthy
 
   loki: # stores logs received from the OpenTelemetry Collector
+    container_name: otel4s-it--sdk-exporter-logs--loki
     image: grafana/loki:3.5.4
     ports:
-      - "53100:3100"
+      - "3100"
     healthcheck:
       test: [ "CMD", "wget", "--spider", "-S", "http://localhost:3100/ready" ]
       interval: 5s

--- a/sdk-exporter/metrics/docker/config/otel-collector-config.yaml
+++ b/sdk-exporter/metrics/docker/config/otel-collector-config.yaml
@@ -2,19 +2,25 @@ receivers:
   otlp:
     protocols: # enable OpenTelemetry Protocol receiver, both gRPC and HTTP
       grpc:
-        endpoint: 0.0.0.0:44317
+        endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:44318
+        endpoint: 0.0.0.0:4318
 
 exporters:
   prometheus:
     endpoint: "0.0.0.0:9464"
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: "/health"
 
 processors:
   batch:
     timeout: 0 # send data immediately
 
 service:
+  extensions: [health_check]
   pipelines:
     metrics:
       receivers: [otlp]

--- a/sdk-exporter/metrics/docker/docker-compose.yml
+++ b/sdk-exporter/metrics/docker/docker-compose.yml
@@ -1,27 +1,29 @@
 version: '3.7'
 services:
   collector: # receives application metrics and traces via gRPC or HTTP protocol
-    image: otel/opentelemetry-collector-contrib:0.91.0
+    container_name: otel4s-it--sdk-exporter-metrics--otel-collector
+    image: otel/opentelemetry-collector-contrib:0.137.0
     command: [ --config=/etc/otel-collector-config.yaml ]
     volumes:
       - "./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
     ports:
-      - "44317:44317" # OTLP gRPC receiver
-      - "44318:44318" # OTLP http receiver
-      - "49464:9464" # OTLP /metrics endpoint for Prometheus
+      - "4317" # OTLP gRPC receiver
+      - "4318" # OTLP http receiver
+      - "13133" # health check
     depends_on:
       prometheus:
         condition: service_healthy
 
   prometheus: # stores metrics received from the OpenTelemetry Collector
+    container_name: otel4s-it--sdk-exporter-metrics--prometheus
     image: prom/prometheus:v2.51.2
     command: --config.file=/etc/prometheus/prometheus.yml --log.level=debug
     volumes:
       - "./config/prometheus.yaml:/etc/prometheus/prometheus.yml"
     ports:
-      - "49090:9090"
+      - "9090"
     healthcheck:
       test: [ "CMD", "wget", "--spider", "-S", "http://localhost:9090/" ]
       interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 20

--- a/sdk-exporter/trace/docker/config/otel-collector-config.yaml
+++ b/sdk-exporter/trace/docker/config/otel-collector-config.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols: # enable OpenTelemetry Protocol receiver, both gRPC and HTTP
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   otlp/jaeger: # export received traces to Jaeger
@@ -10,11 +12,17 @@ exporters:
     tls:
       insecure: true
 
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: "/health"
+
 processors:
   batch:
     timeout: 0 # send data immediately
 
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]

--- a/sdk-exporter/trace/docker/docker-compose.yml
+++ b/sdk-exporter/trace/docker/docker-compose.yml
@@ -1,23 +1,26 @@
 version: '3.7'
 services:
-  otel-collector: # receives application metrics and traces via gRPC or HTTP protocol
-    image: otel/opentelemetry-collector-contrib:0.91.0
+  collector: # receives application metrics and traces via gRPC or HTTP protocol
+    container_name: otel4s-it--sdk-exporter-trace--otel-collector
+    image: otel/opentelemetry-collector-contrib:0.137.0
     command: [ --config=/etc/otel-collector-config.yaml ]
     volumes:
       - "./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
     ports:
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP http receiver
+      - "4317" # OTLP gRPC receiver
+      - "4318" # OTLP http receiver
+      - "13133" # health check
     depends_on:
       jaeger:
         condition: service_healthy
 
   jaeger: # stores traces received from the OpenTelemetry Collector
+    container_name: otel4s-it--sdk-exporter-trace--jaeger
     image: jaegertracing/all-in-one:1.52
     ports:
-      - "16686:16686" # UI
+      - "16686" # UI
     healthcheck:
       test: [ "CMD", "wget", "--spider", "-S", "http://localhost:14269/health" ]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 20


### PR DESCRIPTION
Test failures usually happen for two reasons:
- The port is already in use `failed to set up container networking: ...`
- The collector isn't ready yet

The following improvements should (hopefully) ease the situation:
- Let Docker assign ports dynamically and retrieve the actual mappings
- Verify the collector's readiness by checking its `/health` endpoint. Since the `otel-collector-contrib` image doesn't include curl or wget, we can't rely on its built-in health check and must do it manually.