### PR TITLE
docs: add `How-to | JVM setup` section

### DIFF
--- a/docs/directory.conf
+++ b/docs/directory.conf
@@ -5,6 +5,7 @@ laika.navigationOrder = [
   modules-structure.md
   tracing-context-propagation.md
   ecosystem.md
+  how-to-jvm-setup
   instrumentation
   customization
   oteljava

--- a/docs/how-to-jvm-setup/directory.conf
+++ b/docs/how-to-jvm-setup/directory.conf
@@ -1,0 +1,7 @@
+laika.title = How-to | JVM setup
+
+laika.navigationOrder = [
+  index.md
+  set-up-otel4s-in-a-jvm-application.md
+  use-the-global-opentelemetry-instance.md
+]

--- a/docs/how-to-jvm-setup/index.md
+++ b/docs/how-to-jvm-setup/index.md
@@ -1,0 +1,20 @@
+# JVM setup
+
+Use this section when you want to get otel4s running on the JVM with the OpenTelemetry Java backend.
+
+## Start here
+
+- Set up a JVM application and export telemetry with OTLP:
+  [Set up otel4s in a JVM application](set-up-otel4s-in-a-jvm-application.md)
+- Use an OpenTelemetry instance that is already configured elsewhere:
+  [Use the global OpenTelemetry instance](use-the-global-opentelemetry-instance.md)
+- Choose the right published module for your application or library:
+  [Modules structure](../modules-structure.md#which-module-do-i-need)
+
+## Related material
+
+- Backend overview and existing JVM-specific pages remain available during the transition:
+  [OtelJava](../oteljava/overview.md)
+- Local verification examples:
+  [Jaeger and Docker](../examples/jaeger-docker/README.md),
+  [Grafana](../examples/grafana/README.md)

--- a/docs/how-to-jvm-setup/set-up-otel4s-in-a-jvm-application.md
+++ b/docs/how-to-jvm-setup/set-up-otel4s-in-a-jvm-application.md
@@ -1,0 +1,123 @@
+# Set up otel4s in a JVM application
+
+Use this page when you want to start a JVM application with `otel4s-oteljava` and export telemetry with OTLP.
+
+## 1. Add the dependencies
+
+@:select(build-tool)
+
+@:choice(sbt)
+
+Add settings to `build.sbt`:
+
+```scala
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "otel4s-oteljava" % "@VERSION@", // <1>
+  "io.opentelemetry" % "opentelemetry-exporter-otlp" % "@OPEN_TELEMETRY_VERSION@" % Runtime, // <2>
+  "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % "@OPEN_TELEMETRY_VERSION@" % Runtime // <3>
+)
+javaOptions += "-Dotel.java.global-autoconfigure.enabled=true" // <4>
+```
+
+@:choice(scala-cli)
+
+Add directives to the `*.scala` file:
+
+```scala
+//> using dep "org.typelevel::otel4s-oteljava:@VERSION@" // <1>
+//> using dep "io.opentelemetry:opentelemetry-exporter-otlp:@OPEN_TELEMETRY_VERSION@" // <2>
+//> using dep "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:@OPEN_TELEMETRY_VERSION@" // <3>
+//> using javaOpt "-Dotel.java.global-autoconfigure.enabled=true" // <4>
+```
+
+@:@
+
+1. Add `otel4s-oteljava`
+2. Add an OTLP exporter
+3. Add the OpenTelemetry Java autoconfigure extension
+4. Enable SDK autoconfiguration
+
+## 2. Configure the SDK
+
+Set the service name and the OTLP endpoint with environment variables or JVM properties.
+
+Example environment variables:
+
+```shell
+export OTEL_SERVICE_NAME=auth-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+Example JVM properties:
+
+```shell
+-Dotel.service.name=auth-service
+-Dotel.exporter.otlp.endpoint=http://localhost:4317
+```
+
+See the full list of supported options in the
+[OpenTelemetry Java configuration guide][opentelemetry-java-configuration].
+
+## 3. Create `OtelJava` and get the providers
+
+Use `OtelJava.autoConfigured` when your application is responsible for creating its own OpenTelemetry SDK instance.
+
+```scala mdoc:reset:silent
+import cats.effect.{IO, IOApp}
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.oteljava.OtelJava
+import org.typelevel.otel4s.trace.TracerProvider
+
+object Main extends IOApp.Simple {
+  def run: IO[Unit] =
+    OtelJava.autoConfigured[IO]().use { otel4s =>
+      program(otel4s.meterProvider, otel4s.tracerProvider)
+    }
+
+  def program(
+      meterProvider: MeterProvider[IO],
+      tracerProvider: TracerProvider[IO]
+  ): IO[Unit] =
+    for {
+      meter <- meterProvider.get("auth-service")
+      tracer <- tracerProvider.get("auth-service")
+
+      counter <- meter.counter[Long]("service.requests").create
+      _ <- counter.inc()
+
+      _ <- tracer.span("startup").surround(IO.unit)
+    } yield ()
+}
+```
+
+@:callout(warning)
+
+`OtelJava.autoConfigured` creates an isolated, non-global SDK instance.
+If you need to reuse the process-wide OpenTelemetry instance, use
+[Use the global OpenTelemetry instance](use-the-global-opentelemetry-instance.md).
+
+@:@
+
+## 4. Run the application
+
+Start your application with the same environment variables or JVM properties you used for configuration.
+
+At that point, the application can create meters and tracers and export telemetry through OTLP.
+
+## 5. Verify the setup
+
+If you want a local target for traces, use
+[Jaeger and Docker](../examples/jaeger-docker/README.md).
+If you want a local stack for traces and metrics, use
+[Grafana](../examples/grafana/README.md).
+
+## What's next
+
+- Create spans in your application code:
+  [Tracing](../instrumentation/tracing.md)
+- Record application metrics:
+  [Metrics](../instrumentation/metrics.md)
+- Reuse an OpenTelemetry instance that is configured elsewhere:
+  [Use the global OpenTelemetry instance](use-the-global-opentelemetry-instance.md)
+
+[opentelemetry-java-configuration]: https://opentelemetry.io/docs/languages/java/configuration/

--- a/docs/how-to-jvm-setup/use-the-global-opentelemetry-instance.md
+++ b/docs/how-to-jvm-setup/use-the-global-opentelemetry-instance.md
@@ -1,0 +1,78 @@
+# Use the global OpenTelemetry instance
+
+Use this page when OpenTelemetry is already configured outside `otel4s`, and you want to reuse that process-wide instance.
+
+Common cases:
+
+- you use a Java agent
+- another library or framework configures OpenTelemetry before your code runs
+- you need `otel4s` to interoperate with Java libraries that expect the global SDK
+
+## Prerequisites
+
+- Your application depends on `"org.typelevel" %% "otel4s-oteljava" % "@VERSION@"`.
+- A global OpenTelemetry SDK is configured elsewhere.
+- If you need Cats Effect and Java SDK context to stay aligned, add
+  `otel4s-oteljava-context-storage` and follow
+  [Tracing | Context propagation](../oteljava/tracing-context-propagation.md).
+
+## 1. Make sure the global SDK is configured elsewhere
+
+`OtelJava.global` does not create or configure an SDK.
+It only reads the current global OpenTelemetry instance.
+
+That instance might come from:
+
+- the OpenTelemetry Java agent
+- your own SDK bootstrap code
+- framework-managed startup code
+
+## 2. Read the global instance from otel4s
+
+```scala mdoc:reset:silent
+import cats.effect.{IO, IOApp}
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.oteljava.OtelJava
+import org.typelevel.otel4s.trace.TracerProvider
+
+object Main extends IOApp.Simple {
+  def run: IO[Unit] =
+    OtelJava.global[IO].flatMap { otel4s =>
+      program(otel4s.meterProvider, otel4s.tracerProvider)
+    }
+
+  def program(
+      meterProvider: MeterProvider[IO],
+      tracerProvider: TracerProvider[IO]
+  ): IO[Unit] =
+    for {
+      meter <- meterProvider.get("auth-service")
+      tracer <- tracerProvider.get("auth-service")
+
+      counter <- meter.counter[Long]("service.requests").create
+      _ <- counter.inc()
+
+      _ <- tracer.span("startup").surround(IO.unit)
+    } yield ()
+}
+```
+
+## 3. Do not create a second SDK in the same application
+
+If your process already has a configured global SDK, do not also call `OtelJava.autoConfigured` for the same application path.
+
+Use:
+
+- `OtelJava.autoConfigured` when your application owns SDK creation
+- `OtelJava.global` when SDK creation happens elsewhere
+
+## What's next
+
+- Align Cats Effect and Java SDK context:
+  [Tracing | Context propagation](../oteljava/tracing-context-propagation.md)
+- Use otel4s with the Java agent:
+  [Zero-code | Java Agent](../oteljava/agent.md)
+- Create spans in your application code:
+  [Tracing](../instrumentation/tracing.md)
+- Record application metrics:
+  [Metrics](../instrumentation/metrics.md)


### PR DESCRIPTION
The current documentation is quite comprehensive, yet it's quite hard to navigate. I want to adopt [Diátaxis](https://diataxis.fr/) approach eventually. 
A full rewrite is nearly impossible to review, so I want to split it into steps:
1. Add how-to sections: How-to JVM Setup, How-to Tracing, How-to Metrics
2. Move/rewrite existing articles into these sections

Then we can work on tutorials, and eventually we _should_ end up with a refined version of the documentation.

___

This PR introduces the `How-to | JVM Setup` section. 