### PR TITLE
Improve the site's visual style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -558,6 +558,7 @@ lazy val docs = project
       "PEKKO_STREAM_VERSION" -> PekkoStreamVersion,
     ),
     tlSiteApiPackage := Some("org.typelevel.otel4s"),
+    tlSiteHelium ~= (_.site.internalCSS(laika.ast.Path.Root / "site.css")),
     run / fork := true,
     javaOptions += "-Dcats.effect.trackFiberContext=true",
     laikaConfig := {

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,0 +1,199 @@
+:root {
+  --block-spacing: 12px;
+  --line-height: 1.6;
+  --nav-width: 300px;
+}
+
+/* Content hierarchy */
+
+main.content h1,
+main.content h2,
+main.content h3,
+main.content h4,
+main.content h5,
+main.content h6 {
+  color: var(--text-color);
+  line-height: 1.25;
+}
+
+main.content h1.title {
+  padding-top: 32px;
+  padding-bottom: 12px;
+  margin-bottom: 28px;
+}
+
+main.content h2 {
+  margin-top: 44px;
+  margin-bottom: 14px;
+}
+
+main.content h3,
+main.content h4,
+main.content h5,
+main.content h6 {
+  margin-top: 26px;
+}
+
+main.content pre {
+  padding: 14px 16px;
+  line-height: 1.5;
+  overflow-x: auto;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  white-space: pre-wrap;
+}
+
+main.content pre code {
+  white-space: pre-wrap;
+}
+
+main.content :not(pre) > code {
+  padding: 0.12em 0.3em;
+  background-color: var(--primary-light);
+  border-radius: 3px;
+}
+
+/* Build-tool and configuration selectors */
+
+main.content .tab-container {
+  margin-top: 20px;
+  margin-bottom: 24px;
+}
+
+main.content li.tab {
+  padding: 5px 9px;
+  margin-right: 4px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+}
+
+main.content li.tab:not(.active):hover {
+  background: var(--primary-light);
+  border-bottom-color: var(--component-border);
+}
+
+main.content li.tab.active {
+  border-bottom-color: var(--secondary-color);
+  background: transparent;
+}
+
+main.content li.tab.active a {
+  color: var(--text-color);
+  font-weight: bold;
+}
+
+main.content li.tab a:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 3px;
+}
+
+main.content .tab-content {
+  padding: 14px 0 0;
+  border: 0;
+  border-top: 1px solid var(--component-border);
+  border-radius: 0;
+}
+
+/* Callouts and tables */
+
+main.content .callout {
+  margin: 20px 0;
+  padding: 10px 14px;
+  border-radius: 3px;
+}
+
+main.content .callout .icofont-laika {
+  display: block;
+  padding: 0 0 5px;
+  font-size: 1em;
+}
+
+main.content .callout.info,
+main.content .callout.warning,
+main.content .callout.error {
+  border-left-width: 4px;
+}
+
+main.content .callout > :last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 575px) {
+  main.content table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
+/* Main navigation */
+
+#sidebar ul.nav-list {
+  padding: 16px 12px 28px;
+  margin: 0;
+}
+
+#sidebar .nav-list li {
+  margin-bottom: 1px;
+  line-height: 1.3;
+}
+
+#sidebar .nav-list li a,
+#sidebar .nav-list li.level1 a,
+#sidebar .nav-list li.level1.nav-node a {
+  padding: 5px 12px;
+  border-radius: 3px;
+}
+
+#sidebar .nav-list li.level1 {
+  margin-left: 0;
+  font-size: 1em;
+}
+
+#sidebar .nav-list li.level2 {
+  margin-left: 12px;
+  font-size: 0.95em;
+}
+
+#sidebar .nav-list li.nav-header,
+#sidebar .nav-list li.level1.nav-header {
+  padding: 5px 12px;
+  margin-top: 14px;
+  margin-left: 0;
+  color: var(--primary-color);
+  font-size: 0.92em;
+  letter-spacing: 0.01em;
+  text-transform: none;
+}
+
+#sidebar .nav-list .active a,
+#sidebar .nav-list .active a:hover {
+  color: var(--primary-color);
+  background: var(--subtle-highlight);
+  font-weight: bold;
+}
+
+/* Page outline */
+
+#page-nav .header {
+  background: transparent;
+  border-bottom: 1px solid var(--component-border);
+}
+
+#page-nav .header a,
+#page-nav .header a:hover {
+  color: var(--primary-color);
+  background: transparent;
+  font-weight: bold;
+}
+
+#page-nav .footer {
+  border-top: 0;
+}
+
+#page-nav .nav-list li {
+  margin-bottom: 7px;
+  line-height: 1.35;
+}


### PR DESCRIPTION
I'm exploring options to make the site a little easier to navigate by making pages feel calmer and a bit more compact. 

Key changes:
- Use the red accent more selectively
- Reduce visual weight around tabs, callouts, and navigation
- Tighten spacing


### Before

<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/82f6a920-da4a-447b-bd08-eafa5d777639" />

### After

<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/78042f50-9d6d-4e62-a699-8cff0d683e14" />

_____

### Before

<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/855e4cd2-5a12-4d06-9e54-a0bb324e3c07" />


### After

<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/4f040ad4-e8d4-421f-907c-3973c84ce537" />

____

### Before

<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/fac85f92-8e7a-42dd-9995-33c6f694e0ce" />


### After


<img width="2107" height="1252" alt="image" src="https://github.com/user-attachments/assets/93defff5-cc80-4863-8bd3-b353118ef1c2" />

